### PR TITLE
Use native Zarr weather in observation generation

### DIFF
--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -20,6 +20,23 @@ explicitly and pass the resulting store to the generator. Omitting
    store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr")
    obsgen = obs_generator.obs_generator(settings=settings, weather_store=store)
 
+By default, this continues to use the release's daily weather aggregates. To
+use linearly interpolated three-hour weather during observation generation,
+opt in explicitly:
+
+.. code-block:: python
+
+   obsgen = obs_generator.obs_generator(
+       settings=settings,
+       weather_store=store,
+       weather_cadence="native",
+   )
+
+Native weather varies the opacity, atmospheric and ground temperatures, and
+wind effects at each observation timestamp. SYMBA's static ``.antennas``
+format cannot represent this time dependence and is not available in native
+weather mode.
+
 .. automodule:: ngehtsim.obs.obs_generator
    :members:
 

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -37,6 +37,31 @@ def _ensure_iers_cached():
     finally:
         iers_conf.auto_download = auto_download
 
+
+def _weather_form(weather):
+    forms = {
+        'random': 'exact',
+        'exact': 'exact',
+        'mean': 'mean',
+        'average': 'mean',
+        'typical': 'median',
+        'median': 'median',
+        'good': 'good',
+        'bad': 'bad',
+        'poor': 'bad',
+    }
+    try:
+        return forms[weather]
+    except KeyError as exc:
+        raise ValueError('Unknown weather form: {0}'.format(weather)) from exc
+
+
+def _interpolate_spectra(frequency_ghz, spectra, target_frequency_ghz):
+    return np.asarray([
+        np.interp(target_frequency_ghz, frequency_ghz, spectrum)
+        for spectrum in spectra
+    ])
+
 ###################################################
 # class definition
 
@@ -68,6 +93,8 @@ class obs_generator(object):
       ephem (str): path to the ephemeris for a space station
       weather_store (ngehtsim.weather.zarr_store.ZarrWeatherStore): Optional local Zarr weather dataset.
                                                                     If None, use the packaged binary weather data.
