### PR TITLE
Add Zarr-backed weather API adapter

### DIFF
--- a/docs/source/weather.rst
+++ b/docs/source/weather.rst
@@ -22,6 +22,18 @@ optional Zarr dependency and open it with an explicit path:
    store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr")
    april_weather = store.read_partition("ALMA", "Apr", cadence="daily")
 
+The established weather functions can use that store directly. Without the
+``weather_store`` argument, they continue to use the packaged binary data:
+
+.. code-block:: python
+
+   from ngehtsim.weather import weather
+
+   opacity = weather.opacity(
+       "ALMA", form="exact", month="Apr", day=11, year=2017, freq=230.0,
+       weather_store=store,
+   )
+
 The reader only opens local filesystem paths. Synchronization and download are
 deliberately outside of ngehtsim, so the same interface works with a manually
 downloaded release, a network filesystem, or a cloud-synchronized directory.

--- a/ngehtsim/weather/weather.py
+++ b/ngehtsim/weather/weather.py
@@ -1,28 +1,21 @@
 ###################################################
 # imports
 
-import numpy as np
-import ngehtsim.const_def as const
+from functools import lru_cache
 import os
 import struct
 
-###################################################
-# load eigenspectra
+import numpy as np
 
-meanspec_tau = np.loadtxt(const.path_to_eigenspectra+'/spectrum_mean.txt',unpack=True)
-meanspec_Tb = np.loadtxt(const.path_to_eigenspectra+'_Tb/spectrum_mean.txt',unpack=True)
-tau_spectra = list()
-Tb_spectra = list()
-for i in range(const.number_of_components):
-    spechere = np.loadtxt(const.path_to_eigenspectra+'/spectrum_'+str(i).zfill(4)+'.txt',unpack=True)
-    spechere_Tb = np.loadtxt(const.path_to_eigenspectra+'_Tb/spectrum_'+str(i).zfill(4)+'.txt',unpack=True)
-    tau_spectra.append(spechere)
-    Tb_spectra.append(spechere_Tb)
+import ngehtsim.const_def as const
+from ngehtsim.weather.zarr_store import ZarrWeatherStore
+
 
 ###################################################
 # function definitions
 
-def read_binary_atm(filename,Ncomps=const.number_of_components):
+
+def read_binary_atm(filename, Ncomps=const.number_of_components):
     """
     Read a stored weather data file containing either opacity or brightness temperature info.
 
@@ -34,36 +27,37 @@ def read_binary_atm(filename,Ncomps=const.number_of_components):
       (numpy.ndarray): Several arrays containing the dates/times and PCA component coefficients
     """
 
-    with open(filename, 'rb') as binary_file:
+    with open(filename, "rb") as binary_file:
         contents = bytearray(binary_file.read())
 
     linelength = int(contents[0:2][0])
-    prelength = linelength - (2*Ncomps)
-    Nlines = int((len(contents) - 2) / linelength)
+    prelength = linelength - (2 * Ncomps)
+    nlines = int((len(contents) - 2) / linelength)
 
-    years = np.zeros(Nlines)
-    months = np.zeros(Nlines)
-    days = np.zeros(Nlines)
+    years = np.zeros(nlines)
+    months = np.zeros(nlines)
+    days = np.zeros(nlines)
     if prelength > 4:
-        times = np.zeros(Nlines)
-    coeffs = np.zeros((Nlines,Ncomps))
-    for i in range(Nlines):
+        times = np.zeros(nlines)
+    coeffs = np.zeros((nlines, Ncomps))
+    for index in range(nlines):
+        start = 2 + (linelength * index)
+        stop = start + linelength
+        line = contents[start:stop]
 
-        istart = 2 + (linelength*i)
-        iend = istart + linelength
-        linehere = contents[istart:iend]
-
-        years[i] = int(struct.unpack('<h', linehere[0:2])[0])
-        months[i] = int(struct.unpack('b', linehere[2:3])[0])
-        days[i] = int(struct.unpack('b', linehere[3:4])[0])
+        years[index] = int(struct.unpack("<h", line[0:2])[0])
+        months[index] = int(struct.unpack("b", line[2:3])[0])
+        days[index] = int(struct.unpack("b", line[3:4])[0])
         if prelength > 4:
-            times[i] = int(struct.unpack('b', linehere[4:5])[0])
-        coeffs[i,:] = np.array(struct.unpack('<'+'e'*Ncomps, linehere[prelength:])).astype(float)
+            times[index] = int(struct.unpack("b", line[4:5])[0])
+        coeffs[index, :] = np.array(
+            struct.unpack("<" + "e" * Ncomps, line[prelength:])
+        ).astype(float)
 
     if prelength > 4:
         return years, months, days, times, coeffs
-    else:
-        return years, months, days, coeffs
+    return years, months, days, coeffs
+
 
 def read_binary_weather(filename):
     """
@@ -76,35 +70,58 @@ def read_binary_weather(filename):
       (numpy.ndarray): Several arrays containing the dates/times and weather values read from the file
     """
 
-    with open(filename, 'rb') as binary_file:
+    with open(filename, "rb") as binary_file:
         contents = bytearray(binary_file.read())
 
     linelength = int(contents[0:2][0])
     prelength = linelength - 8
