### PR TITLE
Cache elevation-filtered observation templates

### DIFF
--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -199,6 +199,7 @@ class obs_generator(object):
 
         self.obs_empty = None
         self.obs_empty_key = None
+        self.obs_template_cache = {}
 
     ###################################################
     # initialization functions
@@ -640,9 +641,10 @@ class obs_generator(object):
             print('WARNING: data generated in a non-circular polarization basis does not have properly-stored metadata info.')
 
         # generate and elevation-limit an empty observation template
-        self.obs_empty, self.obs_empty_key, obs_empty = observation_geometry.observation_template(
+        self.obs_empty, self.obs_empty_key, self.obs_template_cache, obs_empty = observation_geometry.observation_template(
             self.obs_empty,
             self.obs_empty_key,
+            self.obs_template_cache,
             self.arr,
             self.geometry_context(),
             el_min=el_min,

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -92,7 +92,30 @@ def apply_elevation_limits(obs_empty, el_min, el_max):
 # public interface
 
 
-def observation_template(obs_empty, cached_key, array, context, el_min, el_max):
+def elevation_cache_key(cached_key, el_min, el_max):
+    return cached_key, _cache_value(el_min), _cache_value(el_max)
+
+
+def cached_elevation_template(obs_empty, template_cache, cached_key, el_min, el_max):
+    key = elevation_cache_key(cached_key, el_min, el_max)
+    if key not in template_cache:
+        template_cache[key] = apply_elevation_limits(obs_empty, el_min, el_max)
+    return template_cache[key]
+
+
+def observation_template(obs_empty, cached_key, template_cache, array, context, el_min, el_max):
+    old_key = cached_key
     obs_empty, cached_key = ensure_empty_observation(obs_empty, cached_key, array, context)
-    obs_limited = apply_elevation_limits(obs_empty, el_min, el_max)
-    return obs_empty, cached_key, obs_limited
+
+    if template_cache is None or cached_key != old_key:
+        template_cache = {}
+
+    obs_limited = cached_elevation_template(
+        obs_empty,
+        template_cache,
+        cached_key,
+        el_min,
+        el_max,
+    )
+
+    return obs_empty, cached_key, template_cache, obs_limited.copy()

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -1,145 +1,167 @@
-#######################################################
-# imports
-
 import pytest
-import ngehtsim.obs.obs_generator as og
+
+from ngehtsim.obs.obs_generator import obs_generator
 import ngehtsim.obs.observation_geometry as observation_geometry
 
-#######################################################
-# helpers
 
-COMPACT_OBS_SETTINGS = {
-    "source": "M87",
-    "sites": ["ALMA", "APEX", "LMT", "SMT"],
-    "weather": "typical",
-    "t_start": 0.0,
-    "dt": 6.0,
-    "t_int": 600.0,
-    "t_rest": 1200.0,
-    "random_seed": 1,
-}
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture
 def array_and_context():
-    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obsgen = obs_generator(settings={"weather": "exact", "source": "M87"})
     return obsgen.arr, obsgen.geometry_context()
-
-#######################################################
-# tests
 
 
 def test_geometry_cache_key_changes_when_geometry_context_changes(array_and_context):
-    array, context = array_and_context
+    _, context = array_and_context
 
-    key = observation_geometry.geometry_cache_key(context)
+    original_key = observation_geometry.geometry_cache_key(context)
 
-    new_context = dict(context)
-    new_context["t_stop"] = context["t_stop"] + 1.0
+    changed_context = dict(context)
+    changed_context["rf"] = context["rf"] * 2
 
-    new_key = observation_geometry.geometry_cache_key(new_context)
-
-    assert new_key != key
+    assert observation_geometry.geometry_cache_key(changed_context) != original_key
 
 
 def test_observation_template_reuses_cached_empty_observation(array_and_context):
     array, context = array_and_context
 
-    cached_obs, cached_key, limited_obs = observation_geometry.observation_template(
+    cached_obs, cached_key, template_cache, limited_obs = observation_geometry.observation_template(
         None,
         None,
+        {},
         array,
         context,
-        el_min=0.0,
-        el_max=90.0,
+        el_min=0,
+        el_max=90,
     )
 
-    cached_obs_again, cached_key_again, limited_obs_again = observation_geometry.observation_template(
+    cached_obs_again, cached_key_again, template_cache, limited_obs_again = observation_geometry.observation_template(
         cached_obs,
         cached_key,
+        template_cache,
         array,
         context,
-        el_min=0.0,
-        el_max=90.0,
+        el_min=0,
+        el_max=90,
     )
 
     assert cached_obs_again is cached_obs
     assert cached_key_again == cached_key
-    assert limited_obs is not cached_obs
-    assert limited_obs_again is not cached_obs
+    assert len(template_cache) == 1
+    assert limited_obs_again is not limited_obs
+    assert len(limited_obs_again.data) == len(limited_obs.data)
 
 
 def test_observation_template_rebuilds_when_frequency_changes(array_and_context):
     array, context = array_and_context
 
-    cached_obs, cached_key, _ = observation_geometry.observation_template(
+    cached_obs, cached_key, template_cache, _ = observation_geometry.observation_template(
         None,
         None,
+        {},
         array,
         context,
-        el_min=0.0,
-        el_max=90.0,
+        el_min=0,
+        el_max=90,
     )
 
-    new_context = dict(context)
-    new_context["rf"] = 345.0e9
+    changed_context = dict(context)
+    changed_context["rf"] = context["rf"] * 2
 
-    rebuilt_obs, rebuilt_key, _ = observation_geometry.observation_template(
+    rebuilt_obs, rebuilt_key, template_cache, _ = observation_geometry.observation_template(
         cached_obs,
         cached_key,
+        template_cache,
         array,
-        new_context,
-        el_min=0.0,
-        el_max=90.0,
+        changed_context,
+        el_min=0,
+        el_max=90,
     )
 
     assert rebuilt_obs is not cached_obs
-    assert rebuilt_obs.rf == new_context["rf"]
     assert rebuilt_key != cached_key
+    assert len(template_cache) == 1
+    assert observation_geometry.elevation_cache_key(rebuilt_key, 0, 90) in template_cache
 
 
 def test_observation_template_rebuilds_when_timing_changes(array_and_context):
     array, context = array_and_context
 
-    cached_obs, cached_key, _ = observation_geometry.observation_template(
+    cached_obs, cached_key, template_cache, _ = observation_geometry.observation_template(
         None,
         None,
+        {},
         array,
         context,
-        el_min=0.0,
-        el_max=90.0,
+        el_min=0,
+        el_max=90,
     )
 
-    new_context = dict(context)
-    new_context["t_stop"] = context["t_stop"] + 1.0
+    changed_context = dict(context)
+    changed_context["t_stop"] = context["t_stop"] + 1
 
-    rebuilt_obs, rebuilt_key, _ = observation_geometry.observation_template(
+    rebuilt_obs, rebuilt_key, template_cache, _ = observation_geometry.observation_template(
         cached_obs,
         cached_key,
+        template_cache,
         array,
-        new_context,
-        el_min=0.0,
-        el_max=90.0,
+        changed_context,
+        el_min=0,
+        el_max=90,
     )
 
     assert rebuilt_obs is not cached_obs
     assert rebuilt_key != cached_key
+    assert len(template_cache) == 1
+    assert observation_geometry.elevation_cache_key(rebuilt_key, 0, 90) in template_cache
+
+
+def test_observation_template_caches_distinct_elevation_limits(array_and_context):
+    array, context = array_and_context
+
+    cached_obs, cached_key, template_cache, limited_obs = observation_geometry.observation_template(
+        None,
+        None,
+        {},
+        array,
+        context,
+        el_min=0,
+        el_max=90,
+    )
+
+    cached_obs_again, cached_key_again, template_cache, stricter_obs = observation_geometry.observation_template(
+        cached_obs,
+        cached_key,
+        template_cache,
+        array,
+        context,
+        el_min=50,
+        el_max=80,
+    )
+
+    assert cached_obs_again is cached_obs
+    assert cached_key_again == cached_key
+    assert len(template_cache) == 2
+    assert len(stricter_obs.data) <= len(limited_obs.data)
 
 
 def test_elevation_limits_do_not_mutate_cached_empty_observation(array_and_context):
     array, context = array_and_context
 
-    cached_obs, cached_key, strict_obs = observation_geometry.observation_template(
+    cached_obs, cached_key = observation_geometry.ensure_empty_observation(
         None,
         None,
         array,
         context,
-        el_min=50.0,
-        el_max=80.0,
+    )
+    original_len = len(cached_obs.data)
+
+    limited_obs = observation_geometry.apply_elevation_limits(
+        cached_obs,
+        el_min=50,
+        el_max=80,
     )
 
-    original_row_count = len(cached_obs.data)
-
+    assert len(cached_obs.data) == original_len
+    assert len(limited_obs.data) <= original_len
+    assert limited_obs is not cached_obs
     assert cached_key == observation_geometry.geometry_cache_key(context)
-    assert len(strict_obs.data) < original_row_count
-    assert len(cached_obs.data) == original_row_count


### PR DESCRIPTION
Caches reusable elevation-filtered observation templates while still returning fresh Obsdata copies to downstream source-model code.

Validation:
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 1 --warmups 0 --scenario eht2017_model_clean_reused_generator