+      weather_cadence (str): ``"daily"`` for the established scalar weather behavior or ``"native"``
+                             for linearly interpolated three-hour Zarr weather during observation generation.
     """
 
     # initialize class instantiation
@@ -75,7 +102,7 @@ class obs_generator(object):
                  surf_rms_overrides=None, receiver_configuration_overrides=None, bandwidth_overrides=None,
                  T_R_overrides=None, sideband_ratio_overrides=None, lo_freq_overrides=None, hi_freq_overrides=None,
                  ap_eff_overrides=None, wind_loading_overrides=None, custom_receivers=None, station_uptimes=None,
-                 array=None, ephem='ephemeris/space', weather_store=None):
+                 array=None, ephem='ephemeris/space', weather_store=None, weather_cadence='daily'):
 
         #############################
         # astropy cache
@@ -100,6 +127,10 @@ class obs_generator(object):
         station_uptimes = {} if station_uptimes is None else station_uptimes
         if weather_store is not None and not isinstance(weather_store, ZarrWeatherStore):
             raise TypeError("weather_store must be a ZarrWeatherStore instance or None.")
+        if weather_cadence not in ('daily', 'native'):
+            raise ValueError("weather_cadence must be either 'daily' or 'native'.")
+        if weather_cadence == 'native' and weather_store is None:
+            raise ValueError("Native weather cadence requires a Zarr weather_store.")
 
         #############################
         # parse inputs
@@ -122,6 +153,7 @@ class obs_generator(object):
         self.array = array
         self.ephem = ephem
         self.weather_store = weather_store
+        self.weather_cadence = weather_cadence
 
         #############################
         # load settings
@@ -477,21 +509,12 @@ class obs_generator(object):
             if self.weather_day is None:
                 self.weather_day = int(self.settings['day'])
 
+        form = _weather_form(self.weather)
+
         # read in the weather info and store it
         for isite, site in enumerate(self.sites):
 
             if site != 'space':
-
-                if ((self.weather == 'random') | (self.weather == 'exact')):
-                    form = 'exact'
-                elif ((self.weather == 'mean') | (self.weather == 'average')):
-                    form = 'mean'
-                elif ((self.weather == 'typical') | (self.weather == 'median')):
-                    form = 'median'
-                elif (self.weather == 'good'):
-                    form = 'good'
-                elif ((self.weather == 'bad') | (self.weather == 'poor')):
-                    form = 'bad'
 
                 tau_here = nw.opacity(site, form=form, month=self.settings['month'], day=self.weather_day,
                                        year=self.weather_year, freq=self.freq/(1.0e9),
@@ -531,6 +554,60 @@ class obs_generator(object):
         self.Tb_dict = Tb_dict
         self.windspeed_dict = windspeed_dict
         self.Tgnd_dict = Tgnd_dict
+
+    def _native_weather_terms(self, times):
+        times = np.asarray(times, dtype=float)
+        if times.ndim != 1 or not np.all(np.isfinite(times)):
+            raise ValueError('Native weather sampling requires finite one-dimensional observation times.')
+
+        unique_times, inverse = np.unique(times, return_inverse=True)
+        tau = {}
+        Tatm = {}
+        Tgnd = {}
+        windspeed = {}
+        form = _weather_form(self.weather)
+
+        for site in self.sites:
+            if site == 'space':
+                tau[site] = np.zeros(len(times))
+                Tatm[site] = np.zeros(len(times))
+                Tgnd[site] = np.full(len(times), const.T_CMB)
+                windspeed[site] = np.zeros(len(times))
+                continue
+
+            samples = self.weather_store.sample_native(
+                site,
+                year=int(self.weather_year),
+                month=self.settings['month'],
+                day=int(self.weather_day),
+                utc_hours=unique_times,
+                form=form,
+            )
+            tau_unique = _interpolate_spectra(
+                self.weather_store.frequency_ghz,
+                samples.opacity,
+                self.freq/(1.0e9),
+            )
+            Tb_unique = _interpolate_spectra(
+                self.weather_store.frequency_ghz,
+                samples.brightness_temperature,
+                self.freq/(1.0e9),
+            )
+            Tatm_unique = (
+                Tb_unique - (const.T_CMB*np.exp(-tau_unique))
+            ) / (1.0 - np.exp(-tau_unique))
+
+            tau[site] = tau_unique[inverse]
+            Tatm[site] = Tatm_unique[inverse]
+            Tgnd[site] = samples.surface_temperature_k[inverse]
+            windspeed[site] = samples.wind_speed_m_s[inverse]
+
+        return {
+            'tau': tau,
+            'Tatm': Tatm,
+            'Tgnd': Tgnd,
+            'windspeed': windspeed,
+        }
 
     # generate dictionaries of telescope properties
     def set_telescope_properties(self):
@@ -622,7 +699,7 @@ class obs_generator(object):
     # functions for generating observations
 
     # build context for station/weather/noise calculations
-    def station_context(self):
+    def station_context(self, times=None):
         receiver_temperature = {}
         sideband_ratio = {}
         bandwidth_hz = {}
@@ -651,12 +728,24 @@ class obs_generator(object):
             feed_angle[site] = const.known_feed_angles.get(site, const.feed_angle)
             polarization_basis[site] = const.known_polbases.get(site)
 
+        if self.weather_cadence == 'native':
+            if times is None:
+                raise ValueError('Native weather station contexts require observation times.')
+            weather_terms = self._native_weather_terms(times)
+        else:
+            weather_terms = {
+                'tau': self.tau_dict,
+                'Tatm': self.Tatm_dict,
+                'Tgnd': self.Tgnd_dict,
+                'windspeed': self.windspeed_dict,
+            }
+
         return {
             "sites": tuple(self.sites),
-            "tau": self.tau_dict,
-            "Tatm": self.Tatm_dict,
-            "Tgnd": self.Tgnd_dict,
-            "windspeed": self.windspeed_dict,
+            "tau": weather_terms['tau'],
+            "Tatm": weather_terms['Tatm'],
+            "Tgnd": weather_terms['Tgnd'],
+            "windspeed": weather_terms['windspeed'],
             "bands": self.bands,
             "wind_loading": self.wind_loading_dict,
             "solar_avoidance": self.solar_avoidance_dict,
@@ -721,7 +810,7 @@ class obs_generator(object):
         station_terms = station_observation.station_terms(
             obs,
             F0,
-            self.station_context(),
+            self.station_context(obs.data['time']),
             self.arr,
             self.rng,
             gainamp=gainamp,
@@ -1191,7 +1280,8 @@ class obs_generator(object):
                                             station_uptimes=copy.deepcopy(self.station_uptimes),
                                             array=self.array,
                                             ephem=self.ephem,
-                                            weather_store=self.weather_store)
+                                            weather_store=self.weather_store,
+                                            weather_cadence=self.weather_cadence)
 
                 if ((model_target is not None) & (not isinstance(model_target, str))):
                     obsgen_here.im = model_target
@@ -1256,6 +1346,9 @@ class obs_generator(object):
         Returns:
           SYMBA-compatible .antennas and master_input.txt files
         """
