### PR TITLE
Stabilize core tests and observation safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,23 @@
+# Python
 __pycache__/
-*.pyc
+*.py[cod]
+*$py.class
 *.egg-info/
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
 .tox/
 .coverage*
 coverage.json
 htmlcov/
 build/
 dist/
-*.uvfits
-tests/data_generation/*.png
-tests/data_generation_flagging/*.png
-tests/data_generation_flagging/*.uvfits
-tests/weather_plots/
+
+# OS/editor
 .DS_Store
+*.swp
+
+# Generated test/example outputs
+*.uvfits
+tests/**/*.png
+tests/weather_plots/

--- a/ngehtsim/calibration/calibration.py
+++ b/ngehtsim/calibration/calibration.py
@@ -53,7 +53,7 @@ def argunique(array):
 
 
 def apriorical(filename,sourcename,bandwidth,debias=True,remove_autocorr=True,
-               SNR_cut=0.0,station_codes={},return_coords=False,
+               SNR_cut=0.0,station_codes=None,return_coords=False,
                weather='exact',random_seed=None,**kwargs):
     """
     Read an alist data file and carry out a priori flux density calibration.
@@ -76,6 +76,10 @@ def apriorical(filename,sourcename,bandwidth,debias=True,remove_autocorr=True,
 
     ############################################
     # check inputs
+
+    # initialize station codes
+    if station_codes is None:
+        station_codes = {}
     
     # update the station codes if needed
     station_dict = copy.deepcopy(known_station_dict)
@@ -364,7 +368,7 @@ def apriorical(filename,sourcename,bandwidth,debias=True,remove_autocorr=True,
 
 
 def write_dlist(filename,sourcename,bandwidth,outname,debias=True,remove_autocorr=True,
-                SNR_cut=0.0,station_codes={},weather='exact',random_seed=None,**kwargs):
+                SNR_cut=0.0,station_codes=None,weather='exact',random_seed=None,**kwargs):
     """
     Write a "dlist" data file from an "alist" file.
 
