### PR TITLE
Correct synthetic observation scan metadata

### DIFF
--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -183,7 +183,7 @@ def ground_visibility_template(array, context, geometry=None):
         np.sqrt(sefd1l * sefd2r / denominator) / 0.88,
     ))
 
-    scan_half_width_s = 0.5 * float(context["t_rest"])
+    scan_half_width_s = 0.5 * float(context["t_int"])
     scan_times = np.unique(geometry.time_hours)
     reference_mjd = float(context["mjd"])
     time_mjd = reference_mjd + (geometry.time_hours / 24.0)
@@ -223,22 +223,11 @@ def ground_visibility_template(array, context, geometry=None):
 def _ground_geometry_obsdata(array, context, geometry):
     """Adapt the native ground visibility template to the ``ehtim`` boundary."""
 
-    obs = ground_visibility_template(
+    return ground_visibility_template(
         array,
         context,
         geometry=geometry,
     ).to_ehtim_obsdata()
-
-    # ehtim's Array.obsdata() currently uses tadv seconds as if they were
-    # hours when it creates its scan table. Preserve that legacy public output
-    # until scan metadata can be corrected in a dedicated compatibility change.
-    scan_half_width_hours = 0.5 * float(context["t_rest"])
-    scan_times = np.unique(geometry.time_hours)
-    obs.scans = np.column_stack((
-        scan_times - scan_half_width_hours,
-        scan_times + scan_half_width_hours,
-    ))
-    return obs
 
 
 def _legacy_empty_observation(array, context):
@@ -261,10 +250,24 @@ def _legacy_empty_observation(array, context):
     )
 
 
+def _set_integration_scan_metadata(obs, context):
+    """Set scan intervals centered on integrations with widths in seconds."""
+
+    scan_half_width_hours = 0.5 * float(context["t_int"]) / 3600.0
+    scan_times = np.unique(obs.data["time"])
+    obs.scans = np.column_stack((
+        scan_times - scan_half_width_hours,
+        scan_times + scan_half_width_hours,
+    ))
+    return obs
+
+
 def make_empty_observation(array, context):
     if _has_space_station(array):
-        return _legacy_empty_observation(array, context)
-    return _ground_geometry_obsdata(array, context, ground_geometry(array, context))
+        obs = _legacy_empty_observation(array, context)
+    else:
+        obs = _ground_geometry_obsdata(array, context, ground_geometry(array, context))
+    return _set_integration_scan_metadata(obs, context)
 
 
 def ensure_empty_observation(obs_empty, cached_key, array, context):

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -31,8 +31,16 @@ def geometry_context(array_name):
     }
 
 
+def expected_scans(context, time_hours):
+    scan_half_width_hours = 0.5 * context["t_int"] / 3600.0
+    return np.column_stack((
+        time_hours - scan_half_width_hours,
+        time_hours + scan_half_width_hours,
+    ))
+
+
 @pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
-def test_ground_geometry_matches_legacy_ehtim_template(array_name):
+def test_ground_geometry_preserves_legacy_rows_and_corrects_scan_metadata(array_name):
     array = make_array(const.known_arrays[array_name])
     context = geometry_context(array_name)
 
@@ -43,7 +51,8 @@ def test_ground_geometry_matches_legacy_ehtim_template(array_name):
     assert np.array_equal(internal.data["t2"], legacy.data["t2"])
     for field in ("time", "tint", "tau1", "tau2", "u", "v", "rrsigma", "llsigma", "rlsigma", "lrsigma"):
         assert np.allclose(internal.data[field], legacy.data[field], rtol=1.0e-9, atol=1.0e-12)
-    assert np.allclose(internal.scans, legacy.scans)
+    assert np.allclose(internal.scans, expected_scans(context, np.unique(internal.data["time"])))
+    assert not np.allclose(internal.scans, legacy.scans)
 
 
 @pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
@@ -65,15 +74,49 @@ def test_ground_visibility_template_preserves_legacy_visibility_rows(array_name)
     assert np.allclose(template.uvw_m, geometry.uvw_m)
     for field in ("time", "tint", "tau1", "tau2", "u", "v", "rrsigma", "llsigma", "rlsigma", "lrsigma"):
         assert np.allclose(adapted.data[field], legacy.data[field], rtol=1.0e-9, atol=1.0e-12)
-    scan_times = np.unique(geometry.time_hours)
-    expected_scan_half_width_hours = 0.5 * context["t_rest"] / 3600.0
-    assert np.allclose(
-        adapted.scans,
-        np.column_stack((
-            scan_times - expected_scan_half_width_hours,
-            scan_times + expected_scan_half_width_hours,
-        )),
+    assert np.allclose(adapted.scans, expected_scans(context, np.unique(geometry.time_hours)))
+
+
+def test_ground_geometry_scan_groups_preserve_individual_snapshots():
+    array = make_array(const.known_arrays["EHT2017"])
+    context = geometry_context("EHT2017")
+    obs = observation_geometry.make_empty_observation(array, context)
+
+    scan_groups = obs.tlist(scan_gather=True)
+    scan_averaged = obs.avg_coherent(0.0, scan_avg=True)
+
+    assert len(scan_groups) == len(np.unique(obs.data["time"]))
+    assert len(scan_averaged.data) == len(obs.data)
+
+
+def test_obs_generator_outputs_scan_averaging_ready_data():
+    obsgen = obs_generator(
+        settings={
+            "weather": "exact",
+            "source": "M87",
+            "array": "EHT2017",
+            "dt": 3.0,
+            "t_int": 600.0,
+            "t_rest": 1800.0,
+            "fringe_finder": ["naive", 0.0],
+            "random_seed": 1,
+        }
     )
+    model = eh.model.Model().add_circ_gauss(F0=1.0, FWHM=40.0 * eh.RADPERUAS)
+
+    obs = obsgen.make_obs(
+        model,
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    scan_averaged = obs.avg_coherent(0.0, scan_avg=True)
+
+    assert len(obs.tlist(scan_gather=True)) == 6
+    assert len(scan_averaged.data) == len(obs.data)
+    assert np.allclose(obs.scans[:, 1] - obs.scans[:, 0], 600.0 / 3600.0)
 
 
 def test_ground_visibility_template_preserves_rows_across_utc_midnight():
@@ -143,15 +186,19 @@ def test_space_station_uses_legacy_geometry_fallback(array_and_context, monkeypa
     array.tarr[0]["x"] = 0.0
     array.tarr[0]["y"] = 0.0
     array.tarr[0]["z"] = 0.0
-    sentinel = object()
+    original_legacy_path = observation_geometry._legacy_empty_observation
+    calls = []
 
-    monkeypatch.setattr(
-        observation_geometry,
-        "_legacy_empty_observation",
-        lambda array, context: sentinel,
-    )
+    def capture_legacy_path(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_legacy_path(*args, **kwargs)
 
-    assert observation_geometry.make_empty_observation(array, context) is sentinel
+    monkeypatch.setattr(observation_geometry, "_legacy_empty_observation", capture_legacy_path)
+    with np.errstate(invalid="ignore"):
+        obs = observation_geometry.make_empty_observation(array, context)
+
+    assert len(calls) == 1
+    assert np.allclose(obs.scans, expected_scans(context, np.unique(obs.data["time"])))
 
 
 def test_geometry_cache_key_changes_when_geometry_context_changes(array_and_context):


### PR DESCRIPTION
Use integration durations for generated scan intervals so scan-aware ehtim operations preserve individual snapshots. Cover ground geometry, the spacecraft fallback, and obs_generator output.