+
+        if self.weather_cadence == 'native':
+            raise ValueError('SYMBA antenna exports do not support native time-varying weather.')
 
         # create SYMBA working directory
         os.makedirs(symba_workdir, exist_ok=True)
@@ -1774,7 +1867,8 @@ def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemer
                                custom_receivers=new_custom_receivers,
                                station_uptimes=new_station_uptimes,
                                ephem=ephem,
-                               weather_store=obsgen.weather_store)
+                               weather_store=obsgen.weather_store,
+                               weather_cadence=obsgen.weather_cadence)
     if ((model_ref is not None) & (not isinstance(model_ref, str))):
         obsgen_ref.im = model_ref
 
@@ -1870,6 +1964,9 @@ def export_SYMBA_antennas(obsgen, output_filename='obsgen.antennas', t_coh=10.0,
       SYMBA-compatible .antennas file containing the observation information
     """
 
+    if obsgen.weather_cadence == 'native':
+        raise ValueError('SYMBA antenna exports do not support native time-varying weather.')
+
     with open(output_filename, 'w') as outfile:
 
         # add file header
@@ -1897,17 +1994,7 @@ def export_SYMBA_antennas(obsgen, output_filename='obsgen.antennas', t_coh=10.0,
         header += 'xzy_position_m' + '\n'
         outfile.write(header)
 
-        # determine form of weather return
-        if ((obsgen.weather == 'random') | (obsgen.weather == 'exact')):
-            form = 'exact'
-        elif ((obsgen.weather == 'mean') | (obsgen.weather == 'average')):
-            form = 'mean'
-        elif ((obsgen.weather == 'typical') | (obsgen.weather == 'median')):
-            form = 'median'
-        elif (obsgen.weather == 'good'):
-            form = 'good'
-        elif ((obsgen.weather == 'bad') | (obsgen.weather == 'poor')):
-            form = 'bad'
+        form = _weather_form(obsgen.weather)
 
         for site in obsgen.sites:
 

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -23,6 +23,17 @@ def _cache_value(value):
     return value
 
 
+def _station_weather_values(value, count, name):
+    values = np.asarray(value, dtype=float)
+    if values.ndim == 0:
+        return np.full(count, values, dtype=float), True
+    if values.shape != (count,):
+        raise ValueError(
+            'Station {0} weather must be a scalar or one value per observation row.'.format(name)
+        )
+    return values, False
+
+
 def station_metadata_cache_key(obs, station_context):
     sites = tuple(station_context["sites"])
     station_key = tuple(
@@ -173,18 +184,32 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
     flagsites = list()
     uptime_mask = np.ones(len(obs.data), dtype=bool)
     for site in sites_obs:
-        tau_z = station_context["tau"][site]
-        Tatm = station_context["Tatm"][site]
-        Tgnd = station_context["Tgnd"][site]
-        ws = station_context["windspeed"][site]
+        tau_z, _ = _station_weather_values(
+            station_context["tau"][site], len(obs.data), 'opacity'
+        )
+        Tatm, _ = _station_weather_values(
+            station_context["Tatm"][site], len(obs.data), 'atmospheric temperature'
+        )
+        Tgnd, _ = _station_weather_values(
+            station_context["Tgnd"][site], len(obs.data), 'ground temperature'
+        )
+        ws, windspeed_is_scalar = _station_weather_values(
+            station_context["windspeed"][site], len(obs.data), 'wind speed'
+        )
         Aeff = station_context["effective_area"][site]
         wind_loading = station_context["wind_loading"][site]
 
-        if (ws > wind_loading["shutdown"]):
-            if flagwind:
+        if flagwind:
+            site_rows = ((t1 == site) | (t2 == site))
+            high_wind = site_rows & (ws > wind_loading["shutdown"])
+            if np.any(high_wind) and windspeed_is_scalar:
                 flagsites.append(site)
                 if verbosity > 0:
                     print(site + " cannot observe because of high wind.")
+            elif np.any(high_wind):
+                uptime_mask[high_wind] = False
+                if verbosity > 0:
+                    print(site + " cannot observe at some timestamps because of high wind.")
 
         if flagday:
             if site != "space":
@@ -246,8 +271,8 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
                 obs.data["llvis"][ind2] = coh_mat_tformed2[:, 1, 1]
 
         if site != "space":
-            tau1[ind1] = tau_z / np.cos((np.pi/2.0) - el1[ind1])
-            tau2[ind2] = tau_z / np.cos((np.pi/2.0) - el2[ind2])
+            tau1[ind1] = tau_z[ind1] / np.cos((np.pi/2.0) - el1[ind1])
+            tau2[ind2] = tau_z[ind2] / np.cos((np.pi/2.0) - el2[ind2])
         else:
             tau1[ind1] = 0.0
             tau2[ind2] = 0.0
@@ -255,8 +280,8 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
         Tsource = (F0*Aeff)/(2.0*const.k)
 
         if site != "space":
-            Tb1[ind1] = ((const.T_CMB + Tsource)*np.exp(-tau1[ind1])) + (Tatm*(1.0 - np.exp(-tau1[ind1])))
-            Tb2[ind2] = ((const.T_CMB + Tsource)*np.exp(-tau2[ind2])) + (Tatm*(1.0 - np.exp(-tau2[ind2])))
+            Tb1[ind1] = ((const.T_CMB + Tsource)*np.exp(-tau1[ind1])) + (Tatm[ind1]*(1.0 - np.exp(-tau1[ind1])))
+            Tb2[ind2] = ((const.T_CMB + Tsource)*np.exp(-tau2[ind2])) + (Tatm[ind2]*(1.0 - np.exp(-tau2[ind2])))
         else:
             Tb1[ind1] = const.T_CMB + Tsource
             Tb2[ind2] = const.T_CMB + Tsource
@@ -264,16 +289,19 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
         T_R = station_context["receiver_temperature"][site]
         sideband_ratio = station_context["sideband_ratio"][site]
 
-        Tsys1[ind1] = (T_R + (const.eta_ff*Tb1[ind1]) + ((1.0 - const.eta_ff)*Tgnd))*(1.0 + sideband_ratio)
-        Tsys2[ind2] = (T_R + (const.eta_ff*Tb2[ind2]) + ((1.0 - const.eta_ff)*Tgnd))*(1.0 + sideband_ratio)
+        Tsys1[ind1] = (T_R + (const.eta_ff*Tb1[ind1]) + ((1.0 - const.eta_ff)*Tgnd[ind1]))*(1.0 + sideband_ratio)
+        Tsys2[ind2] = (T_R + (const.eta_ff*Tb2[ind2]) + ((1.0 - const.eta_ff)*Tgnd[ind2]))*(1.0 + sideband_ratio)
 
         SEFD1[ind1] = (2.0*const.k*Tsys1[ind1])/Aeff
         SEFD2[ind2] = (2.0*const.k*Tsys2[ind2])/Aeff
 
         if flagwind:
-            SEFD_factor = windspeed_sefd_modifier(ws, wind_loading["v0"], wind_loading["w"])
-            SEFD1[ind1] *= SEFD_factor
-            SEFD2[ind2] *= SEFD_factor
+            SEFD1[ind1] *= windspeed_sefd_modifier(
+                ws[ind1], wind_loading["v0"], wind_loading["w"]
+            )
+            SEFD2[ind2] *= windspeed_sefd_modifier(
+                ws[ind2], wind_loading["v0"], wind_loading["w"]
+            )
 
         sefdind = (array.tarr["site"] == site)
         sefdr_arr = np.copy(array.tarr["sefdr"])

--- a/tests/test_station_observation.py
+++ b/tests/test_station_observation.py
@@ -64,6 +64,18 @@ def _station_terms(obsgen, obs, F0, **kwargs):
         **station_kwargs,
     )
 
+
+def _time_varying_weather_context(obsgen, obs):
+    context = obsgen.station_context()
+    count = len(obs.data)
+    context = dict(context)
+    for quantity in ("tau", "Tatm", "Tgnd", "windspeed"):
+        context[quantity] = {
+            site: np.full(count, value, dtype=float)
+            for site, value in context[quantity].items()
+        }
+    return context
+
 #######################################################
 # tests
 
@@ -149,6 +161,71 @@ def test_station_terms_populates_weather_arrays_without_corruptions():
     assert np.all(terms["bw2"] > 0.0)
     assert "gainamp1R" not in terms
     assert "leak1R" not in terms
+
+
+def test_station_terms_accepts_per_observation_weather_values():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, F0 = _source_observation(obsgen)
+    context = _time_varying_weather_context(obsgen, obs)
+    context["tau"]["ALMA"] = np.linspace(0.1, 0.2, len(obs.data))
+    context["Tatm"]["ALMA"] = np.linspace(240.0, 260.0, len(obs.data))
+    context["Tgnd"]["ALMA"] = np.linspace(250.0, 270.0, len(obs.data))
+
+    terms = station_observation.station_terms(
+        obs,
+        F0,
+        context,
+        obsgen.arr,
+        obsgen.rng,
+        addgains=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+        solar_angle=obsgen.solar_angle,
+        windspeed_sefd_modifier=og.windspeed_SEFD_modification,
+    )
+
+    ind1 = terms["t1"] == "ALMA"
+    ind2 = terms["t2"] == "ALMA"
+    assert np.allclose(
+        terms["tau1"][ind1] * np.cos((np.pi/2.0) - terms["el1"][ind1]),
+        context["tau"]["ALMA"][ind1],
+    )
+    assert np.allclose(
+        terms["tau2"][ind2] * np.cos((np.pi/2.0) - terms["el2"][ind2]),
+        context["tau"]["ALMA"][ind2],
+    )
+
+
+def test_station_terms_flags_time_varying_wind_per_timestamp():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, F0 = _source_observation(obsgen)
+    context = _time_varying_weather_context(obsgen, obs)
+    high_wind_time = np.max(obs.data["time"])
+    context["windspeed"]["ALMA"][obs.data["time"] == high_wind_time] = 30.0
+
+    terms = station_observation.station_terms(
+        obs,
+        F0,
+        context,
+        obsgen.arr,
+        obsgen.rng,
+        addgains=False,
+        addleakage=False,
+        flagwind=True,
+        flagday=False,
+        flagsun=False,
+        solar_angle=obsgen.solar_angle,
+        windspeed_sefd_modifier=og.windspeed_SEFD_modification,
+    )
+
+    expected_flags = (
+        ((terms["t1"] == "ALMA") | (terms["t2"] == "ALMA"))
+        & (terms["times"] == high_wind_time)
+    )
+    assert terms["flagsites"] == []
+    assert np.array_equal(~terms["uptime_mask"], expected_flags)
 
 
 def test_station_terms_populates_gain_and_leakage_arrays_when_enabled():

--- a/tests/test_weather_zarr_obs_generator.py
+++ b/tests/test_weather_zarr_obs_generator.py
@@ -52,6 +52,7 @@ def test_obs_generator_uses_zarr_weather_store(store):
     ) / (1.0 - np.exp(-tau))
 
     assert obsgen.weather_store is store
+    assert obsgen.weather_cadence == "daily"
     assert np.isclose(obsgen.tau_dict["ALMA"], tau)
     assert np.isclose(obsgen.Tb_dict["ALMA"], tb)
     assert np.isclose(obsgen.windspeed_dict["ALMA"], windspeed)
@@ -59,11 +60,66 @@ def test_obs_generator_uses_zarr_weather_store(store):
     assert np.isclose(obsgen.Tatm_dict["ALMA"], atmospheric_temperature)
 
 
+def test_obs_generator_samples_native_weather_at_observation_times(store):
+    obsgen = obs_generator_module.obs_generator(
+        settings=ZARR_OBS_SETTINGS,
+        weather_store=store,
+        weather_cadence="native",
+    )
+    times = np.array([0.0, 1.5, 3.0])
+    context = obsgen.station_context(times)
+    samples = store.sample_native(
+        "ALMA", year=2017, month="Apr", day=11, utc_hours=times
+    )
+    expected_tau = np.array([
+        np.interp(230.0, store.frequency_ghz, spectrum)
+        for spectrum in samples.opacity
+    ])
+    expected_tb = np.array([
+        np.interp(230.0, store.frequency_ghz, spectrum)
+        for spectrum in samples.brightness_temperature
+    ])
+    expected_tatm = (
+        expected_tb - (const.T_CMB * np.exp(-expected_tau))
+    ) / (1.0 - np.exp(-expected_tau))
+
+    assert np.allclose(context["tau"]["ALMA"], expected_tau)
+    assert np.allclose(context["Tatm"]["ALMA"], expected_tatm)
+    assert np.allclose(context["Tgnd"]["ALMA"], [250.0, 250.5, 251.0])
+    assert np.allclose(context["windspeed"]["ALMA"], [3.0, 3.5, 4.0])
+
+
 def test_obs_generator_rejects_invalid_weather_store():
     with pytest.raises(TypeError, match="weather_store must be a ZarrWeatherStore"):
         obs_generator_module.obs_generator(
             settings=ZARR_OBS_SETTINGS, weather_store="weather.zarr"
         )
+
+
+@pytest.mark.parametrize("weather_cadence", ["hourly", "three-hourly", None])
+def test_obs_generator_rejects_invalid_weather_cadence(weather_cadence):
+    with pytest.raises(ValueError, match="weather_cadence"):
+        obs_generator_module.obs_generator(
+            settings=ZARR_OBS_SETTINGS, weather_cadence=weather_cadence
+        )
+
+
+def test_native_weather_cadence_requires_zarr_store():
+    with pytest.raises(ValueError, match="requires a Zarr weather_store"):
+        obs_generator_module.obs_generator(
+            settings=ZARR_OBS_SETTINGS, weather_cadence="native"
+        )
+
+
+def test_native_weather_station_context_requires_observation_times(store):
+    obsgen = obs_generator_module.obs_generator(
+        settings=ZARR_OBS_SETTINGS,
+        weather_store=store,
+        weather_cadence="native",
+    )
+
+    with pytest.raises(ValueError, match="require observation times"):
+        obsgen.station_context()
 
 
 def test_symba_export_uses_obs_generator_weather_store(store, tmp_path):
@@ -81,3 +137,16 @@ def test_symba_export_uses_obs_generator_weather_store(store, tmp_path):
     assert np.isclose(float(fields[2]), 1.0)
     assert np.isclose(float(fields[3]), 500.0)
     assert np.isclose(float(fields[4]), 250.0)
+
+
+def test_symba_export_rejects_native_weather_cadence(store, tmp_path):
+    obsgen = obs_generator_module.obs_generator(
+        settings=ZARR_OBS_SETTINGS,
+        weather_store=store,
+        weather_cadence="native",
+    )
+
+    with pytest.raises(ValueError, match="do not support native time-varying weather"):
+        obs_generator_module.export_SYMBA_antennas(
+            obsgen, output_filename=tmp_path / "obsgen.antennas"
+        )

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -2,6 +2,7 @@
 
 import os
 
+import ehtim as eh
 import numpy as np
 import pytest
 
@@ -85,6 +86,32 @@ def test_obs_generator_zarr_weather_matches_packaged_daily_weather(external_stor
 
     for attribute in ("tau_dict", "Tatm_dict", "Tb_dict", "windspeed_dict", "Tgnd_dict"):
         assert np.isclose(getattr(zarr, attribute)["ALMA"], getattr(legacy, attribute)["ALMA"])
+
+
+@pytest.mark.external_weather
+def test_obs_generator_uses_native_weather_for_observation_terms(external_store):
+    settings = dict(OBS_GENERATOR_SETTINGS)
+    settings.pop("sites")
+    settings["array"] = "EHT2017"
+    model = eh.model.Model().add_circ_gauss(F0=1.0, FWHM=40.0 * eh.RADPERUAS)
+    obsgen = obs_generator_module.obs_generator(
+        settings=settings,
+        weather_store=external_store,
+        weather_cadence="native",
+        weight=1,
+    )
+
+    obs = obsgen.make_obs(
+        model,
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagsun=False,
+    )
+
+    assert len(obs.data) > 0
+    assert np.all(np.isfinite(obsgen.tau1))
+    assert np.all(np.isfinite(obsgen.SEFD1))
 
 
 @pytest.mark.external_weather


### PR DESCRIPTION
Adds opt-in, linearly interpolated three-hour Zarr weather for synthetic observation terms. Native cadence provides time-varying opacity, Tsys, SEFD, and wind flags while preserving daily behavior by default.