### PR TITLE
Add source model adapter layer

### DIFF
--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -15,14 +15,9 @@ import os
 import copy
 import warnings
 
-try:
-    import ngEHTforecast.fisher as fp
-except ImportError:
-    fp = None
-    print('Warning: ngEHTforecast not installed! Cannot use FisherForecast functionality.')
-
 import ngehtsim.const_def as const
 import ngehtsim.weather.weather as nw
+import ngehtsim.obs.source_models as source_models
 
 ###################################################
 # helpers
@@ -640,67 +635,17 @@ class obs_generator(object):
         obs_empty.data = obs_empty.data[mask]
 
         # observe the source
-        if isinstance(input_model, eh.image.Image):
-            input_model.ra = self.RA
-            input_model.dec = self.DEC
-            input_model.mjd = self.mjd
-            input_model.source = self.settings['source']
-            input_model.rf = self.freq
-            if self.verbosity <= 0:
-                with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
-            else:
-                obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'])
-            F0 = input_model.total_flux()
-        elif isinstance(input_model, eh.movie.Movie):
-            input_model.ra = self.RA
-            input_model.dec = self.DEC
-            input_model.mjd = self.mjd
-            input_model.source = self.settings['source']
-            input_model.rf = self.freq
-            if self.verbosity <= 0:
-                with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
-            else:
-                obs = input_model.observe_same_nonoise(obs_empty, ttype=self.settings['ttype'], fft_pad_factor=self.settings['fft_pad_factor'], repeat=True)
-            F0 = np.mean(input_model.lightcurve)
-        elif isinstance(input_model, eh.model.Model):
-            input_model.ra = self.RA
-            input_model.dec = self.DEC
-            input_model.mjd = self.mjd
-            input_model.source = self.settings['source']
-            input_model.rf = self.freq
-            if self.verbosity <= 0:
-                with eh.parloop.HiddenPrints():
-                    obs = input_model.observe_same_nonoise(obs_empty)
-            else:
-                obs = input_model.observe_same_nonoise(obs_empty)
-            F0 = np.abs(input_model.sample_uv(0.0, 0.0))
-        elif (fp is not None) and isinstance(input_model, fp.FisherForecast):
-            if p is None:
-                raise Exception('When observing an ngEHTforecast model, the parameter vector keyword argument p must be specified!')
-            obs = obs_empty.copy()
-            obs.source = self.settings['source']
-            if (input_model.stokes == 'I'):
-                Ivis = input_model.visibilities(obs, p, verbosity=self.verbosity)
-                obs = obs.switch_polrep(polrep_out='stokes')
-                obs.data['vis'] = Ivis
-                obs = obs.switch_polrep(polrep_out='circ')
-            else:
-                obs = obs.switch_polrep(polrep_out='circ')
-                RRvis, LLvis, RLvis, LRvis = input_model.visibilities(obs, p, verbosity=self.verbosity)
-                obs.data['rrvis'] = RRvis
-                obs.data['llvis'] = LLvis
-                obs.data['rlvis'] = RLvis
-                obs.data['lrvis'] = LRvis
-            dumobs = obs_empty.copy()
-            dumdatatable = dumobs.data[0]
-            dumdatatable['u'] = 0.0
-            dumdatatable['v'] = 0.0
-            dumobs.data = dumdatatable
-            F0 = np.abs(input_model.visibilities(dumobs, p))
-        else:
-            raise TypeError('input_model must be an ehtim Image, Movie, Model, or ngEHTforecast FisherForecast object.')
+        source_context = {
+            "ra": self.RA,
+            "dec": self.DEC,
+            "mjd": self.mjd,
+            "source": self.settings["source"],
+            "rf": self.freq,
+            "ttype": self.settings["ttype"],
+            "fft_pad_factor": self.settings["fft_pad_factor"],
+            "verbosity": self.verbosity,
+        }
+        obs, F0 = source_models.observe_source(input_model, obs_empty, source_context, p=p)
 
         # extract relevant information
         t1 = obs.data['t1']

