### PR TITLE
Add automated documentation deployment

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,70 @@
+name: Build and deploy documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+      - refactor
+  pull_request:
+    branches:
+      - main
+      - dev
+      - refactor
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r docs/requirements.txt
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build documentation
+        run: |
+          python -m sphinx -b html --keep-going . docs/_build/html
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    if: github.event_name == 'push' && contains(fromJSON('["refs/heads/main","refs/heads/dev","refs/heads/refactor"]'), github.ref)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .tox/
 .coverage*
 coverage.json
+docs/_build/
 htmlcov/
 build/
 dist/

--- a/conf.py
+++ b/conf.py
@@ -49,12 +49,12 @@ source_suffix = '.rst'
 master_doc = 'docs/source/index'
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['docs/source/_templates']
+templates_path = []
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ['docs/_build']
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -66,7 +66,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['docs/source/_static']
+html_static_path = []
 
 # Example configuration for intersphinx: refer to the Python standard library.
 # intersphinx_mapping = {'https://docs.python.org/': None}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SPHINXPROJ    = ngehtsim
 SOURCEDIR     = ../
-BUILDDIR      = ../../ngehtsim_docs/ngeht-sims
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -21,4 +21,4 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 htmlpush: html
-	touch .docdate; cd $(BUILDDIR); git add . ; git commit -m "rebuilt docs"; git push origin gh-pages
+	@echo "Documentation deployment is handled by GitHub Actions."

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,10 @@
+astropy>=5.2.2
+ehtim>=1.2.7
+matplotlib>=3.7.4
+numpy>=1.23.1,<2.0.0
+pandas<2.0.0; python_version < "3.12"
+pandas>=2.2.2; python_version >= "3.12"
+PyYAML>=6.0
+scipy>=1.10.1
+sphinx>=7
+sphinx-rtd-theme>=2


### PR DESCRIPTION
Summary:
- Add a GitHub Actions workflow that builds Sphinx documentation.
- Deploy GitHub Pages automatically from pushes to active integration branches.
- Add documentation build dependencies.
- Remove the manual gh-pages push behavior from docs/Makefile.

Addresses #15.

Validation:
- MPLBACKEND=Agg python3 -m sphinx -b html --keep-going . docs/_build/html
- MPLBACKEND=Agg python3 -m pytest -q