### PR TITLE
Benchmark legacy and Zarr weather backends

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,36 @@ Run one scenario with more repeats:
 MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 5 --warmups 1 --scenario eht2017_model_clean_reused_generator
 ```
 
+## Compare Weather Backends
+
+The default is the packaged daily weather backend, preserving the original
+benchmark behavior. To compare it with a local external Zarr weather release,
+pass its explicit path and select each backend. The runner creates an
+independent Zarr store for each backend so that one backend's partition cache
+cannot warm another's results.
+
+```bash
+WEATHER_STORE=/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr
+
+MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py \
+  --scenario eht2017_model_clean \
+  --scenario ngeht_model_clean \
+  --repeats 3 \
+  --warmups 1 \
+  --weather-store "$WEATHER_STORE" \
+  --weather-backend legacy \
+  --weather-backend zarr-daily \
+  --weather-backend zarr-native
+```
+
+The JSON result records the backend, release path, and time to open each Zarr
+store separately from generator initialization. Zarr benchmark runs require
+the optional weather dependency:
+
+```bash
+python3 -m pip install "ngehtsim[weather-zarr]"
+```
+
 Benchmark outputs are written to `benchmarks/results/`.
 
 ## Profile Synthetic Data Generation
@@ -46,6 +76,19 @@ Profile initialization and observation generation together:
 
 ```bash
 MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py --scenario eht2017_model_clean --phase full --repeats 3 --warmups 1
+```
+
+Profile one external-weather backend at a time. For example, profile native
+three-hour weather during generator initialization:
+
+```bash
+MPLBACKEND=Agg python3 benchmarks/profile_synthetic_data.py \
+  --scenario eht2017_model_clean \
+  --phase init \
+  --repeats 3 \
+  --warmups 0 \
+  --weather-store "$WEATHER_STORE" \
+  --weather-backend zarr-native
 ```
 
 The profiler writes both a raw `.prof` file and a readable `.txt` summary under `benchmarks/results/`. The `.txt` summary is usually the first file to inspect. The `.prof` file can be opened with tools such as `snakeviz` if desired.

--- a/benchmarks/benchmark_synthetic_data.py
+++ b/benchmarks/benchmark_synthetic_data.py
@@ -9,7 +9,7 @@ import statistics
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 os.environ.setdefault("MPLBACKEND", "Agg")
@@ -88,6 +88,132 @@ SCENARIOS = [
     },
 ]
 
+WEATHER_BACKENDS = ("legacy", "zarr-daily", "zarr-native")
+
+
+def add_weather_backend_arguments(parser):
+    """Add optional external-weather benchmark arguments to ``parser``."""
+
+    parser.add_argument(
+        "--weather-store",
+        type=Path,
+        default=None,
+        help="Path to a local Zarr weather release.",
+    )
+    parser.add_argument(
+        "--weather-backend",
+        action="append",
+        choices=WEATHER_BACKENDS,
+        default=None,
+        help="Weather backend to benchmark. May be passed more than once.",
+    )
+
+
+def prepare_weather_backends(weather_backends, weather_store_path):
+    """Create independent runtime weather configurations for each backend."""
+
+    backend_names = weather_backends or ["legacy"]
+    backend_names = list(dict.fromkeys(backend_names))
+    zarr_backends = {"zarr-daily", "zarr-native"}
+
+    if not zarr_backends.intersection(backend_names):
+        return [
+            {
+                "name": "legacy",
+                "store": None,
+                "store_path": None,
+                "store_init_seconds": 0.0,
+                "obs_generator_kwargs": {},
+            }
+        ]
+
+    if weather_store_path is None:
+        raise SystemExit("--weather-store is required for Zarr weather backends.")
+
+    weather_store_path = weather_store_path.expanduser().resolve()
+    if not weather_store_path.is_dir():
+        raise SystemExit(
+            "Zarr weather dataset directory does not exist: {0}".format(weather_store_path)
+        )
+
+    try:
+        from ngehtsim.weather.zarr_store import ZarrWeatherStore
+    except ImportError as exc:
+        raise SystemExit(
+            "Zarr weather benchmarks require `pip install \"ngehtsim[weather-zarr]\"`."
+        ) from exc
+
+    backends = []
+    for backend_name in backend_names:
+        if backend_name == "legacy":
+            backends.append(
+                {
+                    "name": backend_name,
+                    "store": None,
+                    "store_path": None,
+                    "store_init_seconds": 0.0,
+                    "obs_generator_kwargs": {},
+                }
+            )
+            continue
+
+        t0 = time.perf_counter()
+        store = ZarrWeatherStore(weather_store_path)
+        store_init_seconds = time.perf_counter() - t0
+        backends.append(
+            {
+                "name": backend_name,
+                "store": store,
+                "store_path": str(weather_store_path),
+                "store_init_seconds": store_init_seconds,
+                "obs_generator_kwargs": {
+                    "weather_store": store,
+                    "weather_cadence": (
+                        "daily" if backend_name == "zarr-daily" else "native"
+                    ),
+                },
+            }
+        )
+
+    return backends
+
+
+def expand_scenarios(scenarios, weather_backends):
+    """Return one executable scenario for every scenario/backend combination."""
+
+    expanded = []
+    for scenario in scenarios:
+        for backend in weather_backends:
+            expanded_scenario = dict(scenario)
+            expanded_scenario["settings"] = dict(scenario["settings"])
+            expanded_scenario["name"] = "{0}__{1}".format(
+                scenario["name"], backend["name"]
+            )
+            expanded_scenario["description"] = "{0} Weather backend: {1}.".format(
+                scenario["description"], backend["name"]
+            )
+            expanded_scenario["weather_backend"] = backend["name"]
+            expanded_scenario["weather_store_path"] = backend["store_path"]
+            expanded_scenario["weather_store_init_seconds"] = backend["store_init_seconds"]
+            expanded_scenario["_obs_generator_kwargs"] = backend["obs_generator_kwargs"]
+            expanded.append(expanded_scenario)
+    return expanded
+
+
+def scenario_definition(scenario):
+    """Return a JSON-serializable benchmark scenario description."""
+
+    return {key: value for key, value in scenario.items() if not key.startswith("_")}
+
+
+def make_obs_generator(scenario):
+    """Construct an observation generator for one benchmark scenario."""
+
+    return og.obs_generator(
+        settings=dict(scenario["settings"]),
+        **scenario["_obs_generator_kwargs"],
+    )
+
 
 def make_source(input_kind):
     model = eh.model.Model()
@@ -124,7 +250,7 @@ def git_value(*args):
 
 def metadata():
     return {
-        "timestamp_utc": datetime.utcnow().isoformat() + "Z",
+        "timestamp_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "python": sys.version.replace("\n", " "),
         "python_executable": sys.executable,
         "platform": platform.platform(),
@@ -140,7 +266,7 @@ def run_fresh_iteration(scenario):
     input_model = make_source(scenario["input_kind"])
 
     t0 = time.perf_counter()
-    obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+    obsgen = make_obs_generator(scenario)
     t1 = time.perf_counter()
     obs = obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
     t2 = time.perf_counter()
@@ -154,7 +280,7 @@ def run_fresh_iteration(scenario):
 
 def run_reused_generator_iterations(scenario, repeats, warmups=0):
     t0 = time.perf_counter()
-    obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+    obsgen = make_obs_generator(scenario)
     t1 = time.perf_counter()
     obsgen_init_seconds = t1 - t0
 
@@ -200,6 +326,9 @@ def run_scenario(scenario, repeats, warmups):
         "input_kind": scenario["input_kind"],
         "make_obs_kwargs": scenario["make_obs_kwargs"],
         "reuse_generator": scenario["reuse_generator"],
+        "weather_backend": scenario["weather_backend"],
+        "weather_store_path": scenario["weather_store_path"],
+        "weather_store_init_seconds": scenario["weather_store_init_seconds"],
         "rows": rows,
         "obsgen_init_seconds": summarize(init_seconds),
         "make_obs_seconds": summarize(make_obs_seconds),
@@ -241,6 +370,7 @@ def main():
     parser.add_argument("--scenario", action="append", help="Scenario name to run. May be passed more than once.")
     parser.add_argument("--output", type=Path, default=None, help="JSON output path.")
     parser.add_argument("--list-scenarios", action="store_true", help="List available scenarios and exit.")
+    add_weather_backend_arguments(parser)
     args = parser.parse_args()
 
     if args.repeats < 1:
@@ -251,9 +381,11 @@ def main():
     if args.list_scenarios:
         for scenario in SCENARIOS:
             print("{0}: {1}".format(scenario["name"], scenario["description"]))
+        print("Weather backends: {0}".format(", ".join(WEATHER_BACKENDS)))
         return 0
 
-    scenarios = select_scenarios(args.scenario)
+    weather_backends = prepare_weather_backends(args.weather_backend, args.weather_store)
+    scenarios = expand_scenarios(select_scenarios(args.scenario), weather_backends)
     output_path = args.output or default_output_path()
 
     payload = {
@@ -262,8 +394,9 @@ def main():
             "repeats": args.repeats,
             "warmups": args.warmups,
             "scenario_names": [scenario["name"] for scenario in scenarios],
+            "weather_backends": [backend["name"] for backend in weather_backends],
         },
-        "scenario_definitions": scenarios,
+        "scenario_definitions": [scenario_definition(scenario) for scenario in scenarios],
         "scenarios": [run_scenario(scenario, args.repeats, args.warmups) for scenario in scenarios],
     }
 

--- a/benchmarks/profile_synthetic_data.py
+++ b/benchmarks/profile_synthetic_data.py
@@ -8,7 +8,7 @@ import os
 import pstats
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 os.environ.setdefault("MPLBACKEND", "Agg")
@@ -20,11 +20,10 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "benchmarks"))
 
 import benchmark_synthetic_data as bench
-import ngehtsim.obs.obs_generator as og
 
 
 def default_output_paths(scenario_name, phase):
-    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     stem = "synthetic_data_profile_{0}_{1}_{2}".format(
         scenario_name,
         phase,
@@ -39,7 +38,7 @@ def warmup_make_obs(scenario, count):
         return
 
     if scenario["reuse_generator"]:
-        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        obsgen = bench.make_obs_generator(scenario)
         for _ in range(count):
             input_model = bench.make_source(scenario["input_kind"])
             obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
@@ -47,7 +46,7 @@ def warmup_make_obs(scenario, count):
 
     for _ in range(count):
         input_model = bench.make_source(scenario["input_kind"])
-        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        obsgen = bench.make_obs_generator(scenario)
         obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
 
 
@@ -55,7 +54,7 @@ def make_init_target(scenario, repeats):
     def target():
         rows = []
         for _ in range(repeats):
-            og.obs_generator(settings=dict(scenario["settings"]))
+            bench.make_obs_generator(scenario)
             rows.append(0)
         return rows
 
@@ -64,7 +63,7 @@ def make_init_target(scenario, repeats):
 
 def make_make_obs_target(scenario, repeats, warmups):
     if scenario["reuse_generator"]:
-        obsgen = og.obs_generator(settings=dict(scenario["settings"]))
+        obsgen = bench.make_obs_generator(scenario)
         for _ in range(warmups):
             input_model = bench.make_source(scenario["input_kind"])
             obsgen.make_obs(input_model, **scenario["make_obs_kwargs"])
@@ -83,7 +82,7 @@ def make_make_obs_target(scenario, repeats, warmups):
     warmup_make_obs(scenario, warmups)
     obs_inputs = [
         (
-            og.obs_generator(settings=dict(scenario["settings"])),
+            bench.make_obs_generator(scenario),
             bench.make_source(scenario["input_kind"]),
         )
         for _ in range(repeats)
@@ -134,6 +133,8 @@ def profile_target(target, sort, limit, profile_output, stats_output, metadata):
     header = [
         "scenario: {0}".format(metadata["scenario"]),
         "phase: {0}".format(metadata["phase"]),
+        "weather_backend: {0}".format(metadata["weather_backend"]),
+        "weather_store_path: {0}".format(metadata["weather_store_path"]),
         "repeats: {0}".format(metadata["repeats"]),
         "warmups: {0}".format(metadata["warmups"]),
         "sort: {0}".format(sort),
@@ -159,6 +160,7 @@ def main():
     parser.add_argument("--profile-output", type=Path, default=None)
     parser.add_argument("--stats-output", type=Path, default=None)
     parser.add_argument("--list-scenarios", action="store_true")
+    bench.add_weather_backend_arguments(parser)
     args = parser.parse_args()
 
     if args.repeats < 1:
@@ -169,9 +171,15 @@ def main():
     if args.list_scenarios:
         for scenario in bench.SCENARIOS:
             print("{0}: {1}".format(scenario["name"], scenario["description"]))
+        print("Weather backends: {0}".format(", ".join(bench.WEATHER_BACKENDS)))
         return 0
 
-    scenario = bench.select_scenarios([args.scenario])[0]
+    if args.weather_backend is not None and len(set(args.weather_backend)) != 1:
+        raise SystemExit("The profiler accepts exactly one --weather-backend at a time.")
+
+    weather_backends = bench.prepare_weather_backends(args.weather_backend, args.weather_store)
+    scenarios = bench.expand_scenarios(bench.select_scenarios([args.scenario]), weather_backends)
+    scenario = scenarios[0]
     profile_output, stats_output = default_output_paths(scenario["name"], args.phase)
     if args.profile_output is not None:
         profile_output = args.profile_output
@@ -194,6 +202,8 @@ def main():
         {
             "scenario": scenario["name"],
             "phase": args.phase,
+            "weather_backend": scenario["weather_backend"],
+            "weather_store_path": scenario["weather_store_path"],
             "repeats": args.repeats,
             "warmups": args.warmups,
         },

--- a/tests/test_benchmark_weather_backends.py
+++ b/tests/test_benchmark_weather_backends.py
@@ -1,0 +1,38 @@
+"""Tests for opt-in weather-backend benchmark configuration."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+BENCHMARKS_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+if str(BENCHMARKS_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARKS_DIR))
+
+import benchmark_synthetic_data as bench
+
+
+def test_legacy_weather_backend_does_not_require_a_zarr_release():
+    backends = bench.prepare_weather_backends(None, None)
+
+    assert len(backends) == 1
+    assert backends[0]["name"] == "legacy"
+    assert backends[0]["store_path"] is None
+    assert backends[0]["obs_generator_kwargs"] == {}
+
+
+def test_zarr_weather_backend_requires_an_explicit_release_path():
+    with pytest.raises(SystemExit, match="--weather-store"):
+        bench.prepare_weather_backends(["zarr-native"], None)
+
+
+def test_expanded_benchmark_scenario_is_json_serializable():
+    backends = bench.prepare_weather_backends(None, None)
+    scenario = bench.expand_scenarios([bench.SCENARIOS[0]], backends)[0]
+    definition = bench.scenario_definition(scenario)
+
+    assert scenario["name"] == "eht2017_model_clean__legacy"
+    assert scenario["_obs_generator_kwargs"] == {}
+    assert definition["weather_backend"] == "legacy"
+    assert "_obs_generator_kwargs" not in definition


### PR DESCRIPTION
Adds opt-in timing and profiling support for packaged daily weather, external Zarr daily summaries, and native three-hour weather. Records store-open time separately, prevents cross-backend cache warming, documents local runs, and adds focused benchmark configuration tests.