-    Nlines = int((len(contents) - 2) / linelength)
+    nlines = int((len(contents) - 2) / linelength)
 
-    years = np.zeros(Nlines)
-    months = np.zeros(Nlines)
-    days = np.zeros(Nlines)
+    years = np.zeros(nlines)
+    months = np.zeros(nlines)
+    days = np.zeros(nlines)
     if prelength > 4:
-        times = np.zeros(Nlines)
-    vals = np.zeros(Nlines)
-    for i in range(Nlines):
-        istart = 2 + (linelength*i)
-        iend = istart + linelength
-        linehere = contents[istart:iend]
+        times = np.zeros(nlines)
+    values = np.zeros(nlines)
+    for index in range(nlines):
+        start = 2 + (linelength * index)
+        stop = start + linelength
+        line = contents[start:stop]
 
-        years[i] = int(struct.unpack('<h', linehere[0:2])[0])
-        months[i] = int(struct.unpack('b', linehere[2:3])[0])
-        days[i] = int(struct.unpack('b', linehere[3:4])[0])
+        years[index] = int(struct.unpack("<h", line[0:2])[0])
+        months[index] = int(struct.unpack("b", line[2:3])[0])
+        days[index] = int(struct.unpack("b", line[3:4])[0])
         if prelength > 4:
-            times[i] = int(struct.unpack('b', linehere[4:5])[0])
-        vals[i] = float(struct.unpack('<d', linehere[prelength:])[0])
+            times[index] = int(struct.unpack("b", line[4:5])[0])
+        values[index] = float(struct.unpack("<d", line[prelength:])[0])
 
     if prelength > 4:
-        return years, months, days, times, vals
-    else:
-        return years, months, days, vals
+        return years, months, days, times, values
+    return years, months, days, values
+
+
+@lru_cache(maxsize=1)
+def _legacy_pca_bases():
+    """Load binary-weather PCA bases only when the legacy backend is used."""
+
+    mean_tau = np.loadtxt(const.path_to_eigenspectra + "/spectrum_mean.txt", unpack=True)
+    mean_tb = np.loadtxt(const.path_to_eigenspectra + "_Tb/spectrum_mean.txt", unpack=True)
+    tau_components = tuple(
+        np.loadtxt(
+            const.path_to_eigenspectra + "/spectrum_" + str(index).zfill(4) + ".txt",
+            unpack=True,
+        )
+        for index in range(const.number_of_components)
+    )
+    tb_components = tuple(
+        np.loadtxt(
+            const.path_to_eigenspectra + "_Tb/spectrum_" + str(index).zfill(4) + ".txt",
+            unpack=True,
+        )
+        for index in range(const.number_of_components)
+    )
+    return mean_tau, mean_tb, tau_components, tb_components
+
 
 def reconstruct_spectrum_tau(coeffs):
     """
@@ -117,12 +134,12 @@ def reconstruct_spectrum_tau(coeffs):
       (numpy.ndarray): Array containing the opacity spectrum
     """
 
-    reconstructed_spectrum = np.zeros(const.length_of_spectrum)
-    for ispec, eigenspec in enumerate(tau_spectra):
-        reconstructed_spectrum += coeffs[ispec]*eigenspec
-    reconstructed_spectrum += meanspec_tau
-    reconstructed_spectrum = 10.0**reconstructed_spectrum
-    return reconstructed_spectrum
+    mean_tau, _, tau_components, _ = _legacy_pca_bases()
+    reconstructed_spectrum = np.array(mean_tau, dtype=float, copy=True)
+    for coefficient, eigenspectrum in zip(coeffs, tau_components):
+        reconstructed_spectrum += coefficient * eigenspectrum
+    return 10.0**reconstructed_spectrum
+
 
 def reconstruct_spectrum_Tb(coeffs):
     """
@@ -135,457 +152,268 @@ def reconstruct_spectrum_Tb(coeffs):
       (numpy.ndarray): Array containing the brightness temperature spectrum
     """
 
-    reconstructed_spectrum = np.zeros(const.length_of_spectrum)
-    for ispec, eigenspec in enumerate(Tb_spectra):
-        reconstructed_spectrum += coeffs[ispec]*eigenspec
-    reconstructed_spectrum += meanspec_Tb
+    _, mean_tb, _, tb_components = _legacy_pca_bases()
+    reconstructed_spectrum = np.array(mean_tb, dtype=float, copy=True)
+    for coefficient, eigenspectrum in zip(coeffs, tb_components):
+        reconstructed_spectrum += coefficient * eigenspectrum
     return reconstructed_spectrum
 
+
 def _parse_month(month):
-    monthnums = np.array(['01','02','03','04','05','06','07','08','09','10','11','12'])
-    monthnams = np.array(['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'])
+    monthnums = ("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12")
+    monthnams = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 
     if month in monthnams:
