### PR TITLE
Add observation context builders

### DIFF
--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -574,6 +574,33 @@ class obs_generator(object):
             print("Beginning of last integration: {0}".format(t_last))
             print('Scan start times: {0}'.format(self.t_seg_times))
 
+    # build context for empty observation construction
+    def geometry_context(self):
+        return {
+            "ra": self.RA,
+            "dec": self.DEC,
+            "rf": self.freq,
+            "bandwidth_hz": (1.0e9)*float(self.settings["bandwidth"]),
+            "t_int": self.settings["t_int"],
+            "t_rest": self.settings["t_rest"],
+            "t_start": self.settings["t_start"],
+            "t_stop": self.settings["t_start"] + self.settings["dt"],
+            "mjd": self.mjd,
+        }
+
+    # build context for source-model adapters
+    def source_context(self):
+        return {
+            "ra": self.RA,
+            "dec": self.DEC,
+            "mjd": self.mjd,
+            "source": self.settings["source"],
+            "rf": self.freq,
+            "ttype": self.settings["ttype"],
+            "fft_pad_factor": self.settings["fft_pad_factor"],
+            "verbosity": self.verbosity,
+        }
+
     ###################################################
     # functions for generating observations
 
@@ -611,37 +638,16 @@ class obs_generator(object):
             print('WARNING: data generated in a non-circular polarization basis does not have properly-stored metadata info.')
 
         # generate and elevation-limit an empty observation template
-        geometry_context = {
-            "ra": self.RA,
-            "dec": self.DEC,
-            "rf": self.freq,
-            "bandwidth_hz": (1.0e9)*float(self.settings["bandwidth"]),
-            "t_int": self.settings["t_int"],
-            "t_rest": self.settings["t_rest"],
-            "t_start": self.settings["t_start"],
-            "t_stop": self.settings["t_start"] + self.settings["dt"],
-            "mjd": self.mjd,
-        }
         self.obs_empty, obs_empty = observation_geometry.observation_template(
             self.obs_empty,
             self.arr,
-            geometry_context,
+            self.geometry_context(),
             el_min=el_min,
             el_max=el_max,
         )
 
         # observe the source
-        source_context = {
-            "ra": self.RA,
-            "dec": self.DEC,
-            "mjd": self.mjd,
-            "source": self.settings["source"],
-            "rf": self.freq,
-            "ttype": self.settings["ttype"],
-            "fft_pad_factor": self.settings["fft_pad_factor"],
-            "verbosity": self.verbosity,
-        }
-        obs, F0 = source_models.observe_source(input_model, obs_empty, source_context, p=p)
+        obs, F0 = source_models.observe_source(input_model, obs_empty, self.source_context(), p=p)
 
         # extract relevant information
         t1 = obs.data['t1']

--- a/tests/test_observation_contexts.py
+++ b/tests/test_observation_contexts.py
@@ -1,0 +1,52 @@
+#######################################################
+# imports
+
+import ngehtsim.obs.obs_generator as og
+
+#######################################################
+# helpers
+
+COMPACT_OBS_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 6.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
+
+#######################################################
+# tests
+
+
+def test_geometry_context_contains_observation_template_inputs():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    context = obsgen.geometry_context()
+
+    assert context["ra"] == obsgen.RA
+    assert context["dec"] == obsgen.DEC
+    assert context["rf"] == obsgen.freq
+    assert context["bandwidth_hz"] == (1.0e9)*float(obsgen.settings["bandwidth"])
+    assert context["t_int"] == obsgen.settings["t_int"]
+    assert context["t_rest"] == obsgen.settings["t_rest"]
+    assert context["t_start"] == obsgen.settings["t_start"]
+    assert context["t_stop"] == obsgen.settings["t_start"] + obsgen.settings["dt"]
+    assert context["mjd"] == obsgen.mjd
+
+
+def test_source_context_contains_source_adapter_inputs():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+
+    context = obsgen.source_context()
+
+    assert context["ra"] == obsgen.RA
+    assert context["dec"] == obsgen.DEC
+    assert context["mjd"] == obsgen.mjd
+    assert context["source"] == obsgen.settings["source"]
+    assert context["rf"] == obsgen.freq
+    assert context["ttype"] == obsgen.settings["ttype"]
+    assert context["fft_pad_factor"] == obsgen.settings["fft_pad_factor"]
+    assert context["verbosity"] == obsgen.verbosity


### PR DESCRIPTION
Summary:
- Move geometry context construction out of obs_generator.observe().
- Move source adapter context construction out of obs_generator.observe().
- Preserve existing observation-generation behavior.
- Add tests for context contents.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean