### PR TITLE
Document Zarr weather release v0.2.0

### DIFF
--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -17,7 +17,7 @@ explicitly and pass the resulting store to the generator. Omitting
    from ngehtsim.obs import obs_generator
    from ngehtsim.weather.zarr_store import ZarrWeatherStore
 
-   store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr")
+   store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.2.0.zarr")
    obsgen = obs_generator.obs_generator(settings=settings, weather_store=store)
 
 By default, this continues to use the release's daily weather aggregates. To

--- a/docs/source/weather.rst
+++ b/docs/source/weather.rst
@@ -15,11 +15,20 @@ The versioned MERRA-2 weather releases are distributed separately from the
 Python package. After downloading a release to a local directory, install the
 optional Zarr dependency and open it with an explicit path:
 
+The current release is
+`ngehtsim-weather-merra2-3hour-v0.2.0 <https://drive.google.com/drive/folders/18NOmRZrZytD4zmKuOFYsaHzB_e3O-Bk5?usp=drive_link>`_.
+Download the complete ``.zarr`` directory without changing its internal
+layout. Its
+`release manifest <https://drive.google.com/file/d/1rSX4uMIEyW99Yj-BeVworYgg-7r_wPsi/view?usp=drive_link>`_
+records the source inputs, builder revision, schema, and coverage validation.
+All published releases are available from the
+`weather release folder <https://drive.google.com/drive/folders/1ElKYZJPfFoJCKNxzLCAxFXyeNO5f6Jx6?usp=drive_link>`_.
+
 .. code-block:: python
 
    from ngehtsim.weather.zarr_store import ZarrWeatherStore
 
-   store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.1.0.zarr")
+   store = ZarrWeatherStore("/path/to/ngehtsim-weather-merra2-3hour-v0.2.0.zarr")
    april_weather = store.read_partition("ALMA", "Apr", cadence="daily")
 
 The established weather functions can use that store directly. Without the
@@ -38,6 +47,8 @@ Native three-hour weather can be sampled at arbitrary UTC-hour offsets with
 linear interpolation between consecutive stored records. ``form`` accepts
 ``"exact"``, ``"mean"``, ``"median"``, ``"good"``, and ``"bad"``; summary
 forms are evaluated independently at each stored UTC time before interpolation.
+Schema v0.2.0 stores these physical native summary products in the release,
+avoiding the one-time reconstruction of every historical native spectrum.
 The result always has a leading sample dimension, including for one requested
 time:
 

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -11,6 +11,9 @@ import ngehtsim.weather.weather as weather
 from ngehtsim.weather.zarr_store import SUPPORTED_SCHEMA_VERSIONS, ZarrWeatherStore
 
 
+DEFAULT_DATASET_ID = "ngehtsim-weather-merra2-3hour-v0.1.0"
+EXPECTED_DATASET_ID_ENVIRONMENT_VARIABLE = "NGEHTSIM_WEATHER_ZARR_DATASET_ID"
+
 WEATHER_FUNCTIONS = (
     (weather.opacity_spectrum, {}),
     (weather.brightness_temperature_spectrum, {}),
@@ -51,7 +54,11 @@ def external_store():
 @pytest.mark.external_weather
 def test_local_weather_release_has_expected_schema_and_alma_coverage(external_store):
     assert external_store.attributes["schema_version"] in SUPPORTED_SCHEMA_VERSIONS
-    assert external_store.dataset_id == "ngehtsim-weather-merra2-3hour-v0.1.0"
+    expected_dataset_id = os.environ.get(
+        EXPECTED_DATASET_ID_ENVIRONMENT_VARIABLE,
+        DEFAULT_DATASET_ID,
+    )
+    assert external_store.dataset_id == expected_dataset_id
     assert len(external_store.sites) == 141
 
     daily = external_store.read_partition("ALMA", "Apr", cadence="daily")
@@ -59,6 +66,34 @@ def test_local_weather_release_has_expected_schema_and_alma_coverage(external_st
     assert daily.record_count * 8 == native.record_count
     assert np.all(np.isfinite(external_store.reconstruct_tau_spectra(daily)))
     assert np.all(np.isfinite(external_store.reconstruct_tb_spectra(daily)))
+
+
+@pytest.mark.external_weather
+def test_schema_v02_reads_precomputed_native_summaries(external_store, monkeypatch):
+    if external_store.attributes["schema_version"] != "0.2.0":
+        pytest.skip("Precomputed native summaries were introduced in schema v0.2.0.")
+
+    external_store._native_summary_cache.clear()
+
+    def fail_if_legacy_summary_fallback_is_used(*args, **kwargs):
+        raise AssertionError("Schema v0.2.0 must not reconstruct native summary products.")
+
+    monkeypatch.setattr(
+        external_store,
+        "_summarize_native_partition",
+        fail_if_legacy_summary_fallback_is_used,
+    )
+    samples = external_store.sample_native(
+        "ALMA",
+        year=2017,
+        month="Apr",
+        day=11,
+        utc_hours=[0.0, 1.5, 3.0],
+        form="median",
+    )
+
+    assert samples.opacity.shape == (3, len(external_store.frequency_ghz))
+    assert np.all(np.isfinite(samples.opacity))
 
 
 @pytest.mark.external_weather


### PR DESCRIPTION
Document the published v0.2.0 weather release and provenance manifest, update Zarr examples, and make external-release acceptance tests configurable for either v0.1.0 or v0.2.0 datasets.