### PR TITLE
Restore fast legacy exact weather lookup

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,10 @@ Run one scenario with more repeats:
 MPLBACKEND=Agg python3 benchmarks/benchmark_synthetic_data.py --repeats 5 --warmups 1 --scenario eht2017_model_clean_reused_generator
 ```
 
+The `eht2017_model_exact_weather` scenario measures fresh-generator
+initialization with exact-date packaged weather. It protects the fast
+select-before-reconstruct path used by repeated timestamp workflows.
+
 ## Compare Weather Backends
 
 The default is the packaged daily weather backend, preserving the original

--- a/benchmarks/benchmark_synthetic_data.py
+++ b/benchmarks/benchmark_synthetic_data.py
@@ -55,6 +55,14 @@ SCENARIOS = [
         "reuse_generator": False,
     },
     {
+        "name": "eht2017_model_exact_weather",
+        "description": "EHT2017 array, analytic ehtim Model source, exact-date weather, and a fresh generator.",
+        "settings": {**base_settings("EHT2017"), "weather": "exact"},
+        "input_kind": "model",
+        "make_obs_kwargs": {"addnoise": False, "addgains": False},
+        "reuse_generator": False,
+    },
+    {
         "name": "eht2017_model_corruptions",
         "description": "EHT2017 array, analytic ehtim Model source, thermal noise and gain corruptions enabled.",
         "settings": base_settings("EHT2017"),

--- a/ngehtsim/weather/weather.py
+++ b/ngehtsim/weather/weather.py
@@ -185,25 +185,62 @@ def _remove_false_february_entries(years, days, values, monthnam):
     return years[keep], days[keep], values[keep]
 
 
-def _legacy_records(site, monthnum, monthnam, quantity, path_to_weather):
-    filenames = {
-        "tau": "tau.txt",
-        "tb": "Tb.txt",
-        "pressure": "Pbase.txt",
-        "temperature": "Tbase.txt",
-        "pwv": "PWV.txt",
-        "windspeed": "windspeed.txt",
-    }
-    filename = os.path.join(str(path_to_weather), site, monthnum + monthnam, filenames[quantity])
+_WEATHER_FILENAMES = {
+    "tau": "tau.txt",
+    "tb": "Tb.txt",
+    "pressure": "Pbase.txt",
+    "temperature": "Tbase.txt",
+    "pwv": "PWV.txt",
+    "windspeed": "windspeed.txt",
+}
 
+
+def _legacy_weather_filename(site, monthnum, monthnam, quantity, path_to_weather):
+    return os.path.join(
+        str(path_to_weather), site, monthnum + monthnam, _WEATHER_FILENAMES[quantity]
+    )
+
+
+def _legacy_atmospheric_records(site, monthnum, monthnam, quantity, path_to_weather):
+    filename = _legacy_weather_filename(
+        site, monthnum, monthnam, quantity, path_to_weather
+    )
+    years, _, days, coefficients = read_binary_atm(filename)
+    return _remove_false_february_entries(years, days, coefficients, monthnam)
+
+
+def _legacy_records(site, monthnum, monthnam, quantity, path_to_weather):
     if quantity in ("tau", "tb"):
-        years, _, days, coefficients = read_binary_atm(filename)
+        years, days, coefficients = _legacy_atmospheric_records(
+            site, monthnum, monthnam, quantity, path_to_weather
+        )
         reconstruct = reconstruct_spectrum_tau if quantity == "tau" else reconstruct_spectrum_Tb
         values = np.array([reconstruct(coefficients[index]) for index in range(len(coefficients))])
     else:
+        filename = _legacy_weather_filename(
+            site, monthnum, monthnam, quantity, path_to_weather
+        )
         years, _, days, values = read_binary_weather(filename)
 
     return _remove_false_february_entries(years, days, values, monthnam)
+
+
+def _legacy_spectrum(site, form, month, day, year, path_to_weather, quantity):
+    monthnum, monthnam = _parse_month(month)
+    years, days, coefficients = _legacy_atmospheric_records(
+        site, monthnum, monthnam, quantity, path_to_weather
+    )
+    reconstruct = reconstruct_spectrum_tau if quantity == "tau" else reconstruct_spectrum_Tb
+
+    if form == "exact":
+        return reconstruct(
+            _select_weather_values(coefficients, years, days, form, day, year)
+        )
+
+    spectra = np.array([
+        reconstruct(coefficients[index]) for index in range(len(coefficients))
+    ])
+    return _select_weather_values(spectra, years, days, form, day, year)
 
 
 def _zarr_records(store, site, month, quantity):
@@ -252,6 +289,11 @@ def _select_weather_values(values, years, days, form, day, year):
 
 
 def _spectrum(site, form, month, day, year, path_to_weather, weather_store, quantity):
+    if weather_store is None:
+        return _legacy_spectrum(
+            site, form, month, day, year, path_to_weather, quantity
+        )
+
     years, days, spectra = _weather_records(
         site, month, quantity, path_to_weather, weather_store
     )

--- a/tests/test_weather_lookup.py
+++ b/tests/test_weather_lookup.py
@@ -51,6 +51,31 @@ def test_exact_spectrum_weather_month_aliases(weather_function, month):
     assert np.allclose(result, reference, equal_nan=True)
 
 
+@pytest.mark.parametrize(
+    ("weather_function", "reconstructor_name"),
+    [
+        (nw.opacity_spectrum, "reconstruct_spectrum_tau"),
+        (nw.brightness_temperature_spectrum, "reconstruct_spectrum_Tb"),
+    ],
+)
+def test_exact_spectrum_reconstructs_only_the_requested_legacy_record(
+    weather_function, reconstructor_name, monkeypatch
+):
+    original_reconstructor = getattr(nw, reconstructor_name)
+    calls = []
+
+    def count_reconstructions(coefficients):
+        calls.append(np.asarray(coefficients))
+        return original_reconstructor(coefficients)
+
+    monkeypatch.setattr(nw, reconstructor_name, count_reconstructions)
+
+    result = weather_function("ALMA", form="exact", month="Apr", day=11, year=2017)
+
+    assert len(calls) == 1
+    assert np.all(np.isfinite(result))
+
+
 @pytest.mark.parametrize("weather_function, extra_kwargs", SCALAR_WEATHER_FUNCTIONS)
 def test_february_scalar_integer_month_matches_named_month(weather_function, extra_kwargs):
     kwargs = dict(site="ALMA", form="median")


### PR DESCRIPTION
Select exact-date legacy weather coefficients before reconstructing spectra, and add regression coverage and a benchmark scenario.