-        monthnum = monthnums[monthnams == month][0]
-        monthnam = month
-    elif str(month).zfill(2) in monthnums:
-        monthnum = str(month).zfill(2)
-        monthnam = monthnams[monthnums == monthnum][0]
+        return monthnums[monthnams.index(month)], month
+    monthnum = str(month).zfill(2)
+    if monthnum in monthnums:
+        return monthnum, monthnams[monthnums.index(monthnum)]
+    raise ValueError(
+        "Specified month not recognized; please use either a three-letter abbreviation "
+        "(e.g., Jan, Apr) or else a two-digit number (e.g., 03, 10)."
+    )
+
+
+def _remove_false_february_entries(years, days, values, monthnam):
+    if monthnam != "Feb":
+        return years, days, values
+
+    keep = np.ones(len(days), dtype=bool)
+    for index in range(1, len(days)):
+        if days[index] == days[index - 1]:
+            keep[index] = False
+    return years[keep], days[keep], values[keep]
+
+
+def _legacy_records(site, monthnum, monthnam, quantity, path_to_weather):
+    filenames = {
+        "tau": "tau.txt",
+        "tb": "Tb.txt",
+        "pressure": "Pbase.txt",
+        "temperature": "Tbase.txt",
+        "pwv": "PWV.txt",
+        "windspeed": "windspeed.txt",
+    }
+    filename = os.path.join(str(path_to_weather), site, monthnum + monthnam, filenames[quantity])
+
+    if quantity in ("tau", "tb"):
+        years, _, days, coefficients = read_binary_atm(filename)
+        reconstruct = reconstruct_spectrum_tau if quantity == "tau" else reconstruct_spectrum_Tb
+        values = np.array([reconstruct(coefficients[index]) for index in range(len(coefficients))])
     else:
-        raise ValueError('Specified month not recognized; please use either a three-letter abbreviation (e.g., Jan, Apr) or else a two-digit number (e.g., 03, 10).')
+        years, _, days, values = read_binary_weather(filename)
 
-    return monthnum, monthnam
+    return _remove_false_february_entries(years, days, values, monthnam)
 
