### PR TITLE
Build ground visibility templates natively

### DIFF
--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -8,6 +8,12 @@ from astropy.constants import c as SPEED_OF_LIGHT
 from astropy.time import Time
 import ehtim as eh
 
+from ngehtsim.obs.visibility_dataset import (
+    CIRCULAR_CORRELATIONS,
+    StationTable,
+    VisibilityDataset,
+)
+
 
 GEOMETRY_CACHE_FIELDS = (
     "sites",
@@ -30,6 +36,7 @@ class GroundGeometry:
     time_hours: np.ndarray
     station1_indices: np.ndarray
     station2_indices: np.ndarray
+    uvw_m: np.ndarray
     u: np.ndarray
     v: np.ndarray
 
@@ -120,8 +127,13 @@ def ground_geometry(array, context):
     projection_u = np.cross(np.array((0.0, 0.0, 1.0)), source_vector)
     projection_u /= np.linalg.norm(projection_u)
     projection_v = -np.cross(projection_u, source_vector)
+    baseline_m = coordinate1 - coordinate2
+    uvw_m = np.column_stack((
+        baseline_m @ projection_u,
+        baseline_m @ projection_v,
+        baseline_m @ source_vector,
+    ))
     wavelength = SPEED_OF_LIGHT.to_value("m / s") / float(context["rf"])
-    baseline = (coordinate1 - coordinate2) / wavelength
 
     elevation1 = np.rad2deg(
         0.5 * np.pi - np.arccos(
@@ -142,53 +154,91 @@ def ground_geometry(array, context):
         time_hours=row_times[visible],
         station1_indices=row_station1[visible],
         station2_indices=row_station2[visible],
-        u=baseline[visible] @ projection_u,
-        v=baseline[visible] @ projection_v,
+        uvw_m=uvw_m[visible],
+        u=uvw_m[visible, 0] / wavelength,
+        v=uvw_m[visible, 1] / wavelength,
     )
 
 
-def _ground_geometry_obsdata(array, context, geometry):
-    """Adapt internal ground geometry to the established ``ehtim.Obsdata`` boundary."""
+def ground_visibility_template(array, context, geometry=None):
+    """Build a native visibility template for a ground-only array.
 
-    data = np.zeros(len(geometry.time_hours), dtype=eh.const_def.DTPOL_CIRC)
-    data["time"] = geometry.time_hours
-    data["tint"] = float(context["t_int"])
-    data["t1"] = array.tarr["site"][geometry.station1_indices]
-    data["t2"] = array.tarr["site"][geometry.station2_indices]
-    data["u"] = geometry.u
-    data["v"] = geometry.v
+    The template carries geometry and thermal weights but contains zero-valued
+    circular visibilities. Source sampling remains at the ``ehtim`` adapter
+    boundary until native source adapters are introduced.
+    """
+
+    if geometry is None:
+        geometry = ground_geometry(array, context)
 
     sefd1r = array.tarr["sefdr"][geometry.station1_indices]
     sefd2r = array.tarr["sefdr"][geometry.station2_indices]
     sefd1l = array.tarr["sefdl"][geometry.station1_indices]
     sefd2l = array.tarr["sefdl"][geometry.station2_indices]
     denominator = 2.0 * float(context["bandwidth_hz"]) * float(context["t_int"])
-    data["rrsigma"] = np.sqrt(sefd1r * sefd2r / denominator) / 0.88
-    data["llsigma"] = np.sqrt(sefd1l * sefd2l / denominator) / 0.88
-    data["rlsigma"] = np.sqrt(sefd1r * sefd2l / denominator) / 0.88
-    data["lrsigma"] = np.sqrt(sefd1l * sefd2r / denominator) / 0.88
+    sigma = np.column_stack((
+        np.sqrt(sefd1r * sefd2r / denominator) / 0.88,
+        np.sqrt(sefd1l * sefd2l / denominator) / 0.88,
+        np.sqrt(sefd1r * sefd2l / denominator) / 0.88,
+        np.sqrt(sefd1l * sefd2r / denominator) / 0.88,
+    ))
 
-    scan_half_width = 0.5 * float(context["t_rest"])
+    scan_half_width_s = 0.5 * float(context["t_rest"])
     scan_times = np.unique(geometry.time_hours)
-    scans = np.column_stack((scan_times - scan_half_width, scan_times + scan_half_width))
-    return eh.obsdata.Obsdata(
-        context["ra"],
-        context["dec"],
-        context["rf"],
-        context["bandwidth_hz"],
-        data,
-        array.tarr,
+    reference_mjd = float(context["mjd"])
+    time_mjd = reference_mjd + (geometry.time_hours / 24.0)
+    scan_start_mjd = reference_mjd + (scan_times / 24.0) - (scan_half_width_s / 86400.0)
+    scan_stop_mjd = reference_mjd + (scan_times / 24.0) + (scan_half_width_s / 86400.0)
+
+    return VisibilityDataset(
+        stations=StationTable.from_ehtim_tarr(array.tarr),
+        time_mjd=time_mjd,
+        integration_time_s=np.full(len(time_mjd), float(context["t_int"])),
+        antenna1=geometry.station1_indices,
+        antenna2=geometry.station2_indices,
+        uvw_m=geometry.uvw_m,
+        tau1=np.zeros(len(time_mjd)),
+        tau2=np.zeros(len(time_mjd)),
+        channel_frequency_hz=np.array((float(context["rf"]),)),
+        channel_bandwidth_hz=np.array((float(context["bandwidth_hz"]),)),
+        spectral_window_id=np.array((0,), dtype=np.intp),
+        correlation_layouts=(CIRCULAR_CORRELATIONS,),
+        row_layout_id=np.zeros(len(time_mjd), dtype=np.intp),
+        visibilities=np.zeros((len(time_mjd), 1, 4), dtype=complex),
+        weights=(1.0 / np.square(sigma))[:, np.newaxis, :],
+        flags=np.zeros((len(time_mjd), 1, 4), dtype=bool),
         source=str(context["ra"]) + ":" + str(context["dec"]),
-        mjd=context["mjd"],
-        timetype="UTC",
-        polrep="circ",
+        ra_hours=float(context["ra"]),
+        dec_degrees=float(context["dec"]),
         ampcal=True,
         phasecal=True,
         opacitycal=True,
         dcal=True,
         frcal=True,
-        scantable=scans,
+        scan_start_mjd=scan_start_mjd,
+        scan_stop_mjd=scan_stop_mjd,
     )
+
+
+def _ground_geometry_obsdata(array, context, geometry):
+    """Adapt the native ground visibility template to the ``ehtim`` boundary."""
+
+    obs = ground_visibility_template(
+        array,
+        context,
+        geometry=geometry,
+    ).to_ehtim_obsdata()
+
+    # ehtim's Array.obsdata() currently uses tadv seconds as if they were
+    # hours when it creates its scan table. Preserve that legacy public output
+    # until scan metadata can be corrected in a dedicated compatibility change.
+    scan_half_width_hours = 0.5 * float(context["t_rest"])
+    scan_times = np.unique(geometry.time_hours)
+    obs.scans = np.column_stack((
+        scan_times - scan_half_width_hours,
+        scan_times + scan_half_width_hours,
+    ))
+    return obs
 
 
 def _legacy_empty_observation(array, context):

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -378,8 +378,6 @@ class VisibilityDataset:
             raise ValueError("ehtim Obsdata output requires at least one visibility row.")
 
         reference_mjd = int(np.floor(np.min(self.time_mjd)))
-        if np.any(np.floor(self.time_mjd) != reference_mjd):
-            raise ValueError("ehtim Obsdata output cannot represent rows spanning multiple MJD days.")
 
         import ehtim as eh
 

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -7,6 +7,7 @@ from ngehtsim.obs.obs_generator import obs_generator
 import ngehtsim.obs.observation_geometry as observation_geometry
 from ngehtsim.obs.obs_generator import make_array
 import ngehtsim.obs.source_models as source_models
+from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, VisibilityDataset
 
 
 @pytest.fixture
@@ -45,16 +46,66 @@ def test_ground_geometry_matches_legacy_ehtim_template(array_name):
     assert np.allclose(internal.scans, legacy.scans)
 
 
+@pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
+def test_ground_visibility_template_preserves_legacy_visibility_rows(array_name):
+    array = make_array(const.known_arrays[array_name])
+    context = geometry_context(array_name)
+
+    legacy = observation_geometry._legacy_empty_observation(array, context)
+    template = observation_geometry.ground_visibility_template(array, context)
+    adapted = template.to_ehtim_obsdata()
+
+    assert isinstance(template, VisibilityDataset)
+    assert template.channel_count == 1
+    assert template.correlation_layouts == (CIRCULAR_CORRELATIONS,)
+    assert np.allclose(template.time_mjd, legacy.mjd + (legacy.data["time"] / 24.0))
+    geometry = observation_geometry.ground_geometry(array, context)
+    assert np.array_equal(template.antenna1, geometry.station1_indices)
+    assert np.array_equal(template.antenna2, geometry.station2_indices)
+    assert np.allclose(template.uvw_m, geometry.uvw_m)
+    for field in ("time", "tint", "tau1", "tau2", "u", "v", "rrsigma", "llsigma", "rlsigma", "lrsigma"):
+        assert np.allclose(adapted.data[field], legacy.data[field], rtol=1.0e-9, atol=1.0e-12)
+    scan_times = np.unique(geometry.time_hours)
+    expected_scan_half_width_hours = 0.5 * context["t_rest"] / 3600.0
+    assert np.allclose(
+        adapted.scans,
+        np.column_stack((
+            scan_times - expected_scan_half_width_hours,
+            scan_times + expected_scan_half_width_hours,
+        )),
+    )
+
+
+def test_ground_visibility_template_preserves_rows_across_utc_midnight():
+    array = make_array(const.known_arrays["EHT2017"])
+    context = geometry_context("EHT2017")
+    context.update(t_start=22.0, t_stop=2.0)
+
+    template = observation_geometry.ground_visibility_template(array, context)
+    adapted = template.to_ehtim_obsdata()
+
+    assert np.max(template.time_mjd) - np.min(template.time_mjd) > 0.0
+    assert np.any(adapted.data["time"] >= 24.0)
+
+
 def test_ground_geometry_path_does_not_call_legacy_obsdata(array_and_context, monkeypatch):
     array, context = array_and_context
+    original_template = observation_geometry.ground_visibility_template
+    template_calls = []
 
     def unexpected_legacy_path(*args, **kwargs):
         raise AssertionError("Ground arrays must use internal geometry.")
 
+    def capture_template(*args, **kwargs):
+        template_calls.append((args, kwargs))
+        return original_template(*args, **kwargs)
+
     monkeypatch.setattr(observation_geometry, "_legacy_empty_observation", unexpected_legacy_path)
+    monkeypatch.setattr(observation_geometry, "ground_visibility_template", capture_template)
     obs = observation_geometry.make_empty_observation(array, context)
 
     assert len(obs.data) > 0
+    assert len(template_calls) == 1
 
 
 def test_ground_geometry_preserves_ehtim_model_visibilities():

--- a/tests/test_visibility_dataset.py
+++ b/tests/test_visibility_dataset.py
@@ -159,3 +159,21 @@ def test_ehtim_adapter_rejects_unrepresentable_datasets():
     )
     with pytest.raises(ValueError, match="flagged"):
         flagged.to_ehtim_obsdata()
+
+
+def test_ehtim_adapter_preserves_rows_across_mjd_boundaries():
+    original = dataset(
+        channel_frequency_hz=np.array((230.0e9,)),
+        channel_bandwidth_hz=np.array((2.0e9,)),
+        spectral_window_id=np.array((0,)),
+        correlation_layouts=(CIRCULAR_CORRELATIONS,),
+        row_layout_id=np.array((0, 0)),
+        visibilities=np.ones((2, 1, 4), dtype=complex),
+        weights=np.ones((2, 1, 4)),
+        flags=np.zeros((2, 1, 4), dtype=bool),
+        time_mjd=np.array((60000.99, 60001.01)),
+    )
+
+    restored = VisibilityDataset.from_ehtim_obsdata(original.to_ehtim_obsdata())
+
+    assert np.allclose(restored.time_mjd, original.time_mjd)


### PR DESCRIPTION
Construct ground-array observation templates as VisibilityDataset objects, retain ehtim compatibility at the boundary, and cover full UVW and multi-MJD adapter behavior.