### PR TITLE
Key cached observation geometry

### DIFF
--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -198,6 +198,7 @@ class obs_generator(object):
         # other settings
 
         self.obs_empty = None
+        self.obs_empty_key = None
 
     ###################################################
     # initialization functions
@@ -577,6 +578,7 @@ class obs_generator(object):
     # build context for empty observation construction
     def geometry_context(self):
         return {
+            "sites": tuple(self.sites),
             "ra": self.RA,
             "dec": self.DEC,
             "rf": self.freq,
@@ -638,8 +640,9 @@ class obs_generator(object):
             print('WARNING: data generated in a non-circular polarization basis does not have properly-stored metadata info.')
 
         # generate and elevation-limit an empty observation template
-        self.obs_empty, obs_empty = observation_geometry.observation_template(
+        self.obs_empty, self.obs_empty_key, obs_empty = observation_geometry.observation_template(
             self.obs_empty,
+            self.obs_empty_key,
             self.arr,
             self.geometry_context(),
             el_min=el_min,

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -1,9 +1,45 @@
 ###################################################
+# cache key construction
+
+GEOMETRY_CACHE_FIELDS = (
+    "sites",
+    "ra",
+    "dec",
+    "rf",
+    "bandwidth_hz",
+    "t_int",
+    "t_rest",
+    "t_start",
+    "t_stop",
+    "mjd",
+)
+
+
+def _cache_value(value):
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+
+    if isinstance(value, list):
+        return tuple(_cache_value(item) for item in value)
+
+    if isinstance(value, tuple):
+        return tuple(_cache_value(item) for item in value)
+
+    if isinstance(value, dict):
+        return tuple(sorted((key, _cache_value(item)) for key, item in value.items()))
+
+    return value
+
+
+def geometry_cache_key(context):
+    return tuple((field, _cache_value(context[field])) for field in GEOMETRY_CACHE_FIELDS)
+
+###################################################
 # empty observation construction
 
 
-def needs_new_empty_observation(obs_empty, rf):
-    return (obs_empty is None) or (obs_empty.rf != rf)
+def needs_new_empty_observation(obs_empty, cached_key, context):
+    return (obs_empty is None) or (cached_key != geometry_cache_key(context))
 
 
 def make_empty_observation(array, context):
@@ -26,10 +62,13 @@ def make_empty_observation(array, context):
     )
 
 
-def ensure_empty_observation(obs_empty, array, context):
-    if needs_new_empty_observation(obs_empty, context["rf"]):
-        return make_empty_observation(array, context)
-    return obs_empty
+def ensure_empty_observation(obs_empty, cached_key, array, context):
+    new_key = geometry_cache_key(context)
+
+    if needs_new_empty_observation(obs_empty, cached_key, context):
+        return make_empty_observation(array, context), new_key
+
+    return obs_empty, cached_key
 
 ###################################################
 # elevation limits
@@ -53,7 +92,7 @@ def apply_elevation_limits(obs_empty, el_min, el_max):
 # public interface
 
 
-def observation_template(obs_empty, array, context, el_min, el_max):
-    obs_empty = ensure_empty_observation(obs_empty, array, context)
+def observation_template(obs_empty, cached_key, array, context, el_min, el_max):
+    obs_empty, cached_key = ensure_empty_observation(obs_empty, cached_key, array, context)
     obs_limited = apply_elevation_limits(obs_empty, el_min, el_max)
-    return obs_empty, obs_limited
+    return obs_empty, cached_key, obs_limited

--- a/tests/test_observation_contexts.py
+++ b/tests/test_observation_contexts.py
@@ -26,6 +26,7 @@ def test_geometry_context_contains_observation_template_inputs():
 
     context = obsgen.geometry_context()
 
+    assert context["sites"] == tuple(obsgen.sites)
     assert context["ra"] == obsgen.RA
     assert context["dec"] == obsgen.DEC
     assert context["rf"] == obsgen.freq

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -23,29 +23,30 @@ COMPACT_OBS_SETTINGS = {
 @pytest.fixture(scope="module")
 def array_and_context():
     obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
-
-    context = {
-        "ra": obsgen.RA,
-        "dec": obsgen.DEC,
-        "rf": obsgen.freq,
-        "bandwidth_hz": (1.0e9)*float(obsgen.settings["bandwidth"]),
-        "t_int": obsgen.settings["t_int"],
-        "t_rest": obsgen.settings["t_rest"],
-        "t_start": obsgen.settings["t_start"],
-        "t_stop": obsgen.settings["t_start"] + obsgen.settings["dt"],
-        "mjd": obsgen.mjd,
-    }
-
-    return obsgen.arr, context
+    return obsgen.arr, obsgen.geometry_context()
 
 #######################################################
 # tests
 
 
+def test_geometry_cache_key_changes_when_geometry_context_changes(array_and_context):
+    array, context = array_and_context
+
+    key = observation_geometry.geometry_cache_key(context)
+
+    new_context = dict(context)
+    new_context["t_stop"] = context["t_stop"] + 1.0
+
+    new_key = observation_geometry.geometry_cache_key(new_context)
+
+    assert new_key != key
+
+
 def test_observation_template_reuses_cached_empty_observation(array_and_context):
     array, context = array_and_context
 
-    cached_obs, limited_obs = observation_geometry.observation_template(
+    cached_obs, cached_key, limited_obs = observation_geometry.observation_template(
+        None,
         None,
         array,
         context,
@@ -53,8 +54,9 @@ def test_observation_template_reuses_cached_empty_observation(array_and_context)
         el_max=90.0,
     )
 
-    cached_obs_again, limited_obs_again = observation_geometry.observation_template(
+    cached_obs_again, cached_key_again, limited_obs_again = observation_geometry.observation_template(
         cached_obs,
+        cached_key,
         array,
         context,
         el_min=0.0,
@@ -62,6 +64,7 @@ def test_observation_template_reuses_cached_empty_observation(array_and_context)
     )
 
     assert cached_obs_again is cached_obs
+    assert cached_key_again == cached_key
     assert limited_obs is not cached_obs
     assert limited_obs_again is not cached_obs
 
@@ -69,7 +72,8 @@ def test_observation_template_reuses_cached_empty_observation(array_and_context)
 def test_observation_template_rebuilds_when_frequency_changes(array_and_context):
     array, context = array_and_context
 
-    cached_obs, _ = observation_geometry.observation_template(
+    cached_obs, cached_key, _ = observation_geometry.observation_template(
+        None,
         None,
         array,
         context,
@@ -80,8 +84,9 @@ def test_observation_template_rebuilds_when_frequency_changes(array_and_context)
     new_context = dict(context)
     new_context["rf"] = 345.0e9
 
-    rebuilt_obs, _ = observation_geometry.observation_template(
+    rebuilt_obs, rebuilt_key, _ = observation_geometry.observation_template(
         cached_obs,
+        cached_key,
         array,
         new_context,
         el_min=0.0,
@@ -90,12 +95,42 @@ def test_observation_template_rebuilds_when_frequency_changes(array_and_context)
 
     assert rebuilt_obs is not cached_obs
     assert rebuilt_obs.rf == new_context["rf"]
+    assert rebuilt_key != cached_key
+
+
+def test_observation_template_rebuilds_when_timing_changes(array_and_context):
+    array, context = array_and_context
+
+    cached_obs, cached_key, _ = observation_geometry.observation_template(
+        None,
+        None,
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    new_context = dict(context)
+    new_context["t_stop"] = context["t_stop"] + 1.0
+
+    rebuilt_obs, rebuilt_key, _ = observation_geometry.observation_template(
+        cached_obs,
+        cached_key,
+        array,
+        new_context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    assert rebuilt_obs is not cached_obs
+    assert rebuilt_key != cached_key
 
 
 def test_elevation_limits_do_not_mutate_cached_empty_observation(array_and_context):
     array, context = array_and_context
 
-    cached_obs, strict_obs = observation_geometry.observation_template(
+    cached_obs, cached_key, strict_obs = observation_geometry.observation_template(
+        None,
         None,
         array,
         context,
@@ -105,5 +140,6 @@ def test_elevation_limits_do_not_mutate_cached_empty_observation(array_and_conte
 
     original_row_count = len(cached_obs.data)
 
+    assert cached_key == observation_geometry.geometry_cache_key(context)
     assert len(strict_obs.data) < original_row_count
     assert len(cached_obs.data) == original_row_count


### PR DESCRIPTION
Summary:
- Add an explicit geometry cache key for cached empty observations.
- Invalidate cached observation templates when geometry-relevant context changes.
- Include array site membership, sky position, frequency, bandwidth, timing, and MJD in the cache key.
- Add regression tests for cache reuse and invalidation.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean