### PR TITLE
Allow obs_generator to use Zarr weather

### DIFF
--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -8,6 +8,18 @@ Observation generation
 
 Definition of the obs_generator interface.
 
+To use an externally distributed Zarr weather release, open the local dataset
+explicitly and pass the resulting store to the generator. Omitting
+``weather_store`` retains the packaged binary-weather behavior.
+
+.. code-block:: python
+
+   from ngehtsim.obs import obs_generator
+   from ngehtsim.weather.zarr_store import ZarrWeatherStore
+
+   store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr")
+   obsgen = obs_generator.obs_generator(settings=settings, weather_store=store)
+
 .. automodule:: ngehtsim.obs.obs_generator
    :members:
 

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -17,6 +17,7 @@ import warnings
 
 import ngehtsim.const_def as const
 import ngehtsim.weather.weather as nw
+from ngehtsim.weather.zarr_store import ZarrWeatherStore
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.station_observation as station_observation
@@ -65,6 +66,8 @@ class obs_generator(object):
       station_uptimes (dict): A dictionary of station names and associated uptime ranges, in UT
       array (str): Provide the name of a known array to load the corresponding sites and configuration
       ephem (str): path to the ephemeris for a space station
+      weather_store (ngehtsim.weather.zarr_store.ZarrWeatherStore): Optional local Zarr weather dataset.
+                                                                    If None, use the packaged binary weather data.
     """
 
     # initialize class instantiation
@@ -72,7 +75,7 @@ class obs_generator(object):
                  surf_rms_overrides=None, receiver_configuration_overrides=None, bandwidth_overrides=None,
                  T_R_overrides=None, sideband_ratio_overrides=None, lo_freq_overrides=None, hi_freq_overrides=None,
                  ap_eff_overrides=None, wind_loading_overrides=None, custom_receivers=None, station_uptimes=None,
-                 array=None, ephem='ephemeris/space'):
+                 array=None, ephem='ephemeris/space', weather_store=None):
 
         #############################
         # astropy cache
@@ -95,6 +98,8 @@ class obs_generator(object):
         wind_loading_overrides = {} if wind_loading_overrides is None else wind_loading_overrides
         custom_receivers = {} if custom_receivers is None else custom_receivers
         station_uptimes = {} if station_uptimes is None else station_uptimes
+        if weather_store is not None and not isinstance(weather_store, ZarrWeatherStore):
+            raise TypeError("weather_store must be a ZarrWeatherStore instance or None.")
 
         #############################
         # parse inputs
@@ -116,6 +121,7 @@ class obs_generator(object):
         self.station_uptimes = copy.deepcopy(station_uptimes)
         self.array = array
         self.ephem = ephem
+        self.weather_store = weather_store
 
         #############################
         # load settings
@@ -487,10 +493,16 @@ class obs_generator(object):
                 elif ((self.weather == 'bad') | (self.weather == 'poor')):
                     form = 'bad'
 
-                tau_here = nw.opacity(site, form=form, month=self.settings['month'], day=self.weather_day, year=self.weather_year, freq=self.freq/(1.0e9))
-                Tb_here = nw.brightness_temperature(site, form=form, month=self.settings['month'], day=self.weather_day, year=self.weather_year, freq=self.freq/(1.0e9))
-                ws_here = nw.windspeed(site, form=form, month=self.settings['month'], day=self.weather_day, year=self.weather_year)
-                Tgnd_here = nw.temperature(site, form=form, month=self.settings['month'], day=self.weather_day, year=self.weather_year)
+                tau_here = nw.opacity(site, form=form, month=self.settings['month'], day=self.weather_day,
+                                       year=self.weather_year, freq=self.freq/(1.0e9),
+                                       weather_store=self.weather_store)
+                Tb_here = nw.brightness_temperature(site, form=form, month=self.settings['month'],
+                                                     day=self.weather_day, year=self.weather_year,
+                                                     freq=self.freq/(1.0e9), weather_store=self.weather_store)
+                ws_here = nw.windspeed(site, form=form, month=self.settings['month'], day=self.weather_day,
+                                        year=self.weather_year, weather_store=self.weather_store)
+                Tgnd_here = nw.temperature(site, form=form, month=self.settings['month'], day=self.weather_day,
+                                           year=self.weather_year, weather_store=self.weather_store)
 
                 # divide out the opacity term to get the effective atmospheric temperature
                 Tatm_here = (Tb_here - (const.T_CMB*np.exp(-tau_here))) / (1.0 - np.exp(-tau_here))
@@ -1178,7 +1190,8 @@ class obs_generator(object):
                                             custom_receivers=copy.deepcopy(self.custom_receivers),
                                             station_uptimes=copy.deepcopy(self.station_uptimes),
                                             array=self.array,
-                                            ephem=self.ephem)
+                                            ephem=self.ephem,
+                                            weather_store=self.weather_store)
 
                 if ((model_target is not None) & (not isinstance(model_target, str))):
                     obsgen_here.im = model_target
@@ -1760,7 +1773,8 @@ def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemer
                                wind_loading_overrides=new_wind_loading_overrides,
                                custom_receivers=new_custom_receivers,
                                station_uptimes=new_station_uptimes,
-                               ephem=ephem)
+                               ephem=ephem,
+                               weather_store=obsgen.weather_store)
     if ((model_ref is not None) & (not isinstance(model_ref, str))):
         obsgen_ref.im = model_ref
 
@@ -1914,15 +1928,18 @@ def export_SYMBA_antennas(obsgen, output_filename='obsgen.antennas', t_coh=10.0,
                 strhere += str(np.round(obsgen.receivers[site][band]['T_R'], 2)).ljust(11)
 
                 # add PWV, in mm
-                PWV = nw.PWV(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day, year=obsgen.weather_year)
+                PWV = nw.PWV(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day,
+                             year=obsgen.weather_year, weather_store=obsgen.weather_store)
                 strhere += str(np.round(PWV, 4)).ljust(9)
 
                 # add surface pressure, in mbar
-                pres = nw.pressure(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day, year=obsgen.weather_year)
+                pres = nw.pressure(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day,
+                                   year=obsgen.weather_year, weather_store=obsgen.weather_store)
                 strhere += str(np.round(pres, 2)).ljust(12)
 
                 # add surface temperature, in K
-                temp = nw.temperature(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day, year=obsgen.weather_year)
+                temp = nw.temperature(site, form=form, month=obsgen.settings['month'], day=obsgen.weather_day,
+                                      year=obsgen.weather_year, weather_store=obsgen.weather_store)
                 strhere += str(np.round(temp, 2)).ljust(10)
 
                 # add coherence time, in seconds

--- a/tests/test_weather_zarr_obs_generator.py
+++ b/tests/test_weather_zarr_obs_generator.py
@@ -1,0 +1,83 @@
+"""Tests for using a Zarr weather store in observation generation."""
+
+import numpy as np
+import pytest
+
+import ngehtsim.const_def as const
+import ngehtsim.obs.obs_generator as obs_generator_module
+import ngehtsim.weather.weather as weather
+from ngehtsim.weather.zarr_store import ZarrWeatherStore
+
+
+ZARR_OBS_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA"],
+    "weather": "exact",
+    "month": "Apr",
+    "day": 11,
+    "year": 2017,
+    "weather_day": 11,
+    "weather_year": 2017,
+    "frequency": 230.0,
+    "t_start": 0.0,
+    "dt": 3.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
+
+
+@pytest.fixture
+def store(weather_dataset):
+    return ZarrWeatherStore(weather_dataset)
+
+
+def test_obs_generator_uses_zarr_weather_store(store):
+    obsgen = obs_generator_module.obs_generator(
+        settings=ZARR_OBS_SETTINGS, weather_store=store
+    )
+    weather_kwargs = {
+        "form": "exact",
+        "month": "Apr",
+        "day": 11,
+        "year": 2017,
+        "weather_store": store,
+    }
+    tau = weather.opacity("ALMA", freq=230.0, **weather_kwargs)
+    tb = weather.brightness_temperature("ALMA", freq=230.0, **weather_kwargs)
+    windspeed = weather.windspeed("ALMA", **weather_kwargs)
+    temperature = weather.temperature("ALMA", **weather_kwargs)
+    atmospheric_temperature = (
+        tb - (const.T_CMB * np.exp(-tau))
+    ) / (1.0 - np.exp(-tau))
+
+    assert obsgen.weather_store is store
+    assert np.isclose(obsgen.tau_dict["ALMA"], tau)
+    assert np.isclose(obsgen.Tb_dict["ALMA"], tb)
+    assert np.isclose(obsgen.windspeed_dict["ALMA"], windspeed)
+    assert np.isclose(obsgen.Tgnd_dict["ALMA"], temperature)
+    assert np.isclose(obsgen.Tatm_dict["ALMA"], atmospheric_temperature)
+
+
+def test_obs_generator_rejects_invalid_weather_store():
+    with pytest.raises(TypeError, match="weather_store must be a ZarrWeatherStore"):
+        obs_generator_module.obs_generator(
+            settings=ZARR_OBS_SETTINGS, weather_store="weather.zarr"
+        )
+
+
+def test_symba_export_uses_obs_generator_weather_store(store, tmp_path):
+    obsgen = obs_generator_module.obs_generator(
+        settings=ZARR_OBS_SETTINGS, weather_store=store
+    )
+    output = tmp_path / "obsgen.antennas"
+
+    obs_generator_module.export_SYMBA_antennas(
+        obsgen, output_filename=output, use_two_letter=False
+    )
+
+    fields = output.read_text().splitlines()[1].split()
+    assert fields[0] == "ALMA"
+    assert np.isclose(float(fields[2]), 1.0)
+    assert np.isclose(float(fields[3]), 500.0)
+    assert np.isclose(float(fields[4]), 250.0)

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pytest
 
+import ngehtsim.obs.obs_generator as obs_generator_module
 import ngehtsim.weather.weather as weather
 from ngehtsim.weather.zarr_store import SCHEMA_VERSION, ZarrWeatherStore
 
@@ -19,6 +20,23 @@ WEATHER_FUNCTIONS = (
     (weather.PWV, {}),
     (weather.windspeed, {}),
 )
+
+OBS_GENERATOR_SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA"],
+    "weather": "exact",
+    "month": "Apr",
+    "day": 11,
+    "year": 2017,
+    "weather_day": 11,
+    "weather_year": 2017,
+    "frequency": 230.0,
+    "t_start": 0.0,
+    "dt": 3.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "random_seed": 1,
+}
 
 
 @pytest.fixture(scope="module")
@@ -56,3 +74,14 @@ def test_zarr_weather_api_matches_packaged_daily_weather(
     zarr = weather_function("ALMA", weather_store=external_store, **kwargs)
 
     assert np.allclose(zarr, legacy, equal_nan=True)
+
+
+@pytest.mark.external_weather
+def test_obs_generator_zarr_weather_matches_packaged_daily_weather(external_store):
+    legacy = obs_generator_module.obs_generator(settings=OBS_GENERATOR_SETTINGS)
+    zarr = obs_generator_module.obs_generator(
+        settings=OBS_GENERATOR_SETTINGS, weather_store=external_store
+    )
+
+    for attribute in ("tau_dict", "Tatm_dict", "Tb_dict", "windspeed_dict", "Tgnd_dict"):
+        assert np.isclose(getattr(zarr, attribute)["ALMA"], getattr(legacy, attribute)["ALMA"])


### PR DESCRIPTION
Adds explicit ZarrWeatherStore support to obs_generator and SYMBA export while retaining packaged binary weather by default. Includes unit, release-parity, and documentation coverage.