### PR TITLE
Test Python 3.13 and 3.14 in CI

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -17,9 +17,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py311, py312, coverage
+envlist = py311, py312, py313, py314, coverage
+skip_missing_interpreters = true
 
 [testenv]
 deps =


### PR DESCRIPTION
Expand unit-test coverage to CPython 3.11 through 3.14 on Ubuntu and macOS. Update tox environments while allowing local tox runs to skip interpreters that are not installed.