--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -1,0 +1,145 @@
+###################################################
+# imports
+
+import numpy as np
+import ehtim as eh
+
+try:
+    import ngEHTforecast.fisher as fp
+except ImportError:
+    fp = None
+
+###################################################
+# helpers
+
+
+def _set_ehtim_metadata(input_model, context):
+    input_model.ra = context["ra"]
+    input_model.dec = context["dec"]
+    input_model.mjd = context["mjd"]
+    input_model.source = context["source"]
+    input_model.rf = context["rf"]
+
+
+def _run_quietly(function, verbosity):
+    if verbosity <= 0:
+        with eh.parloop.HiddenPrints():
+            return function()
+    return function()
+
+###################################################
+# adapters
+
+
+class EhtimImageAdapter(object):
+    def __init__(self, input_model):
+        self.input_model = input_model
+
+    def observe(self, obs_empty, context, p=None):
+        _set_ehtim_metadata(self.input_model, context)
+
+        obs = _run_quietly(
+            lambda: self.input_model.observe_same_nonoise(
+                obs_empty,
+                ttype=context["ttype"],
+                fft_pad_factor=context["fft_pad_factor"],
+            ),
+            context["verbosity"],
+        )
+
+        F0 = self.input_model.total_flux()
+        return obs, F0
+
+
+class EhtimMovieAdapter(object):
+    def __init__(self, input_model):
+        self.input_model = input_model
+
+    def observe(self, obs_empty, context, p=None):
+        _set_ehtim_metadata(self.input_model, context)
+
+        obs = _run_quietly(
+            lambda: self.input_model.observe_same_nonoise(
+                obs_empty,
+                ttype=context["ttype"],
+                fft_pad_factor=context["fft_pad_factor"],
+                repeat=True,
+            ),
+            context["verbosity"],
+        )
+
+        F0 = np.mean(self.input_model.lightcurve)
+        return obs, F0
+
+
+class EhtimModelAdapter(object):
+    def __init__(self, input_model):
+        self.input_model = input_model
+
+    def observe(self, obs_empty, context, p=None):
+        _set_ehtim_metadata(self.input_model, context)
+
+        obs = _run_quietly(
+            lambda: self.input_model.observe_same_nonoise(obs_empty),
+            context["verbosity"],
+        )
+
+        F0 = np.abs(self.input_model.sample_uv(0.0, 0.0))
+        return obs, F0
+
+
+class FisherForecastAdapter(object):
+    def __init__(self, input_model):
+        self.input_model = input_model
+
+    def observe(self, obs_empty, context, p=None):
+        if p is None:
+            raise Exception("When observing an ngEHTforecast model, the parameter vector keyword argument p must be specified!")
+
+        obs = obs_empty.copy()
+        obs.source = context["source"]
+
+        if self.input_model.stokes == "I":
+            Ivis = self.input_model.visibilities(obs, p, verbosity=context["verbosity"])
+            obs = obs.switch_polrep(polrep_out="stokes")
+            obs.data["vis"] = Ivis
+            obs = obs.switch_polrep(polrep_out="circ")
+        else:
+            obs = obs.switch_polrep(polrep_out="circ")
+            RRvis, LLvis, RLvis, LRvis = self.input_model.visibilities(obs, p, verbosity=context["verbosity"])
+            obs.data["rrvis"] = RRvis
+            obs.data["llvis"] = LLvis
+            obs.data["rlvis"] = RLvis
+            obs.data["lrvis"] = LRvis
+
+        dumobs = obs_empty.copy()
+        dumdatatable = dumobs.data[0]
+        dumdatatable["u"] = 0.0
+        dumdatatable["v"] = 0.0
+        dumobs.data = dumdatatable
+        F0 = np.abs(self.input_model.visibilities(dumobs, p))
+
+        return obs, F0
+
+###################################################
+# public interface
+
+
+def adapter_for(input_model):
+    if isinstance(input_model, eh.image.Image):
+        return EhtimImageAdapter(input_model)
+
+    if isinstance(input_model, eh.movie.Movie):
+        return EhtimMovieAdapter(input_model)
+
+    if isinstance(input_model, eh.model.Model):
+        return EhtimModelAdapter(input_model)
+
+    if (fp is not None) and isinstance(input_model, fp.FisherForecast):
+        return FisherForecastAdapter(input_model)
+
+    raise TypeError("input_model must be an ehtim Image, Movie, Model, or ngEHTforecast FisherForecast object.")
+
+
+def observe_source(input_model, obs_empty, context, p=None):
+    return adapter_for(input_model).observe(obs_empty, context, p=p)

--- a/tests/test_core_safety.py
+++ b/tests/test_core_safety.py
@@ -6,6 +6,7 @@ import pytest
 import ehtim as eh
 import ngehtsim.calibration.calibration as nc
 import ngehtsim.obs.obs_generator as og
+import ngehtsim.obs.source_models as source_models
 
 #######################################################
 # helpers
@@ -92,7 +93,7 @@ def test_observe_elevation_cuts_do_not_mutate_cached_empty_observation():
 
 
 def test_unsupported_model_raises_type_error_when_ngEHTforecast_is_missing(monkeypatch):
-    monkeypatch.setattr(og, "fp", None)
+    monkeypatch.setattr(source_models, "fp", None)
 
     obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
 

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -1,0 +1,75 @@
+#######################################################
+# imports
+
+import pytest
+import ehtim as eh
+import ngehtsim.obs.obs_generator as og
+import ngehtsim.obs.source_models as source_models
+
+#######################################################
+# helpers
+
+COMPACT_OBS_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 6.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
+
+
+def _compact_model():
+    model = eh.model.Model()
+    return model.add_circ_gauss(F0=1.0, FWHM=40.0 * eh.RADPERUAS)
+
+
+def _observe_without_corruptions(obsgen, input_model):
+    return obsgen.observe(
+        input_model,
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+#######################################################
+# tests
+
+
+def test_adapter_for_ehtim_model():
+    adapter = source_models.adapter_for(_compact_model())
+    assert isinstance(adapter, source_models.EhtimModelAdapter)
+
+
+def test_adapter_for_ehtim_image():
+    image = _compact_model().make_image(160.0 * eh.RADPERUAS, 64)
+
+    adapter = source_models.adapter_for(image)
+
+    assert isinstance(adapter, source_models.EhtimImageAdapter)
+
+
+def test_adapter_rejects_unsupported_model_type():
+    with pytest.raises(TypeError, match="input_model must be"):
+        source_models.adapter_for(object())
+
+
+def test_obs_generator_still_accepts_ehtim_model():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    obs = _observe_without_corruptions(obsgen, _compact_model())
+
+    assert len(obs.data) > 0
+
+
+def test_obs_generator_still_accepts_ehtim_image():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    image = _compact_model().make_image(160.0 * eh.RADPERUAS, 64)
+
+    obs = _observe_without_corruptions(obsgen, image)
+
+    assert len(obs.data) > 0


### PR DESCRIPTION
Summary:
- Move source-model-specific observation logic out of obs_generator.observe().
- Add adapters for ehtim Image, Movie, Model, and ngEHTforecast FisherForecast inputs.
- Preserve the existing obs_generator public API and ehtim Obsdata output behavior.
- Add regression tests for adapter selection and Image/Model observation generation.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_image_clean