@@ -386,6 +390,10 @@ def write_dlist(filename,sourcename,bandwidth,outname,debias=True,remove_autocor
 
     ############################################
     # check inputs
+
+    # initialize station codes
+    if station_codes is None:
+        station_codes = {}
 
     # update the station codes if needed
     station_dict = copy.deepcopy(known_station_dict)

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -18,6 +18,7 @@ import warnings
 try:
     import ngEHTforecast.fisher as fp
 except ImportError:
+    fp = None
     print('Warning: ngEHTforecast not installed! Cannot use FisherForecast functionality.')
 
 import ngehtsim.const_def as const
@@ -70,16 +71,33 @@ class obs_generator(object):
     """
 
     # initialize class instantiation
-    def __init__(self, settings={}, settings_file=None, verbosity=0, weight=0, D_overrides={},
-                 surf_rms_overrides={}, receiver_configuration_overrides={}, bandwidth_overrides={},
-                 T_R_overrides={}, sideband_ratio_overrides={}, lo_freq_overrides={}, hi_freq_overrides={},
-                 ap_eff_overrides={}, wind_loading_overrides={}, custom_receivers={}, station_uptimes={},
+    def __init__(self, settings=None, settings_file=None, verbosity=0, weight=0, D_overrides=None,
+                 surf_rms_overrides=None, receiver_configuration_overrides=None, bandwidth_overrides=None,
+                 T_R_overrides=None, sideband_ratio_overrides=None, lo_freq_overrides=None, hi_freq_overrides=None,
+                 ap_eff_overrides=None, wind_loading_overrides=None, custom_receivers=None, station_uptimes=None,
                  array=None, ephem='ephemeris/space'):
 
         #############################
         # astropy cache
 
         _ensure_iers_cached()
+
+        #############################
+        # initialize inputs
+
+        settings = {} if settings is None else settings
+        D_overrides = {} if D_overrides is None else D_overrides
+        surf_rms_overrides = {} if surf_rms_overrides is None else surf_rms_overrides
+        receiver_configuration_overrides = {} if receiver_configuration_overrides is None else receiver_configuration_overrides
+        bandwidth_overrides = {} if bandwidth_overrides is None else bandwidth_overrides
+        T_R_overrides = {} if T_R_overrides is None else T_R_overrides
+        sideband_ratio_overrides = {} if sideband_ratio_overrides is None else sideband_ratio_overrides
+        lo_freq_overrides = {} if lo_freq_overrides is None else lo_freq_overrides
+        hi_freq_overrides = {} if hi_freq_overrides is None else hi_freq_overrides
+        ap_eff_overrides = {} if ap_eff_overrides is None else ap_eff_overrides
+        wind_loading_overrides = {} if wind_loading_overrides is None else wind_loading_overrides
+        custom_receivers = {} if custom_receivers is None else custom_receivers
+        station_uptimes = {} if station_uptimes is None else station_uptimes
 
         #############################
         # parse inputs
@@ -618,7 +636,8 @@ class obs_generator(object):
         els = self.obs_empty.unpack(['el1', 'el2'])
         mask = (self.obs_empty.data['t1'] == 'space') | ((els['el1'] > el_min) & (els['el1'] < el_max))
         mask &= (self.obs_empty.data['t2'] == 'space') | ((els['el2'] > el_min) & (els['el2'] < el_max))
-        self.obs_empty.data = self.obs_empty.data[mask]
+        obs_empty = self.obs_empty.copy()
+        obs_empty.data = obs_empty.data[mask]
 
         # observe the source
         if isinstance(input_model, eh.image.Image):
@@ -629,9 +648,9 @@ class obs_generator(object):
             input_model.rf = self.freq
             if self.verbosity <= 0:
                 with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(self.obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
+                    obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
             else:
-                obs = input_model.observe_same_nonoise(self.obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
+                obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
             F0 = input_model.total_flux()
         elif isinstance(input_model, eh.movie.Movie):
             input_model.ra = self.RA
@@ -641,9 +660,9 @@ class obs_generator(object):
             input_model.rf = self.freq
             if self.verbosity <= 0:
                 with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(self.obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
+                    obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
             else:
-                obs = input_model.observe_same_nonoise(self.obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
+                obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
             F0 = np.mean(input_model.lightcurve)
         elif isinstance(input_model, eh.model.Model):
             input_model.ra = self.RA
@@ -653,14 +672,14 @@ class obs_generator(object):
             input_model.rf = self.freq
             if self.verbosity <= 0:
                 with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(self.obs_empty)
+                    obs = input_model.observe_same_nonoise(obs_empty)
             else:
-                obs = input_model.observe_same_nonoise(self.obs_empty)
+                obs = input_model.observe_same_nonoise(obs_empty)
             F0 = np.abs(input_model.sample_uv(0.0, 0.0))
-        elif isinstance(input_model, fp.FisherForecast):
+        elif (fp is not None) and isinstance(input_model, fp.FisherForecast):
             if p is None:
                 raise Exception('When observing an ngEHTforecast model, the parameter vector keyword argument p must be specified!')
-            obs = self.obs_empty.copy()
+            obs = obs_empty.copy()
             obs.source = self.settings['source']
             if (input_model.stokes == 'I'):
                 Ivis = input_model.visibilities(obs, p, verbosity=self.verbosity)
@@ -674,12 +693,14 @@ class obs_generator(object):
                 obs.data['llvis'] = LLvis
                 obs.data['rlvis'] = RLvis
                 obs.data['lrvis'] = LRvis
-            dumobs = self.obs_empty.copy()
+            dumobs = obs_empty.copy()
             dumdatatable = dumobs.data[0]
             dumdatatable['u'] = 0.0
             dumdatatable['v'] = 0.0
             dumobs.data = dumdatatable
             F0 = np.abs(input_model.visibilities(dumobs, p))
+        else:
+            raise TypeError('input_model must be an ehtim Image, Movie, Model, or ngEHTforecast FisherForecast object.')
 
         # extract relevant information
         t1 = obs.data['t1']

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,11 @@ versionfile_source = ngehtsim/_version.py
 versionfile_build = ngehtsim/_version.py
 tag_prefix =
 parentdir_prefix = ngehtsim-
+
+[tool:pytest]
+addopts = -ra
+testpaths =
+    tests
+markers =
+    slow: long-running synthetic-data/example workflows
+    optional: tests requiring optional dependencies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+#######################################################
+# imports
+
+import os
+
+#######################################################
+# configuration testing
+
+SLOW_EXAMPLE_TESTS = [
+    "test_SYMBA_export.py",
+    "test_basic.py",
+    "test_flux_calibration.py",
+    "test_generate_observation.py",
+    "test_generate_observation_flagging.py",
+    "test_generate_observation_instrumental_corruptions.py",
+    "test_generate_observation_multi-frequency.py",
+    "test_generate_observation_space.py",
+    "test_generate_observation_with_FPT.py",
+    "test_weather.py",
+]
+
+OPTIONAL_TESTS = [
+    "test_generate_observation_using_ngEHTforecast.py",
+]
+
+collect_ignore = []
+
+if os.environ.get("NGEHTSIM_RUN_SLOW_TESTS") != "1":
+    collect_ignore.extend(SLOW_EXAMPLE_TESTS)
+
+if os.environ.get("NGEHTSIM_RUN_OPTIONAL_TESTS") != "1":
+    collect_ignore.extend(OPTIONAL_TESTS)

--- a/tests/test_core_safety.py
+++ b/tests/test_core_safety.py
@@ -1,0 +1,100 @@
+#######################################################
+# imports
+
+import inspect
+import pytest
+import ehtim as eh
+import ngehtsim.calibration.calibration as nc
+import ngehtsim.obs.obs_generator as og
+
+#######################################################
+# helpers
+
+COMPACT_OBS_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 6.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
+
+
+def _compact_model():
+    model = eh.model.Model()
+    return model.add_circ_gauss(F0=1.0, FWHM=40.0 * eh.RADPERUAS)
+
+
+def _observe_without_corruptions(obsgen, input_model, **kwargs):
+    observe_kwargs = dict(
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    observe_kwargs.update(kwargs)
+    return obsgen.observe(input_model, **observe_kwargs)
+
+#######################################################
+# tests
+
+
+@pytest.mark.parametrize(
+    "callable_obj",
+    [
+        og.obs_generator.__init__,
+        nc.apriorical,
+        nc.write_dlist,
+    ],
+)
+def test_public_api_defaults_are_not_mutable(callable_obj):
+    signature = inspect.signature(callable_obj)
+
+    for parameter in signature.parameters.values():
+        if parameter.default is inspect.Parameter.empty:
+            continue
+
+        assert not isinstance(parameter.default, (dict, list, set))
+
+
+def test_observe_elevation_cuts_do_not_mutate_cached_empty_observation():
+    model = _compact_model()
+
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    strict_obs = _observe_without_corruptions(
+        obsgen,
+        model,
+        el_min=50.0,
+        el_max=80.0,
+    )
+
+    relaxed_after_strict_obs = _observe_without_corruptions(
+        obsgen,
+        model,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    fresh_obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    relaxed_fresh_obs = _observe_without_corruptions(
+        fresh_obsgen,
+        model,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    assert len(strict_obs.data) < len(relaxed_fresh_obs.data)
+    assert len(relaxed_after_strict_obs.data) == len(relaxed_fresh_obs.data)
+
+
+def test_unsupported_model_raises_type_error_when_ngEHTforecast_is_missing(monkeypatch):
+    monkeypatch.setattr(og, "fp", None)
+
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    with pytest.raises(TypeError, match="input_model must be"):
+        _observe_without_corruptions(obsgen, object())

--- a/tests/test_weather_lookup.py
+++ b/tests/test_weather_lookup.py
@@ -2,18 +2,77 @@
 # imports
 
 import numpy as np
+import pytest
 import ngehtsim.weather.weather as nw
 
 #######################################################
-# make sure the month naming/number convention works
+# constants
 
-def test_integer_month_matches_named_month():
-    kwargs = dict(site='ALMA', form='exact', day=11, year=2017)
-    assert np.isclose(
-        nw.opacity(month=4, freq=230.0, **kwargs),
-        nw.opacity(month='Apr', freq=230.0, **kwargs),
-    )
-    assert np.isclose(
-        nw.brightness_temperature(month='04', freq=230.0, **kwargs),
-        nw.brightness_temperature(month='Apr', freq=230.0, **kwargs),
-    )
+MONTH_ALIASES = ["Apr", "04", "4", 4]
+
+SCALAR_WEATHER_FUNCTIONS = [
+    (nw.opacity, {"freq": 230.0}),
+    (nw.brightness_temperature, {"freq": 230.0}),
+    (nw.pressure, {}),
+    (nw.temperature, {}),
+    (nw.PWV, {}),
+    (nw.windspeed, {}),
+]
+
+SPECTRUM_WEATHER_FUNCTIONS = [
+    nw.opacity_spectrum,
+    nw.brightness_temperature_spectrum,
+]
+
+#######################################################
+# tests
+
+
+@pytest.mark.parametrize("month", MONTH_ALIASES)
+@pytest.mark.parametrize("weather_function, extra_kwargs", SCALAR_WEATHER_FUNCTIONS)
+def test_exact_scalar_weather_month_aliases(weather_function, extra_kwargs, month):
+    kwargs = dict(site="ALMA", form="exact", day=11, year=2017)
+    kwargs.update(extra_kwargs)
+
+    reference = weather_function(month="Apr", **kwargs)
+    result = weather_function(month=month, **kwargs)
+
+    assert np.isclose(result, reference, equal_nan=True)
+
+
+@pytest.mark.parametrize("month", MONTH_ALIASES)
+@pytest.mark.parametrize("weather_function", SPECTRUM_WEATHER_FUNCTIONS)
+def test_exact_spectrum_weather_month_aliases(weather_function, month):
+    kwargs = dict(site="ALMA", form="exact", day=11, year=2017)
+
+    reference = weather_function(month="Apr", **kwargs)
+    result = weather_function(month=month, **kwargs)
+
+    assert np.allclose(result, reference, equal_nan=True)
+
+
+@pytest.mark.parametrize("weather_function, extra_kwargs", SCALAR_WEATHER_FUNCTIONS)
+def test_february_scalar_integer_month_matches_named_month(weather_function, extra_kwargs):
+    kwargs = dict(site="ALMA", form="median")
+    kwargs.update(extra_kwargs)
+
+    reference = weather_function(month="Feb", **kwargs)
+    result = weather_function(month=2, **kwargs)
+
+    assert np.allclose(result, reference, equal_nan=True)
+
+
+@pytest.mark.parametrize("weather_function", SPECTRUM_WEATHER_FUNCTIONS)
+def test_february_spectrum_integer_month_matches_named_month(weather_function):
+    kwargs = dict(site="ALMA", form="median")
+
+    reference = weather_function(month="Feb", **kwargs)
+    result = weather_function(month=2, **kwargs)
+
+    assert np.allclose(result, reference, equal_nan=True)
+
+
+@pytest.mark.parametrize("bad_month", [0, 13, "Foo", "", None])
+def test_invalid_month_rejected(bad_month):
+    with pytest.raises(ValueError, match="Specified month not recognized"):
+        nw.opacity(site="ALMA", form="median", month=bad_month, freq=230.0)

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     pandas<2.0.0; python_version < "3.12"
     pandas>=2.2.2; python_version >= "3.12"
     coverage
+setenv =
+    MPLBACKEND = Agg
 commands =
     python -m coverage run -p -m pytest
 extras =


### PR DESCRIPTION
Summary:
- Add test hygiene guardrails so fast tests run separately from slow/example workflows.
- Fix mutable default arguments in observation generation and calibration helpers.
- Stop observe() from mutating cached empty observations.
- Make missing ngEHTforecast handling safe.
- Add regression tests for weather month parsing and core observation safety.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- 50 passed, 16 third-party ehtim warnings.