### PR TITLE
Extract observation geometry helpers

### DIFF
--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -18,6 +18,7 @@ import warnings
 import ngehtsim.const_def as const
 import ngehtsim.weather.weather as nw
 import ngehtsim.obs.source_models as source_models
+import ngehtsim.obs.observation_geometry as observation_geometry
 
 ###################################################
 # helpers
@@ -609,30 +610,25 @@ class obs_generator(object):
         if allow_mixed_basis:
             print('WARNING: data generated in a non-circular polarization basis does not have properly-stored metadata info.')
 
-        # generate an empty obsdata object
-        if ((self.obs_empty is None) or (self.obs_empty.rf != self.freq)):
-            self.obs_empty = self.arr.obsdata(self.RA,
-                                              self.DEC,
-                                              self.freq,
-                                              (1.0e9)*float(self.settings['bandwidth']),
-                                              self.settings['t_int'],
-                                              self.settings['t_rest'],
-                                              self.settings['t_start'],
-                                              self.settings['t_start'] + self.settings['dt'],
-                                              mjd=self.mjd,
-                                              polrep='circ',
-                                              tau=0.0,
-                                              timetype='UTC',
-                                              elevmin=-90,
-                                              elevmax=90,
-                                              fix_theta_GMST=False)
-
-        # apply elevation cuts to ground stations
-        els = self.obs_empty.unpack(['el1', 'el2'])
-        mask = (self.obs_empty.data['t1'] == 'space') | ((els['el1'] > el_min) & (els['el1'] < el_max))
-        mask &= (self.obs_empty.data['t2'] == 'space') | ((els['el2'] > el_min) & (els['el2'] < el_max))
-        obs_empty = self.obs_empty.copy()
-        obs_empty.data = obs_empty.data[mask]
+        # generate and elevation-limit an empty observation template
+        geometry_context = {
+            "ra": self.RA,
+            "dec": self.DEC,
+            "rf": self.freq,
+            "bandwidth_hz": (1.0e9)*float(self.settings["bandwidth"]),
+            "t_int": self.settings["t_int"],
+            "t_rest": self.settings["t_rest"],
+            "t_start": self.settings["t_start"],
+            "t_stop": self.settings["t_start"] + self.settings["dt"],
+            "mjd": self.mjd,
+        }
+        self.obs_empty, obs_empty = observation_geometry.observation_template(
+            self.obs_empty,
+            self.arr,
+            geometry_context,
+            el_min=el_min,
+            el_max=el_max,
+        )
 
         # observe the source
         source_context = {

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -1,0 +1,59 @@
+###################################################
+# empty observation construction
+
+
+def needs_new_empty_observation(obs_empty, rf):
+    return (obs_empty is None) or (obs_empty.rf != rf)
+
+
+def make_empty_observation(array, context):
+    return array.obsdata(
+        context["ra"],
+        context["dec"],
+        context["rf"],
+        context["bandwidth_hz"],
+        context["t_int"],
+        context["t_rest"],
+        context["t_start"],
+        context["t_stop"],
+        mjd=context["mjd"],
+        polrep="circ",
+        tau=0.0,
+        timetype="UTC",
+        elevmin=-90,
+        elevmax=90,
+        fix_theta_GMST=False,
+    )
+
+
+def ensure_empty_observation(obs_empty, array, context):
+    if needs_new_empty_observation(obs_empty, context["rf"]):
+        return make_empty_observation(array, context)
+    return obs_empty
+
+###################################################
+# elevation limits
+
+
+def elevation_mask(obs_empty, el_min, el_max):
+    els = obs_empty.unpack(["el1", "el2"])
+
+    mask = (obs_empty.data["t1"] == "space") | ((els["el1"] > el_min) & (els["el1"] < el_max))
+    mask &= (obs_empty.data["t2"] == "space") | ((els["el2"] > el_min) & (els["el2"] < el_max))
+
+    return mask
+
+
+def apply_elevation_limits(obs_empty, el_min, el_max):
+    obs_limited = obs_empty.copy()
+    obs_limited.data = obs_limited.data[elevation_mask(obs_empty, el_min, el_max)]
+    return obs_limited
+
+###################################################
+# public interface
+
+
+def observation_template(obs_empty, array, context, el_min, el_max):
+    obs_empty = ensure_empty_observation(obs_empty, array, context)
+    obs_limited = apply_elevation_limits(obs_empty, el_min, el_max)
+    return obs_empty, obs_limited

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -1,0 +1,109 @@
+#######################################################
+# imports
+
+import pytest
+import ngehtsim.obs.obs_generator as og
+import ngehtsim.obs.observation_geometry as observation_geometry
+
+#######################################################
+# helpers
+
+COMPACT_OBS_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 6.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
+
+
+@pytest.fixture(scope="module")
+def array_and_context():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    context = {
+        "ra": obsgen.RA,
+        "dec": obsgen.DEC,
+        "rf": obsgen.freq,
+        "bandwidth_hz": (1.0e9)*float(obsgen.settings["bandwidth"]),
+        "t_int": obsgen.settings["t_int"],
+        "t_rest": obsgen.settings["t_rest"],
+        "t_start": obsgen.settings["t_start"],
+        "t_stop": obsgen.settings["t_start"] + obsgen.settings["dt"],
+        "mjd": obsgen.mjd,
+    }
+
+    return obsgen.arr, context
+
+#######################################################
+# tests
+
+
+def test_observation_template_reuses_cached_empty_observation(array_and_context):
+    array, context = array_and_context
+
+    cached_obs, limited_obs = observation_geometry.observation_template(
+        None,
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    cached_obs_again, limited_obs_again = observation_geometry.observation_template(
+        cached_obs,
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    assert cached_obs_again is cached_obs
+    assert limited_obs is not cached_obs
+    assert limited_obs_again is not cached_obs
+
+
+def test_observation_template_rebuilds_when_frequency_changes(array_and_context):
+    array, context = array_and_context
+
+    cached_obs, _ = observation_geometry.observation_template(
+        None,
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    new_context = dict(context)
+    new_context["rf"] = 345.0e9
+
+    rebuilt_obs, _ = observation_geometry.observation_template(
+        cached_obs,
+        array,
+        new_context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    assert rebuilt_obs is not cached_obs
+    assert rebuilt_obs.rf == new_context["rf"]
+
+
+def test_elevation_limits_do_not_mutate_cached_empty_observation(array_and_context):
+    array, context = array_and_context
+
+    cached_obs, strict_obs = observation_geometry.observation_template(
+        None,
+        array,
+        context,
+        el_min=50.0,
+        el_max=80.0,
+    )
+
+    original_row_count = len(cached_obs.data)
+
+    assert len(strict_obs.data) < original_row_count
+    assert len(cached_obs.data) == original_row_count


### PR DESCRIPTION
Summary:
- Move empty observation construction out of obs_generator.observe().
- Move elevation-limit application into a dedicated observation geometry helper.
- Preserve cached empty-observation behavior and public obs_generator APIs.
- Add tests for cache reuse, frequency invalidation, and non-mutating elevation cuts.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean