### PR TITLE
Read precomputed native weather summaries

### DIFF
--- a/ngehtsim/weather/zarr_store.py
+++ b/ngehtsim/weather/zarr_store.py
@@ -17,7 +17,8 @@ from typing import Literal
 import numpy as np
 
 
-SCHEMA_VERSION = "0.1.0"
+CURRENT_SCHEMA_VERSION = "0.2.0"
+SUPPORTED_SCHEMA_VERSIONS = ("0.1.0", CURRENT_SCHEMA_VERSION)
 Cadence = Literal["daily", "native"]
 NativeWeatherForm = Literal["exact", "mean", "median", "good", "bad"]
 
@@ -35,6 +36,11 @@ _SCALAR_ARRAYS = (
 _PARTITION_CACHE_SIZE = 64
 _NATIVE_SUMMARY_CACHE_SIZE = 64
 _NATIVE_SUMMARY_FORMS = ("mean", "median", "good", "bad")
+_NATIVE_SUMMARY_ARRAYS = (
+    "opacity",
+    "brightness_temperature",
+    *_SCALAR_ARRAYS,
+)
 
 
 class WeatherStoreError(ValueError):
@@ -358,11 +364,56 @@ class ZarrWeatherStore:
         try:
             values = self._native_summary_cache.pop(key)
         except KeyError:
-            partition = self.read_partition(site, month, cadence="native")
-            values = self._summarize_native_partition(partition, form)
+            if self._schema_version == CURRENT_SCHEMA_VERSION:
+                values = self._read_native_month_summary(site, month, form)
+            else:
+                partition = self.read_partition(site, month, cadence="native")
+                values = self._summarize_native_partition(partition, form)
             if len(self._native_summary_cache) >= _NATIVE_SUMMARY_CACHE_SIZE:
                 self._native_summary_cache.popitem(last=False)
         self._native_summary_cache[key] = values
+        return values
+
+    def _read_native_month_summary(
+        self, site: str, month: int, form: NativeWeatherForm
+    ) -> dict[str, np.ndarray]:
+        """Read validated physical native-summary products from schema v0.2."""
+
+        prefix = f"sites/{site}/months/{month:02d}/native_summary/{form}"
+        if prefix not in self._root:
+            raise WeatherStoreError(
+                f"Zarr weather dataset is missing the native summary for {site!r}, "
+                f"month {month:02d}, form {form!r}."
+            )
+
+        group = self._root[prefix]
+        missing = [name for name in _NATIVE_SUMMARY_ARRAYS if name not in group]
+        if missing:
+            raise WeatherStoreError(
+                f"Native weather summary {prefix!r} is missing arrays: {', '.join(missing)}."
+            )
+
+        values = {
+            name: self._read_array(f"{prefix}/{name}")
+            for name in _NATIVE_SUMMARY_ARRAYS
+        }
+        expected_spectral_shape = (self._native_samples_per_day, len(self.frequency_ghz))
+        expected_scalar_shape = (self._native_samples_per_day,)
+        for name, value in values.items():
+            expected_shape = (
+                expected_spectral_shape
+                if name in ("opacity", "brightness_temperature")
+                else expected_scalar_shape
+            )
+            if value.shape != expected_shape:
+                raise WeatherStoreError(
+                    f"Native weather summary {prefix!r} has an incompatible shape for "
+                    f"{name!r}."
+                )
+            if not np.all(np.isfinite(value)):
+                raise WeatherStoreError(
+                    f"Native weather summary {prefix!r} contains non-finite values."
+                )
         return values
 
     def _summarize_native_partition(
@@ -449,11 +500,14 @@ class ZarrWeatherStore:
 
     def _validate_root(self) -> None:
         attributes = self._root.attrs
-        if attributes.get("schema_version") != SCHEMA_VERSION:
+        schema_version = attributes.get("schema_version")
+        if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+            allowed = ", ".join(repr(value) for value in SUPPORTED_SCHEMA_VERSIONS)
             raise WeatherStoreError(
                 "Unsupported Zarr weather schema version "
-                f"{attributes.get('schema_version')!r}; expected {SCHEMA_VERSION!r}."
+                f"{schema_version!r}; supported versions are {allowed}."
             )
+        self._schema_version = schema_version
         if not isinstance(attributes.get("dataset_id"), str) or not attributes["dataset_id"]:
             raise WeatherStoreError("Zarr weather dataset has no valid dataset_id attribute.")
 
@@ -497,6 +551,13 @@ class ZarrWeatherStore:
                 "Zarr weather native sampling does not cover one 24-hour UTC day."
             )
         self._native_time_step_hours = time_step_hours
+
+        if self._schema_version == CURRENT_SCHEMA_VERSION:
+            if tuple(attributes.get("native_summary_forms", ())) != _NATIVE_SUMMARY_FORMS:
+                raise WeatherStoreError(
+                    "Zarr weather schema v0.2 requires the native summary forms "
+                    f"{', '.join(_NATIVE_SUMMARY_FORMS)}."
+                )
 
         for quantity in ("tau", "tb"):
             mean = self._read_array(f"pca/{quantity}/mean")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,55 @@ def weather_dataset(tmp_path):
     return path
 
 
+@pytest.fixture
+def weather_dataset_v02(weather_dataset):
+    """Add schema-v0.2 physical native-summary products to the test release."""
+
+    root = pytest.importorskip("zarr").open_group(weather_dataset, mode="r+")
+    root.attrs.update(
+        {
+            "schema_version": "0.2.0",
+            "dataset_id": "test-weather-v0.2.0",
+            "native_summary_forms": ["mean", "median", "good", "bad"],
+        }
+    )
+    native = root["sites/ALMA/months/04/native"]
+    tau_coefficients = np.asarray(native["tau_coefficients"][:], dtype=float)
+    tb_coefficients = np.asarray(native["tb_coefficients"][:], dtype=float)
+    values = {
+        "opacity": np.power(
+            10.0,
+            np.asarray(root["pca/tau/mean"][:])
+            + tau_coefficients @ np.asarray(root["pca/tau/components"][:]),
+        ),
+        "brightness_temperature": (
+            np.asarray(root["pca/tb/mean"][:])
+            + tb_coefficients @ np.asarray(root["pca/tb/components"][:])
+        ),
+        "pwv_mm": np.asarray(native["pwv_mm"][:]),
+        "wind_speed_m_s": np.asarray(native["wind_speed_m_s"][:]),
+        "surface_pressure_mbar": np.asarray(native["surface_pressure_mbar"][:]),
+        "surface_temperature_k": np.asarray(native["surface_temperature_k"][:]),
+    }
+    reducers = {
+        "mean": np.nanmean,
+        "median": np.nanmedian,
+        "good": lambda source, axis: np.nanpercentile(source, 15.87, axis=axis),
+        "bad": lambda source, axis: np.nanpercentile(source, 84.13, axis=axis),
+    }
+    time_index = np.asarray(native["time_index"][:])
+    for form, reducer in reducers.items():
+        group = root.create_group("sites/ALMA/months/04/native_summary/{0}".format(form))
+        for name, source in values.items():
+            group.create_array(
+                name,
+                data=np.asarray(
+                    [reducer(source[time_index == index], axis=0) for index in range(8)]
+                ),
+            )
+    return weather_dataset
+
+
 def _write_weather_records(group, include_time_index):
     if include_time_index:
         time_index = np.tile(np.arange(8, dtype=np.int8), 2)

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -8,7 +8,7 @@ import pytest
 
 import ngehtsim.obs.obs_generator as obs_generator_module
 import ngehtsim.weather.weather as weather
-from ngehtsim.weather.zarr_store import SCHEMA_VERSION, ZarrWeatherStore
+from ngehtsim.weather.zarr_store import SUPPORTED_SCHEMA_VERSIONS, ZarrWeatherStore
 
 
 WEATHER_FUNCTIONS = (
@@ -50,7 +50,7 @@ def external_store():
 
 @pytest.mark.external_weather
 def test_local_weather_release_has_expected_schema_and_alma_coverage(external_store):
-    assert external_store.attributes["schema_version"] == SCHEMA_VERSION
+    assert external_store.attributes["schema_version"] in SUPPORTED_SCHEMA_VERSIONS
     assert external_store.dataset_id == "ngehtsim-weather-merra2-3hour-v0.1.0"
     assert len(external_store.sites) == 141
 

--- a/tests/test_weather_zarr_store.py
+++ b/tests/test_weather_zarr_store.py
@@ -16,6 +16,13 @@ def test_store_exposes_validated_metadata(weather_dataset):
     assert not store.frequency_ghz.flags.writeable
 
 
+def test_store_accepts_schema_v02_metadata(weather_dataset_v02):
+    store = ZarrWeatherStore(weather_dataset_v02)
+
+    assert store.dataset_id == "test-weather-v0.2.0"
+    assert store.attributes["schema_version"] == "0.2.0"
+
+
 @pytest.mark.parametrize("month", ["Apr", "04", "4", 4])
 def test_store_reads_daily_partition_for_month_aliases(weather_dataset, month):
     partition = ZarrWeatherStore(weather_dataset).read_partition("ALMA", month)
@@ -97,6 +104,50 @@ def test_store_summarizes_native_weather_by_utc_time(weather_dataset, form, redu
     assert samples.surface_pressure_mbar.shape == (1,)
     expected = (reducer([500.0, 508.0]) + reducer([501.0, 509.0])) / 2.0
     assert np.allclose(samples.surface_pressure_mbar, [expected])
+
+
+@pytest.mark.parametrize("form", ["mean", "median", "good", "bad"])
+def test_store_uses_precomputed_native_summary_products(weather_dataset_v02, monkeypatch, form):
+    store = ZarrWeatherStore(weather_dataset_v02)
+
+    def fail_if_raw_native_records_are_read(*args, **kwargs):
+        raise AssertionError("Schema v0.2 summary sampling must not read raw native records.")
+
+    monkeypatch.setattr(store, "read_partition", fail_if_raw_native_records_are_read)
+    samples = store.sample_native(
+        "ALMA", year=2017, month="Apr", day=11, utc_hours=1.5, form=form
+    )
+
+    summary = zarr.open_group(weather_dataset_v02, mode="r")[
+        "sites/ALMA/months/04/native_summary/{0}".format(form)
+    ]
+    expected = {
+        name: (np.asarray(summary[name][0]) + np.asarray(summary[name][1])) / 2.0
+        for name in (
+            "opacity",
+            "brightness_temperature",
+            "pwv_mm",
+            "wind_speed_m_s",
+            "surface_pressure_mbar",
+            "surface_temperature_k",
+        )
+    }
+    assert np.allclose(samples.opacity[0], expected["opacity"])
+    assert np.allclose(samples.brightness_temperature[0], expected["brightness_temperature"])
+    assert np.allclose(samples.pwv_mm, [expected["pwv_mm"]])
+    assert np.allclose(samples.wind_speed_m_s, [expected["wind_speed_m_s"]])
+    assert np.allclose(samples.surface_pressure_mbar, [expected["surface_pressure_mbar"]])
+    assert np.allclose(samples.surface_temperature_k, [expected["surface_temperature_k"]])
+
+
+def test_store_rejects_nonfinite_precomputed_native_summary(weather_dataset_v02):
+    root = zarr.open_group(weather_dataset_v02, mode="r+")
+    root["sites/ALMA/months/04/native_summary/median/opacity"][0, 0] = np.nan
+
+    with pytest.raises(WeatherStoreError, match="Native weather summary.*non-finite"):
+        ZarrWeatherStore(weather_dataset_v02).sample_native(
+            "ALMA", year=2017, month="Apr", day=11, utc_hours=0.0, form="median"
+        )
 
 
 @pytest.mark.parametrize("form", ["all", "random", "unknown"])


### PR DESCRIPTION
Add Zarr schema v0.2.0 support for precomputed physical native weather summaries. Preserve schema v0.1.0 fallback behavior, validate summary products at read time, and verify the optimized path does not read raw native records.