### PR TITLE
Add synthetic data profiling harness

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,10 +1,51 @@
 # Benchmarks
 
-This directory contains opt-in runtime benchmarks for representative synthetic-data generation workflows.
+This directory contains opt-in runtime benchmarks and profiling tools for representative synthetic-data generation workflows.
 
-The benchmark runner is intentionally not part of the default unit-test suite. Results depend on hardware, Python version, installed dependency versions, and local system state.
+The benchmark and profiling runners are intentionally not part of the default unit-test suite. Results depend on hardware, Python version, installed dependency versions, and local system state.
 
 ## List Scenarios
 
 ```bash
 MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --list-scenarios
+```
+
+## Run Timing Benchmarks
+
+Run all scenarios with the default repeat and warmup counts:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py
+```
+
+Run one scenario with more repeats:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 5 --warmups 1 --scenario eht2017_model_clean_reused_generator
+```
+
+Benchmark outputs are written to `benchmarks/results/`.
+
+## Profile Synthetic Data Generation
+
+Use the profiler when you need call-stack detail about where time is being spent. The profiler uses the same scenario definitions as the timing benchmark.
+
+Profile the steady-state `make_obs()` phase for the reused-generator scenario:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py --scenario eht2017_model_clean_reused_generator --phase make_obs --repeats 3 --warmups 1
+```
+
+Profile generator initialization:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py --scenario eht2017_model_clean --phase init --repeats 3 --warmups 0
+```
+
+Profile initialization and observation generation together:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py --scenario eht2017_model_clean --phase full --repeats 3 --warmups 1
+```
+
+The profiler writes both a raw `.prof` file and a readable `.txt` summary under `benchmarks/results/`. The `.txt` summary is usually the first file to inspect. The `.prof` file can be opened with tools such as `snakeviz` if desired.

--- a/benchmarks/benchmark_synthetic_data.py
+++ b/benchmarks/benchmark_synthetic_data.py
@@ -152,11 +152,15 @@ def run_fresh_iteration(scenario):
     }
 
 
-def run_reused_generator_iterations(scenario, repeats):
+def run_reused_generator_iterations(scenario, repeats, warmups=0):
     t0 = time.perf_counter()
     obsgen = og.obs_generator(settings=dict(scenario["settings"]))
     t1 = time.perf_counter()
     obsgen_init_seconds = t1 - t0
+
+    for _ in range(warmups):
+        input_model = make_source(scenario["input_kind"])
+        obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
 
     results = []
     for index in range(repeats):
@@ -179,9 +183,7 @@ def run_scenario(scenario, repeats, warmups):
     print("Running {0}...".format(scenario["name"]), flush=True)
 
     if scenario["reuse_generator"]:
-        if warmups > 0:
-            run_reused_generator_iterations(scenario, warmups)
-        raw_results = run_reused_generator_iterations(scenario, repeats)
+        raw_results = run_reused_generator_iterations(scenario, repeats, warmups=warmups)
     else:
         for _ in range(warmups):
             run_fresh_iteration(scenario)

--- a/benchmarks/profile_synthetic_data.py
+++ b/benchmarks/profile_synthetic_data.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Profile representative ngehtsim synthetic-data generation workflows."""
+
+import argparse
+import cProfile
+import io
+import os
+import pstats
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if not (REPO_ROOT / "ngehtsim").exists():
+    REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "benchmarks"))
+
+import benchmark_synthetic_data as bench
+import ngehtsim.obs.obs_generator as og
+
+
+def default_output_paths(scenario_name, phase):
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    stem = "synthetic_data_profile_{0}_{1}_{2}".format(
+        scenario_name,
+        phase,
+        timestamp,
+    )
+    output_dir = Path("benchmarks") / "results"
+    return output_dir / "{0}.prof".format(stem), output_dir / "{0}.txt".format(stem)
+
+
+def warmup_make_obs(scenario, count):
+    if count <= 0:
+        return
+
+    if scenario["reuse_generator"]:
+        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        for _ in range(count):
+            input_model = bench.make_source(scenario["input_kind"])
+            obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
+        return
+
+    for _ in range(count):
+        input_model = bench.make_source(scenario["input_kind"])
+        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
+
+
+def make_init_target(scenario, repeats):
+    def target():
+        rows = []
+        for _ in range(repeats):
+            og.obs_generator(settings=dict(scenario["settings"]))
+            rows.append(0)
+        return rows
+
+    return target
+
+
+def make_make_obs_target(scenario, repeats, warmups):
+    if scenario["reuse_generator"]:
+        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        for _ in range(warmups):
+            input_model = bench.make_source(scenario["input_kind"])
+            obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
+
+        input_models = [bench.make_source(scenario["input_kind"]) for _ in range(repeats)]
+
+        def target():
+            rows = []
+            for input_model in input_models:
+                obs = obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
+                rows.append(int(len(obs.data)))
+            return rows
+
+        return target
+
+    warmup_make_obs(scenario, warmups)
+    obs_inputs = [
+        (
+            og.obs_generator(settings=dict(scenario["settings"])),
+            bench.make_source(scenario["input_kind"]),
+        )
+        for _ in range(repeats)
+    ]
+
+    def target():
+        rows = []
+        for obsgen, input_model in obs_inputs:
+            obs = obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
+            rows.append(int(len(obs.data)))
+        return rows
+
+    return target
+
+
+def make_full_target(scenario, repeats, warmups):
+    def target():
+        if scenario["reuse_generator"]:
+            return [
+                result["rows"]
+                for result in bench.run_reused_generator_iterations(scenario, repeats, warmups=warmups)
+            ]
+
+        for _ in range(warmups):
+            bench.run_fresh_iteration(scenario)
+        return [
+            result["rows"]
+            for result in [bench.run_fresh_iteration(scenario) for _ in range(repeats)]
+        ]
+
+    return target
+
+
+def profile_target(target, sort, limit, profile_output, stats_output, metadata):
+    profiler = cProfile.Profile()
+
+    start = time.perf_counter()
+    rows = profiler.runcall(target)
+    elapsed = time.perf_counter() - start
+
+    profile_output.parent.mkdir(parents=True, exist_ok=True)
+    profiler.dump_stats(str(profile_output))
+
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream)
+    stats.strip_dirs().sort_stats(sort).print_stats(limit)
+
+    header = [
+        "scenario: {0}".format(metadata["scenario"]),
+        "phase: {0}".format(metadata["phase"]),
+        "repeats: {0}".format(metadata["repeats"]),
+        "warmups: {0}".format(metadata["warmups"]),
+        "sort: {0}".format(sort),
+        "limit: {0}".format(limit),
+        "elapsed_seconds: {0:.6f}".format(elapsed),
+        "rows: {0}".format(rows),
+        "profile_output: {0}".format(profile_output),
+        "",
+    ]
+    stats_output.write_text("\n".join(header) + stream.getvalue())
+
+    return rows, elapsed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", default="eht2017_model_clean_reused_generator")
+    parser.add_argument("--phase", choices=["init", "make_obs", "full"], default="make_obs")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--sort", default="cumtime")
+    parser.add_argument("--limit", type=int, default=40)
+    parser.add_argument("--profile-output", type=Path, default=None)
+    parser.add_argument("--stats-output", type=Path, default=None)
+    parser.add_argument("--list-scenarios", action="store_true")
+    args = parser.parse_args()
+
+    if args.repeats < 1:
+        raise SystemExit("--repeats must be at least 1")
+    if args.warmups < 0:
+        raise SystemExit("--warmups must be non-negative")
+
+    if args.list_scenarios:
+        for scenario in bench.SCENARIOS:
+            print("{0}: {1}".format(scenario["name"], scenario["description"]))
+        return 0
+
+    scenario = bench.select_scenarios([args.scenario])[0]
+    profile_output, stats_output = default_output_paths(scenario["name"], args.phase)
+    if args.profile_output is not None:
+        profile_output = args.profile_output
+    if args.stats_output is not None:
+        stats_output = args.stats_output
+
+    if args.phase == "init":
+        target = make_init_target(scenario, args.repeats)
+    elif args.phase == "make_obs":
+        target = make_make_obs_target(scenario, args.repeats, args.warmups)
+    else:
+        target = make_full_target(scenario, args.repeats, args.warmups)
+
+    rows, elapsed = profile_target(
+        target,
+        args.sort,
+        args.limit,
+        profile_output,
+        stats_output,
+        {
+            "scenario": scenario["name"],
+            "phase": args.phase,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+        },
+    )
+
+    print("Profiled {0} [{1}] in {2:.4f}s; rows: {3}".format(
+        scenario["name"],
+        args.phase,
+        elapsed,
+        rows,
+    ))
+    print("Raw profile written to {0}".format(profile_output))
+    print("Text summary written to {0}".format(stats_output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds an opt-in cProfile runner for synthetic-data scenarios and fixes reused-generator warmups so they warm the same generator being measured.

Validation:
- python3 -m py_compile benchmarks/benchmark_synthetic_data.py benchmarks/profile_synthetic_data.py
- MPLBACKEND=Agg python3 -m pytest -q
- MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --scenario eht2017_model_clean_reused_generator --repeats 1 --warmups 1
- MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py --scenario eht2017_model_clean_reused_generator --phase make_obs --repeats 1 --warmups 1 --limit 20