-def opacity_spectrum(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the zenith opacity information for a specified site as a function of frequency.
 
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
-
-    Returns:
-      (numpy.ndarray): The requested opacity values; if form = 'all', then returns a 2D array
-    """
-
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
-
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'tau.txt'
-
-    # read in the table
-    years, months, days, coeffs = read_binary_atm(pathhere)
-
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        coeffs = coeffs[indlist,:]
-
-    # retrieve the requested opacity values
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        tauspec = reconstruct_spectrum_tau(coeffs[ind][0])
-
+def _zarr_records(store, site, month, quantity):
+    partition = store.read_partition(site, month, cadence="daily")
+    if quantity == "tau":
+        values = store.reconstruct_tau_spectra(partition)
+    elif quantity == "tb":
+        values = store.reconstruct_tb_spectra(partition)
     else:
-        tauspec_arr = np.zeros((len(coeffs),const.length_of_spectrum))
-        for i in range(len(coeffs)):
-            tauspec_arr[i,:] = reconstruct_spectrum_tau(coeffs[i])
-        if (form == 'mean'):
-            tauspec = np.nanmean(tauspec_arr,axis=0)
-        elif (form == 'median'):
-            tauspec = np.nanmedian(tauspec_arr,axis=0)
-        elif (form == 'good'):
-            tauspec = np.nanpercentile(tauspec_arr,15.87,axis=0)
-        elif (form == 'bad'):
-            tauspec = np.nanpercentile(tauspec_arr,84.13,axis=0)
-        elif (form == 'all'):
-            tauspec = tauspec_arr
+        field_names = {
+            "pressure": "surface_pressure_mbar",
+            "temperature": "surface_temperature_k",
+            "pwv": "pwv_mm",
+            "windspeed": "wind_speed_m_s",
+        }
+        values = getattr(partition, field_names[quantity])
+    return partition.year, partition.day, values
 
-    return tauspec
 
-def opacity(site, form='exact', month='Apr', day=15, year=2015, freq=230.0, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the zenith opacity information for a specified site at a specified frequency.
+def _weather_records(site, month, quantity, path_to_weather, weather_store):
+    if weather_store is None:
+        monthnum, monthnam = _parse_month(month)
+        return _legacy_records(site, monthnum, monthnam, quantity, path_to_weather)
+    if not isinstance(weather_store, ZarrWeatherStore):
+        raise TypeError("weather_store must be a ZarrWeatherStore instance or None.")
+    return _zarr_records(weather_store, site, month, quantity)
 
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      freq (float): The observing frequency, in GHz
-      path_to_weather (str): The file path for the top-level weather data directory
 
-    Returns:
-      (float): The requested opacity value(s); if form = 'all', then returns a numpy.ndarray
-    """
+def _select_weather_values(values, years, days, form, day, year):
+    if form == "exact":
+        matches = (years == int(year)) & (days == int(day))
+        if not np.any(matches):
+            raise Exception("No weather on file for the selected date.")
+        return values[matches][0]
+    if form == "all":
+        return values
+    if form == "mean":
+        return np.nanmean(values, axis=0)
+    if form == "median":
+        return np.nanmedian(values, axis=0)
+    if form == "good":
+        return np.nanpercentile(values, 15.87, axis=0)
+    if form == "bad":
+        return np.nanpercentile(values, 84.13, axis=0)
+    raise ValueError("Weather form must be exact, mean, median, good, bad, or all.")
 
-    # check frequency
-    if ((freq < 0.0) | (freq > 2000.0)):
-        raise Exception('Specified frequency is outside of the acceptable range (0, 2000) GHz.')
 
-    # get full spectrum
-    tauspec = opacity_spectrum(site, form=form, month=month, day=day, year=year, path_to_weather=path_to_weather)
+def _spectrum(site, form, month, day, year, path_to_weather, weather_store, quantity):
+    years, days, spectra = _weather_records(
+        site, month, quantity, path_to_weather, weather_store
+    )
+    return _select_weather_values(spectra, years, days, form, day, year)
 
-    # isolate the specified frequency
-    if (form != 'all'):
-        tau = np.interp(freq,const.spectrum_frequency,tauspec)
-    else:
-        tau = np.zeros(len(tauspec))
-        for i in range(len(tauspec)):
-            tau[i] = np.interp(freq,const.spectrum_frequency,tauspec[i])
 
-    return tau
+def _spectrum_frequency(weather_store):
+    if weather_store is None:
+        return const.spectrum_frequency
+    return weather_store.frequency_ghz
 
-def brightness_temperature_spectrum(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the zenith brightness temperature information for a specified site as a function of frequency.
 
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
+def _scalar(site, form, month, day, year, path_to_weather, weather_store, quantity):
+    years, days, values = _weather_records(
+        site, month, quantity, path_to_weather, weather_store
+    )
+    return _select_weather_values(values, years, days, form, day, year)
 
-    Returns:
-      (numpy.ndarray): The requested brightness temperature values; if form = 'all', then returns a 2D array
-    """
 
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
+def opacity_spectrum(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve zenith opacity as a function of frequency.
 
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'Tb.txt'
-
-    # read in the table
-    years, months, days, coeffs = read_binary_atm(pathhere)
-
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        coeffs = coeffs[indlist,:]
-
-    # retrieve the requested brightness temperature values
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        Tbspec = reconstruct_spectrum_Tb(coeffs[ind][0])
-
-    else:
-        Tbspec_arr = np.zeros((len(coeffs),const.length_of_spectrum))
-        for i in range(len(coeffs)):
-            Tbspec_arr[i,:] = reconstruct_spectrum_Tb(coeffs[i])
-        if (form == 'mean'):
-            Tbspec = np.nanmean(Tbspec_arr,axis=0)
-        elif (form == 'median'):
-            Tbspec = np.nanmedian(Tbspec_arr,axis=0)
-        elif (form == 'good'):
-            Tbspec = np.nanpercentile(Tbspec_arr,15.87,axis=0)
-        elif (form == 'bad'):
-            Tbspec = np.nanpercentile(Tbspec_arr,84.13,axis=0)
-        elif (form == 'all'):
-            Tbspec = Tbspec_arr
-    
-    return Tbspec
-
-def brightness_temperature(site, form='exact', month='Apr', day=15, year=2015, freq=230.0, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the zenith brightness temperature information for a specified site at a specified frequency.
-
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      freq (float): The observing frequency, in GHz
-      path_to_weather (str): The file path for the top-level weather data directory
-
-    Returns:
-      (float): The requested brightness temperature value(s), in K; if form = 'all', then returns a numpy.ndarray
+    ``weather_store`` may be a :class:`ZarrWeatherStore`; when it is omitted,
+    this function reads the packaged legacy binary weather data.
     """
 
-    # check frequency
-    if ((freq < 0.0) | (freq > 2000.0)):
-        raise Exception('Specified frequency is outside of the acceptable range (0, 2000) GHz.')
+    return _spectrum(site, form, month, day, year, path_to_weather, weather_store, "tau")
 
-    # get full spectrum
-    Tbspec = brightness_temperature_spectrum(site, form=form, month=month, day=day, year=year, path_to_weather=path_to_weather)
 
-    # isolate the specified frequency
-    if (form != 'all'):
-        Tb = np.interp(freq,const.spectrum_frequency,Tbspec)
-    else:
-        Tb = np.zeros(len(Tbspec))
-        for i in range(len(Tbspec)):
-            Tb[i] = np.interp(freq,const.spectrum_frequency,Tbspec[i])
+def opacity(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    freq=230.0,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve zenith opacity at ``freq`` GHz."""
 
-    return Tb
+    if (freq < 0.0) | (freq > 2000.0):
+        raise Exception("Specified frequency is outside of the acceptable range (0, 2000) GHz.")
 
-def pressure(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the surface pressure information for a specified site.
+    spectrum = opacity_spectrum(
+        site,
+        form=form,
+        month=month,
+        day=day,
+        year=year,
+        path_to_weather=path_to_weather,
+        weather_store=weather_store,
+    )
+    frequency_ghz = _spectrum_frequency(weather_store)
+    if form != "all":
+        return np.interp(freq, frequency_ghz, spectrum)
+    return np.array([np.interp(freq, frequency_ghz, values) for values in spectrum])
 
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
 
-    Returns:
-      (float): The requested pressure value(s), in mbar; if form = 'all', then returns a numpy.ndarray
-    """
+def brightness_temperature_spectrum(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve zenith brightness temperature as a function of frequency."""
 
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
+    return _spectrum(site, form, month, day, year, path_to_weather, weather_store, "tb")
 
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'Pbase.txt'
 
-    # read in the table
-    years, months, days, vals = read_binary_weather(pathhere)
+def brightness_temperature(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    freq=230.0,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve zenith brightness temperature at ``freq`` GHz."""
 
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        vals = vals[indlist]
+    if (freq < 0.0) | (freq > 2000.0):
+        raise Exception("Specified frequency is outside of the acceptable range (0, 2000) GHz.")
 
-    # retrieve the requested pressure value(s)
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        P = vals[ind][0]
+    spectrum = brightness_temperature_spectrum(
+        site,
+        form=form,
+        month=month,
+        day=day,
+        year=year,
+        path_to_weather=path_to_weather,
+        weather_store=weather_store,
+    )
+    frequency_ghz = _spectrum_frequency(weather_store)
+    if form != "all":
+        return np.interp(freq, frequency_ghz, spectrum)
+    return np.array([np.interp(freq, frequency_ghz, values) for values in spectrum])
 
-    else:
-        if (form == 'mean'):
-            P = np.nanmean(vals)
-        elif (form == 'median'):
-            P = np.nanmedian(vals)
-        elif (form == 'good'):
-            P = np.nanpercentile(vals,15.87,axis=0)
-        elif (form == 'bad'):
-            P = np.nanpercentile(vals,84.13,axis=0)
-        elif (form == 'all'):
-            P = vals
 
-    return P
+def pressure(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve surface pressure in mbar."""
 
-def temperature(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the surface temperature information for a specified site.
+    return _scalar(site, form, month, day, year, path_to_weather, weather_store, "pressure")
 
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
 
-    Returns:
-      (float): The requested temperature value(s), in K; if form = 'all', then returns a numpy.ndarray
-    """
+def temperature(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve surface temperature in K."""
 
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
+    return _scalar(site, form, month, day, year, path_to_weather, weather_store, "temperature")
 
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'Tbase.txt'
 
-    # read in the table
-    years, months, days, vals = read_binary_weather(pathhere)
+def PWV(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve precipitable water vapor in mm."""
 
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        vals = vals[indlist]
+    return _scalar(site, form, month, day, year, path_to_weather, weather_store, "pwv")
 
-    # retrieve the requested temperature value(s)
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        T = vals[ind][0]
 
-    else:
-        if (form == 'mean'):
-            T = np.nanmean(vals)
-        elif (form == 'median'):
-            T = np.nanmedian(vals)
-        elif (form == 'good'):
-            T = np.nanpercentile(vals,15.87,axis=0)
-        elif (form == 'bad'):
-            T = np.nanpercentile(vals,84.13,axis=0)
-        elif (form == 'all'):
-            T = vals
+def windspeed(
+    site,
+    form="exact",
+    month="Apr",
+    day=15,
+    year=2015,
+    path_to_weather=const.path_to_weather,
+    weather_store=None,
+):
+    """Retrieve wind speed in m/s."""
 
-    return T
-
-def PWV(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the precipitable water vapor (PWV) information for a specified site.
-
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
-
-    Returns:
-      (float): The requested PWV value(s), in mm; if form = 'all', then returns a numpy.ndarray
-    """
-
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
-
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'PWV.txt'
-
-    # read in the table
-    years, months, days, vals = read_binary_weather(pathhere)
-
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        vals = vals[indlist]
-
-    # retrieve the requested temperature value(s)
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        pwv = vals[ind][0]
-
-    else:
-        if (form == 'mean'):
-            pwv = np.nanmean(vals)
-        elif (form == 'median'):
-            pwv = np.nanmedian(vals)
-        elif (form == 'good'):
-            pwv = np.nanpercentile(vals,15.87,axis=0)
-        elif (form == 'bad'):
-            pwv = np.nanpercentile(vals,84.13,axis=0)
-        elif (form == 'all'):
-            pwv = vals
-
-    return pwv
-
-def windspeed(site, form='exact', month='Apr', day=15, year=2015, path_to_weather=const.path_to_weather):
-    """
-    Retrieve the windspeed information for a specified site.
-
-    Args:
-      site (str): The name of the site
-      form (str): The form of value to report; can be 'mean', 'median', 'good', 'bad', exact', or 'all'
-      month (str or int): The month for which to report weather
-      day (str or int): The day of the month for which to report weather; only used for form = 'exact'
-      year (str or int): The year for which to report weather; only used for form = 'exact'
-      path_to_weather (str): The file path for the top-level weather data directory
-
-    Returns:
-      (float): The requested windspeed value(s), in m/s; if form = 'all', then returns a numpy.ndarray
-    """
-
-    # extract month number
-    monthnum, monthnam = _parse_month(month)
-
-    # determine which table to read
-    pathhere = path_to_weather + '/'
-    pathhere += site + '/'
-    pathhere += monthnum + monthnam + '/'
-    pathhere += 'windspeed.txt'
-
-    # read in the table
-    years, months, days, vals = read_binary_weather(pathhere)
-
-    # remove false Feb 29 entries
-    if (monthnam == 'Feb'):
-        indlist = np.ones(len(days),dtype=bool)
-        for i in range(1,len(days)):
-            if (days[i] == days[i-1]):
-                indlist[i] = False
-        years = years[indlist]
-        months = months[indlist]
-        days = days[indlist]
-        vals = vals[indlist]
-
-    # retrieve the requested temperature value(s)
-    if (form == 'exact'):
-        ind = ((years == int(year)) & (days == int(day)))
-        if (np.array(ind).sum() == 0):
-            raise Exception('No weather on file for the selected date.')
-        ws = vals[ind][0]
-
-    else:
-        if (form == 'mean'):
-            ws = np.nanmean(vals)
-        elif (form == 'median'):
-            ws = np.nanmedian(vals)
-        elif (form == 'good'):
-            ws = np.nanpercentile(vals,15.87,axis=0)
-        elif (form == 'bad'):
-            ws = np.nanpercentile(vals,84.13,axis=0)
-        elif (form == 'all'):
-            ws = vals
-
-    return ws
+    return _scalar(site, form, month, day, year, path_to_weather, weather_store, "windspeed")

--- a/ngehtsim/weather/zarr_store.py
+++ b/ngehtsim/weather/zarr_store.py
@@ -8,6 +8,7 @@ an explicit local filesystem path to :class:`ZarrWeatherStore`.
 from __future__ import annotations
 
 import calendar
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -29,6 +30,7 @@ _SCALAR_ARRAYS = (
     "surface_pressure_mbar",
     "surface_temperature_k",
 )
+_PARTITION_CACHE_SIZE = 64
 
 
 class WeatherStoreError(ValueError):
@@ -88,6 +90,9 @@ class ZarrWeatherStore:
 
         self._root = zarr.open_group(self.path, mode="r")
         self._pca_bases: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        self._partition_cache: OrderedDict[
+            tuple[str, int, Cadence], WeatherPartition
+        ] = OrderedDict()
         self._validate_root()
 
     @property
@@ -106,7 +111,7 @@ class ZarrWeatherStore:
     def sites(self) -> tuple[str, ...]:
         """Return all weather site identifiers in deterministic order."""
 
-        return tuple(sorted(self._root["sites"].group_keys()))
+        return self._sites
 
     @property
     def frequency_ghz(self) -> np.ndarray:
@@ -130,6 +135,21 @@ class ZarrWeatherStore:
             raise ValueError(f"Unsupported weather cadence {cadence!r}; use {allowed}.")
         if site not in self.sites:
             raise KeyError(f"Weather dataset does not contain site {site!r}.")
+
+        key = (site, month_number, cadence)
+        try:
+            partition = self._partition_cache.pop(key)
+        except KeyError:
+            partition = self._read_partition(site, month_number, cadence)
+            if len(self._partition_cache) >= _PARTITION_CACHE_SIZE:
+                self._partition_cache.popitem(last=False)
+        self._partition_cache[key] = partition
+        return partition
+
+    def _read_partition(
+        self, site: str, month_number: int, cadence: Cadence
+    ) -> WeatherPartition:
+        """Read and validate one immutable Zarr partition."""
 
         prefix = f"sites/{site}/months/{month_number:02d}/{cadence}"
         if prefix not in self._root:
@@ -207,6 +227,9 @@ class ZarrWeatherStore:
             raise WeatherStoreError(
                 "Zarr weather dataset is missing required paths: " + ", ".join(missing)
             )
+        self._sites = tuple(sorted(self._root["sites"].group_keys()))
+        if not self._sites:
+            raise WeatherStoreError("Zarr weather dataset does not contain any sites.")
 
         frequency = self._read_array("frequency_ghz")
         if frequency.ndim != 1 or not len(frequency) or not np.all(np.isfinite(frequency)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 
 import os
 
+import numpy as np
+import pytest
+
 #######################################################
 # configuration testing
 
@@ -30,3 +33,52 @@ if os.environ.get("NGEHTSIM_RUN_SLOW_TESTS") != "1":
 
 if os.environ.get("NGEHTSIM_RUN_OPTIONAL_TESTS") != "1":
     collect_ignore.extend(OPTIONAL_TESTS)
+
+
+@pytest.fixture
+def weather_dataset(tmp_path):
+    """Create a minimal valid Zarr weather release for unit tests."""
+
+    zarr = pytest.importorskip("zarr")
+    path = tmp_path / "weather.zarr"
+    root = zarr.open_group(path, mode="w", zarr_format=3)
+    root.attrs.update(
+        {
+            "schema_version": "0.1.0",
+            "dataset_id": "test-weather-v0.1.0",
+            "native_time_step_hours": 3,
+            "native_samples_per_day": 8,
+        }
+    )
+    root.create_array("frequency_ghz", data=np.array([100.0, 200.0, 300.0]))
+    root.create_array("pca/tau/mean", data=np.array([0.0, 1.0, 2.0]))
+    root.create_array(
+        "pca/tau/components", data=np.array([[1.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+    )
+    root.create_array("pca/tb/mean", data=np.array([10.0, 20.0, 30.0]))
+    root.create_array(
+        "pca/tb/components", data=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    )
+
+    daily = root.create_group("sites/ALMA/months/04/daily")
+    _write_weather_records(daily, include_time_index=False)
+    native = root.create_group("sites/ALMA/months/04/native")
+    _write_weather_records(native, include_time_index=True)
+    return path
+
+
+def _write_weather_records(group, include_time_index):
+    group.create_array("year", data=np.array([2017, 2017], dtype=np.int16))
+    group.create_array("day", data=np.array([11, 12], dtype=np.int8))
+    group.create_array(
+        "tau_coefficients", data=np.array([[1.0, 2.0], [2.0, 1.0]], dtype=np.float16)
+    )
+    group.create_array(
+        "tb_coefficients", data=np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float16)
+    )
+    group.create_array("pwv_mm", data=np.array([1.0, 2.0]))
+    group.create_array("wind_speed_m_s", data=np.array([3.0, 4.0]))
+    group.create_array("surface_pressure_mbar", data=np.array([500.0, 501.0]))
+    group.create_array("surface_temperature_k", data=np.array([250.0, 251.0]))
+    if include_time_index:
+        group.create_array("time_index", data=np.array([0, 1], dtype=np.int8))

--- a/tests/test_weather_zarr_adapter.py
+++ b/tests/test_weather_zarr_adapter.py
@@ -1,0 +1,84 @@
+"""Unit tests for the optional Zarr-backed public weather API."""
+
+import numpy as np
+import pytest
+
+import ngehtsim.weather.weather as weather
+from ngehtsim.weather.zarr_store import ZarrWeatherStore
+
+
+@pytest.fixture
+def store(weather_dataset):
+    return ZarrWeatherStore(weather_dataset)
+
+
+@pytest.mark.parametrize(
+    "weather_function, extra_kwargs, expected",
+    [
+        (weather.opacity_spectrum, {}, [10.0, 1000.0, 10.0]),
+        (weather.brightness_temperature_spectrum, {}, [11.0, 22.0, 33.0]),
+        (weather.opacity, {"freq": 200.0}, 1000.0),
+        (weather.brightness_temperature, {"freq": 200.0}, 22.0),
+        (weather.pressure, {}, 500.0),
+        (weather.temperature, {}, 250.0),
+        (weather.PWV, {}, 1.0),
+        (weather.windspeed, {}, 3.0),
+    ],
+)
+def test_exact_weather_api_reads_zarr_store(weather_function, extra_kwargs, expected, store):
+    result = weather_function(
+        "ALMA",
+        form="exact",
+        month="Apr",
+        day=11,
+        year=2017,
+        weather_store=store,
+        **extra_kwargs,
+    )
+
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize("form", ["all", "mean", "median", "good", "bad"])
+@pytest.mark.parametrize(
+    "weather_function, extra_kwargs",
+    [
+        (weather.opacity_spectrum, {}),
+        (weather.brightness_temperature_spectrum, {}),
+        (weather.opacity, {"freq": 200.0}),
+        (weather.brightness_temperature, {"freq": 200.0}),
+        (weather.pressure, {}),
+        (weather.temperature, {}),
+        (weather.PWV, {}),
+        (weather.windspeed, {}),
+    ],
+)
+def test_summary_weather_api_reads_zarr_store(weather_function, extra_kwargs, form, store):
+    result = weather_function(
+        "ALMA", form=form, month=4, weather_store=store, **extra_kwargs
+    )
+
+    if form == "all":
+        assert np.shape(result)[0] == 2
+    else:
+        assert np.all(np.isfinite(result))
+
+
+def test_zarr_weather_api_does_not_load_legacy_pca_bases(monkeypatch, store):
+    def fail_if_called():
+        raise AssertionError("The legacy PCA basis must not be loaded for Zarr weather.")
+
+    monkeypatch.setattr(weather, "_legacy_pca_bases", fail_if_called)
+
+    assert weather.opacity(
+        "ALMA", form="exact", month=4, day=11, year=2017, freq=200.0, weather_store=store
+    ) == 1000.0
+    assert weather.pressure(
+        "ALMA", form="exact", month=4, day=11, year=2017, weather_store=store
+    ) == 500.0
+
+
+@pytest.mark.parametrize("weather_function", [weather.opacity, weather.pressure])
+def test_weather_api_rejects_invalid_store(weather_function):
+    with pytest.raises(TypeError, match="weather_store must be a ZarrWeatherStore"):
+        weather_function("ALMA", form="mean", weather_store="not-a-weather-store")

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -5,22 +5,54 @@ import os
 import numpy as np
 import pytest
 
+import ngehtsim.weather.weather as weather
 from ngehtsim.weather.zarr_store import SCHEMA_VERSION, ZarrWeatherStore
 
 
-@pytest.mark.external_weather
-def test_local_weather_release_has_expected_schema_and_alma_coverage():
+WEATHER_FUNCTIONS = (
+    (weather.opacity_spectrum, {}),
+    (weather.brightness_temperature_spectrum, {}),
+    (weather.opacity, {"freq": 230.0}),
+    (weather.brightness_temperature, {"freq": 230.0}),
+    (weather.pressure, {}),
+    (weather.temperature, {}),
+    (weather.PWV, {}),
+    (weather.windspeed, {}),
+)
+
+
+@pytest.fixture(scope="module")
+def external_store():
     path = os.environ.get("NGEHTSIM_WEATHER_ZARR")
     if path is None:
         pytest.skip("Set NGEHTSIM_WEATHER_ZARR to run the external weather release test.")
+    return ZarrWeatherStore(path)
 
-    store = ZarrWeatherStore(path)
-    assert store.attributes["schema_version"] == SCHEMA_VERSION
-    assert store.dataset_id == "ngehtsim-weather-merra2-3hour-v0.1.0"
-    assert len(store.sites) == 141
 
-    daily = store.read_partition("ALMA", "Apr", cadence="daily")
-    native = store.read_partition("ALMA", "Apr", cadence="native")
+@pytest.mark.external_weather
+def test_local_weather_release_has_expected_schema_and_alma_coverage(external_store):
+    assert external_store.attributes["schema_version"] == SCHEMA_VERSION
+    assert external_store.dataset_id == "ngehtsim-weather-merra2-3hour-v0.1.0"
+    assert len(external_store.sites) == 141
+
+    daily = external_store.read_partition("ALMA", "Apr", cadence="daily")
+    native = external_store.read_partition("ALMA", "Apr", cadence="native")
     assert daily.record_count * 8 == native.record_count
-    assert np.all(np.isfinite(store.reconstruct_tau_spectra(daily)))
-    assert np.all(np.isfinite(store.reconstruct_tb_spectra(daily)))
+    assert np.all(np.isfinite(external_store.reconstruct_tau_spectra(daily)))
+    assert np.all(np.isfinite(external_store.reconstruct_tb_spectra(daily)))
+
+
+@pytest.mark.external_weather
+@pytest.mark.parametrize("month, year, day", [("Apr", 2017, 11), ("Feb", 2017, 11)])
+@pytest.mark.parametrize("form", ["exact", "all", "mean", "median", "good", "bad"])
+@pytest.mark.parametrize("weather_function, extra_kwargs", WEATHER_FUNCTIONS)
+def test_zarr_weather_api_matches_packaged_daily_weather(
+    external_store, month, year, day, form, weather_function, extra_kwargs
+):
+    kwargs = {"form": form, "month": month, "day": day, "year": year}
+    kwargs.update(extra_kwargs)
+
+    legacy = weather_function("ALMA", **kwargs)
+    zarr = weather_function("ALMA", weather_store=external_store, **kwargs)
+
+    assert np.allclose(zarr, legacy, equal_nan=True)

--- a/tests/test_weather_zarr_store.py
+++ b/tests/test_weather_zarr_store.py
@@ -6,53 +6,6 @@ import zarr
 
 from ngehtsim.weather.zarr_store import WeatherStoreError, ZarrWeatherStore
 
-
-@pytest.fixture
-def weather_dataset(tmp_path):
-    path = tmp_path / "weather.zarr"
-    root = zarr.open_group(path, mode="w", zarr_format=3)
-    root.attrs.update(
-        {
-            "schema_version": "0.1.0",
-            "dataset_id": "test-weather-v0.1.0",
-            "native_time_step_hours": 3,
-            "native_samples_per_day": 8,
-        }
-    )
-    root.create_array("frequency_ghz", data=np.array([100.0, 200.0, 300.0]))
-    root.create_array("pca/tau/mean", data=np.array([0.0, 1.0, 2.0]))
-    root.create_array(
-        "pca/tau/components", data=np.array([[1.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
-    )
-    root.create_array("pca/tb/mean", data=np.array([10.0, 20.0, 30.0]))
-    root.create_array(
-        "pca/tb/components", data=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    )
-
-    daily = root.create_group("sites/ALMA/months/04/daily")
-    _write_records(daily, include_time_index=False)
-    native = root.create_group("sites/ALMA/months/04/native")
-    _write_records(native, include_time_index=True)
-    return path
-
-
-def _write_records(group, include_time_index):
-    group.create_array("year", data=np.array([2017, 2017], dtype=np.int16))
-    group.create_array("day", data=np.array([11, 12], dtype=np.int8))
-    group.create_array(
-        "tau_coefficients", data=np.array([[1.0, 2.0], [2.0, 1.0]], dtype=np.float16)
-    )
-    group.create_array(
-        "tb_coefficients", data=np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float16)
-    )
-    group.create_array("pwv_mm", data=np.array([1.0, 2.0]))
-    group.create_array("wind_speed_m_s", data=np.array([3.0, 4.0]))
-    group.create_array("surface_pressure_mbar", data=np.array([500.0, 501.0]))
-    group.create_array("surface_temperature_k", data=np.array([250.0, 251.0]))
-    if include_time_index:
-        group.create_array("time_index", data=np.array([0, 1], dtype=np.int8))
-
-
 def test_store_exposes_validated_metadata(weather_dataset):
     store = ZarrWeatherStore(weather_dataset)
 
@@ -83,6 +36,12 @@ def test_store_reads_native_partition(weather_dataset):
     )
 
     assert np.array_equal(partition.time_index, [0, 1])
+
+
+def test_store_caches_validated_partitions(weather_dataset):
+    store = ZarrWeatherStore(weather_dataset)
+
+    assert store.read_partition("ALMA", "Apr") is store.read_partition("ALMA", 4)
 
 
 def test_store_reconstructs_tau_and_tb_spectra(weather_dataset):


### PR DESCRIPTION
Adds an optional ZarrWeatherStore backend to the established weather API while retaining packaged binary weather as the default. Adds bounded per-store partition caching, unit coverage, external-release parity tests, and documentation.