### PR TITLE
Add internal ground-array geometry kernel

### DIFF
--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -1,6 +1,14 @@
 ###################################################
 # cache key construction
 
+from dataclasses import dataclass
+
+import numpy as np
+from astropy.constants import c as SPEED_OF_LIGHT
+from astropy.time import Time
+import ehtim as eh
+
+
 GEOMETRY_CACHE_FIELDS = (
     "sites",
     "ra",
@@ -13,6 +21,17 @@ GEOMETRY_CACHE_FIELDS = (
     "t_stop",
     "mjd",
 )
+
+
+@dataclass(frozen=True)
+class GroundGeometry:
+    """Ground-station observation rows independent of ``ehtim.Obsdata``."""
+
+    time_hours: np.ndarray
+    station1_indices: np.ndarray
+    station2_indices: np.ndarray
+    u: np.ndarray
+    v: np.ndarray
 
 
 def _cache_value(value):
@@ -42,7 +61,137 @@ def needs_new_empty_observation(obs_empty, cached_key, context):
     return (obs_empty is None) or (cached_key != geometry_cache_key(context))
 
 
-def make_empty_observation(array, context):
+def _has_space_station(array):
+    coordinates = np.column_stack((array.tarr["x"], array.tarr["y"], array.tarr["z"]))
+    return np.any(np.all(coordinates == 0.0, axis=1))
+
+
+def _observation_times(context):
+    t_start = float(context["t_start"])
+    t_stop = float(context["t_stop"])
+    if t_stop < t_start:
+        t_stop += 24.0
+    return np.arange(t_start, t_stop, float(context["t_rest"]) / 3600.0)
+
+
+def ground_geometry(array, context):
+    """Generate ground-array baseline rows without ``ehtim`` geometry helpers."""
+
+    if _has_space_station(array):
+        raise ValueError("Ground geometry does not support spacecraft stations.")
+
+    times = _observation_times(context)
+    station1, station2 = np.triu_indices(len(array.tarr), k=1)
+    if not len(times) or not len(station1):
+        raise ValueError("Ground geometry requires at least one timestamp and baseline.")
+
+    row_station1 = np.repeat(station1, len(times))
+    row_station2 = np.repeat(station2, len(times))
+    row_times = np.tile(times, len(station1))
+    time_object = Time(
+        np.floor(float(context["mjd"])) + (times / 24.0),
+        format="mjd",
+        scale="utc",
+    )
+    sidereal_hours = np.tile(
+        time_object.sidereal_time("mean", "greenwich").hour,
+        len(station1),
+    )
+    theta = np.mod((sidereal_hours - float(context["ra"])) * (np.pi / 12.0), 2.0 * np.pi)
+
+    coordinates = np.column_stack((array.tarr["x"], array.tarr["y"], array.tarr["z"]))
+    coordinate1 = coordinates[row_station1]
+    coordinate2 = coordinates[row_station2]
+    cosine = np.cos(theta)
+    sine = np.sin(theta)
+
+    def rotate(coordinate):
+        return np.column_stack((
+            (cosine * coordinate[:, 0]) - (sine * coordinate[:, 1]),
+            (sine * coordinate[:, 0]) + (cosine * coordinate[:, 1]),
+            coordinate[:, 2],
+        ))
+
+    coordinate1 = rotate(coordinate1)
+    coordinate2 = rotate(coordinate2)
+
+    declination = np.deg2rad(float(context["dec"]))
+    source_vector = np.array((np.cos(declination), 0.0, np.sin(declination)))
+    projection_u = np.cross(np.array((0.0, 0.0, 1.0)), source_vector)
+    projection_u /= np.linalg.norm(projection_u)
+    projection_v = -np.cross(projection_u, source_vector)
+    wavelength = SPEED_OF_LIGHT.to_value("m / s") / float(context["rf"])
+    baseline = (coordinate1 - coordinate2) / wavelength
+
+    elevation1 = np.rad2deg(
+        0.5 * np.pi - np.arccos(
+            np.sum(coordinate1 * source_vector, axis=1)
+            / np.linalg.norm(coordinate1, axis=1)
+        )
+    )
+    elevation2 = np.rad2deg(
+        0.5 * np.pi - np.arccos(
+            np.sum(coordinate2 * source_vector, axis=1)
+            / np.linalg.norm(coordinate2, axis=1)
+        )
+    )
+    visible = (elevation1 > -90.0) & (elevation1 < 90.0)
+    visible &= (elevation2 > -90.0) & (elevation2 < 90.0)
+
+    return GroundGeometry(
+        time_hours=row_times[visible],
+        station1_indices=row_station1[visible],
+        station2_indices=row_station2[visible],
+        u=baseline[visible] @ projection_u,
+        v=baseline[visible] @ projection_v,
+    )
+
+
+def _ground_geometry_obsdata(array, context, geometry):
+    """Adapt internal ground geometry to the established ``ehtim.Obsdata`` boundary."""
+
+    data = np.zeros(len(geometry.time_hours), dtype=eh.const_def.DTPOL_CIRC)
+    data["time"] = geometry.time_hours
+    data["tint"] = float(context["t_int"])
+    data["t1"] = array.tarr["site"][geometry.station1_indices]
+    data["t2"] = array.tarr["site"][geometry.station2_indices]
+    data["u"] = geometry.u
+    data["v"] = geometry.v
+
+    sefd1r = array.tarr["sefdr"][geometry.station1_indices]
+    sefd2r = array.tarr["sefdr"][geometry.station2_indices]
+    sefd1l = array.tarr["sefdl"][geometry.station1_indices]
+    sefd2l = array.tarr["sefdl"][geometry.station2_indices]
+    denominator = 2.0 * float(context["bandwidth_hz"]) * float(context["t_int"])
+    data["rrsigma"] = np.sqrt(sefd1r * sefd2r / denominator) / 0.88
+    data["llsigma"] = np.sqrt(sefd1l * sefd2l / denominator) / 0.88
+    data["rlsigma"] = np.sqrt(sefd1r * sefd2l / denominator) / 0.88
+    data["lrsigma"] = np.sqrt(sefd1l * sefd2r / denominator) / 0.88
+
+    scan_half_width = 0.5 * float(context["t_rest"])
+    scan_times = np.unique(geometry.time_hours)
+    scans = np.column_stack((scan_times - scan_half_width, scan_times + scan_half_width))
+    return eh.obsdata.Obsdata(
+        context["ra"],
+        context["dec"],
+        context["rf"],
+        context["bandwidth_hz"],
+        data,
+        array.tarr,
+        source=str(context["ra"]) + ":" + str(context["dec"]),
+        mjd=context["mjd"],
+        timetype="UTC",
+        polrep="circ",
+        ampcal=True,
+        phasecal=True,
+        opacitycal=True,
+        dcal=True,
+        frcal=True,
+        scantable=scans,
+    )
+
+
+def _legacy_empty_observation(array, context):
     return array.obsdata(
         context["ra"],
         context["dec"],
@@ -60,6 +209,12 @@ def make_empty_observation(array, context):
         elevmax=90,
         fix_theta_GMST=False,
     )
+
+
+def make_empty_observation(array, context):
+    if _has_space_station(array):
+        return _legacy_empty_observation(array, context)
+    return _ground_geometry_obsdata(array, context, ground_geometry(array, context))
 
 
 def ensure_empty_observation(obs_empty, cached_key, array, context):

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -1,13 +1,106 @@
+import numpy as np
 import pytest
+import ehtim as eh
 
+import ngehtsim.const_def as const
 from ngehtsim.obs.obs_generator import obs_generator
 import ngehtsim.obs.observation_geometry as observation_geometry
+from ngehtsim.obs.obs_generator import make_array
+import ngehtsim.obs.source_models as source_models
 
 
 @pytest.fixture
 def array_and_context():
     obsgen = obs_generator(settings={"weather": "exact", "source": "M87"})
     return obsgen.arr, obsgen.geometry_context()
+
+
+def geometry_context(array_name):
+    return {
+        "sites": tuple(const.known_arrays[array_name]),
+        "ra": 12.5,
+        "dec": 12.4,
+        "rf": 230.0e9,
+        "bandwidth_hz": 2.0e9,
+        "t_int": 600.0,
+        "t_rest": 1800.0,
+        "t_start": 0.0,
+        "t_stop": 3.0,
+        "mjd": 57855,
+    }
+
+
+@pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
+def test_ground_geometry_matches_legacy_ehtim_template(array_name):
+    array = make_array(const.known_arrays[array_name])
+    context = geometry_context(array_name)
+
+    legacy = observation_geometry._legacy_empty_observation(array, context)
+    internal = observation_geometry.make_empty_observation(array, context)
+
+    assert np.array_equal(internal.data["t1"], legacy.data["t1"])
+    assert np.array_equal(internal.data["t2"], legacy.data["t2"])
+    for field in ("time", "tint", "tau1", "tau2", "u", "v", "rrsigma", "llsigma", "rlsigma", "lrsigma"):
+        assert np.allclose(internal.data[field], legacy.data[field], rtol=1.0e-9, atol=1.0e-12)
+    assert np.allclose(internal.scans, legacy.scans)
+
+
+def test_ground_geometry_path_does_not_call_legacy_obsdata(array_and_context, monkeypatch):
+    array, context = array_and_context
+
+    def unexpected_legacy_path(*args, **kwargs):
+        raise AssertionError("Ground arrays must use internal geometry.")
+
+    monkeypatch.setattr(observation_geometry, "_legacy_empty_observation", unexpected_legacy_path)
+    obs = observation_geometry.make_empty_observation(array, context)
+
+    assert len(obs.data) > 0
+
+
+def test_ground_geometry_preserves_ehtim_model_visibilities():
+    array = make_array(const.known_arrays["EHT2017"])
+    context = geometry_context("EHT2017")
+    source_context = {
+        "ra": context["ra"],
+        "dec": context["dec"],
+        "mjd": context["mjd"],
+        "source": "M87",
+        "rf": context["rf"],
+        "ttype": "fast",
+        "fft_pad_factor": 2,
+        "verbosity": 0,
+    }
+    model = eh.model.Model().add_circ_gauss(F0=1.0, FWHM=40.0 * eh.RADPERUAS)
+
+    legacy, _ = source_models.observe_source(
+        model,
+        observation_geometry._legacy_empty_observation(array, context),
+        source_context,
+    )
+    internal, _ = source_models.observe_source(
+        model,
+        observation_geometry.make_empty_observation(array, context),
+        source_context,
+    )
+
+    for field in ("rrvis", "llvis", "rlvis", "lrvis"):
+        assert np.allclose(internal.data[field], legacy.data[field], rtol=1.0e-9, atol=1.0e-12)
+
+
+def test_space_station_uses_legacy_geometry_fallback(array_and_context, monkeypatch):
+    array, context = array_and_context
+    array.tarr[0]["x"] = 0.0
+    array.tarr[0]["y"] = 0.0
+    array.tarr[0]["z"] = 0.0
+    sentinel = object()
+
+    monkeypatch.setattr(
+        observation_geometry,
+        "_legacy_empty_observation",
+        lambda array, context: sentinel,
+    )
+
+    assert observation_geometry.make_empty_observation(array, context) is sentinel
 
 
 def test_geometry_cache_key_changes_when_geometry_context_changes(array_and_context):


### PR DESCRIPTION
Vectorize ground-array UV geometry using NumPy and Astropy, retain the ehtim Obsdata compatibility boundary, and preserve the legacy geometry path for spacecraft.