### PR TITLE
Calculate ground station geometry natively

### DIFF
--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -41,6 +41,49 @@ class GroundGeometry:
     v: np.ndarray
 
 
+def _readonly_float_array(values):
+    array = np.array(values, dtype=float, copy=True)
+    if array.ndim != 1:
+        raise ValueError("Station geometry values must be one-dimensional.")
+    array.setflags(write=False)
+    return array
+
+
+@dataclass(frozen=True)
+class StationGeometry:
+    """Per-row ground-station elevation and parallactic angles in radians."""
+
+    elevation1_rad: np.ndarray
+    elevation2_rad: np.ndarray
+    parallactic_angle1_rad: np.ndarray
+    parallactic_angle2_rad: np.ndarray
+
+    def __post_init__(self):
+        elevation1_rad = _readonly_float_array(self.elevation1_rad)
+        elevation2_rad = _readonly_float_array(self.elevation2_rad)
+        parallactic_angle1_rad = _readonly_float_array(self.parallactic_angle1_rad)
+        parallactic_angle2_rad = _readonly_float_array(self.parallactic_angle2_rad)
+        shape = elevation1_rad.shape
+        if any(values.shape != shape for values in (
+            elevation2_rad,
+            parallactic_angle1_rad,
+            parallactic_angle2_rad,
+        )):
+            raise ValueError("Station geometry arrays must have matching shapes.")
+        if not all(np.all(np.isfinite(values)) for values in (
+            elevation1_rad,
+            elevation2_rad,
+            parallactic_angle1_rad,
+            parallactic_angle2_rad,
+        )):
+            raise ValueError("Station geometry arrays must contain finite values.")
+
+        object.__setattr__(self, "elevation1_rad", elevation1_rad)
+        object.__setattr__(self, "elevation2_rad", elevation2_rad)
+        object.__setattr__(self, "parallactic_angle1_rad", parallactic_angle1_rad)
+        object.__setattr__(self, "parallactic_angle2_rad", parallactic_angle2_rad)
+
+
 def _cache_value(value):
     if hasattr(value, "tolist"):
         value = value.tolist()
@@ -79,6 +122,87 @@ def _observation_times(context):
     if t_stop < t_start:
         t_stop += 24.0
     return np.arange(t_start, t_stop, float(context["t_rest"]) / 3600.0)
+
+
+def ground_station_geometry(obs):
+    """Calculate station angles for a UTC ground-array ``ehtim.Obsdata``.
+
+    Returns ``None`` for spacecraft-containing arrays or non-UTC observations,
+    which retain the established ``ehtim`` metadata path.
+    """
+
+    if getattr(obs, "timetype", None) != "UTC":
+        return None
+
+    coordinates = np.column_stack((obs.tarr["x"], obs.tarr["y"], obs.tarr["z"]))
+    if np.any(np.all(coordinates == 0.0, axis=1)):
+        return None
+
+    station_index = {str(site): index for index, site in enumerate(obs.tarr["site"])}
+    try:
+        antenna1 = np.fromiter(
+            (station_index[str(site)] for site in obs.data["t1"]),
+            dtype=np.intp,
+            count=len(obs.data),
+        )
+        antenna2 = np.fromiter(
+            (station_index[str(site)] for site in obs.data["t2"]),
+            dtype=np.intp,
+            count=len(obs.data),
+        )
+    except KeyError:
+        return None
+
+    times_sidereal = Time(
+        (np.asarray(obs.data["time"], dtype=float) / 24.0) + np.floor(float(obs.mjd)),
+        format="mjd",
+        scale="utc",
+    ).sidereal_time("mean", "greenwich").hour
+    ra_rad = float(obs.ra) * (np.pi / 12.0)
+    dec_rad = np.deg2rad(float(obs.dec))
+    hour_angle_rotation = np.mod(
+        (times_sidereal - float(obs.ra)) * (np.pi / 12.0),
+        2.0 * np.pi,
+    )
+    source_vector = np.array((np.cos(dec_rad), 0.0, np.sin(dec_rad)))
+
+    def station_angles(antenna):
+        station_coordinates = coordinates[antenna]
+        cosine = np.cos(hour_angle_rotation)
+        sine = np.sin(hour_angle_rotation)
+        rotated_coordinates = np.column_stack((
+            (cosine * station_coordinates[:, 0]) - (sine * station_coordinates[:, 1]),
+            (sine * station_coordinates[:, 0]) + (cosine * station_coordinates[:, 1]),
+            station_coordinates[:, 2],
+        ))
+        elevation = 0.5 * np.pi - np.arccos(
+            np.sum(rotated_coordinates * source_vector, axis=1)
+            / np.linalg.norm(rotated_coordinates, axis=1)
+        )
+        longitude = np.arctan2(station_coordinates[:, 1], station_coordinates[:, 0])
+        latitude = np.arctan2(
+            station_coordinates[:, 2],
+            np.hypot(station_coordinates[:, 0], station_coordinates[:, 1]),
+        )
+        hour_angle = np.mod(
+            (times_sidereal * (np.pi / 12.0)) + longitude - ra_rad,
+            2.0 * np.pi,
+        )
+        parallactic_angle = np.arctan2(
+            np.sin(hour_angle) * np.cos(latitude),
+            (np.sin(latitude) * np.cos(dec_rad))
+            - (np.cos(latitude) * np.sin(dec_rad) * np.cos(hour_angle)),
+        )
+        return elevation, parallactic_angle
+
+    elevation1, parallactic_angle1 = station_angles(antenna1)
+    elevation2, parallactic_angle2 = station_angles(antenna2)
+    return StationGeometry(
+        elevation1_rad=elevation1,
+        elevation2_rad=elevation2,
+        parallactic_angle1_rad=parallactic_angle1,
+        parallactic_angle2_rad=parallactic_angle2,
+    )
 
 
 def ground_geometry(array, context):

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -6,6 +6,7 @@ from astropy.time import Time
 from astropy.coordinates import EarthLocation, AltAz, get_sun
 
 import ngehtsim.const_def as const
+import ngehtsim.obs.observation_geometry as observation_geometry
 
 ###################################################
 # helpers
@@ -69,12 +70,19 @@ def station_metadata(obs, station_context, cache=None):
     t1 = obs.data["t1"]
     t2 = obs.data["t2"]
     sites_obs = np.unique(np.concatenate((t1, t2)))
-    els = obs.unpack(["el1", "el2"], ang_unit="rad")
-    pars = obs.unpack(["par_ang1", "par_ang2"], ang_unit="rad")
-    el1 = els["el1"]
-    el2 = els["el2"]
-    par1 = pars["par_ang1"]
-    par2 = pars["par_ang2"]
+    geometry = observation_geometry.ground_station_geometry(obs)
+    if geometry is None:
+        els = obs.unpack(["el1", "el2"], ang_unit="rad")
+        pars = obs.unpack(["par_ang1", "par_ang2"], ang_unit="rad")
+        el1 = els["el1"]
+        el2 = els["el2"]
+        par1 = pars["par_ang1"]
+        par2 = pars["par_ang2"]
+    else:
+        el1 = geometry.elevation1_rad
+        el2 = geometry.elevation2_rad
+        par1 = geometry.parallactic_angle1_rad
+        par2 = geometry.parallactic_angle2_rad
     times = obs.data["time"]
     tuniq = np.unique(times)
 

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -89,6 +89,34 @@ def test_ground_geometry_scan_groups_preserve_individual_snapshots():
     assert len(scan_averaged.data) == len(obs.data)
 
 
+@pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
+def test_ground_station_geometry_matches_ehtim_unpack(array_name):
+    array = make_array(const.known_arrays[array_name])
+    context = geometry_context(array_name)
+    obs = observation_geometry.make_empty_observation(array, context)
+
+    geometry = observation_geometry.ground_station_geometry(obs)
+    expected = obs.unpack(
+        ["el1", "el2", "par_ang1", "par_ang2"],
+        ang_unit="rad",
+    )
+
+    assert geometry is not None
+    assert np.allclose(geometry.elevation1_rad, expected["el1"], atol=1.0e-10)
+    assert np.allclose(geometry.elevation2_rad, expected["el2"], atol=1.0e-10)
+    assert np.allclose(
+        geometry.parallactic_angle1_rad,
+        expected["par_ang1"],
+        atol=1.0e-10,
+    )
+    assert np.allclose(
+        geometry.parallactic_angle2_rad,
+        expected["par_ang2"],
+        atol=1.0e-10,
+    )
+    assert not geometry.elevation1_rad.flags.writeable
+
+
 def test_obs_generator_outputs_scan_averaging_ready_data():
     obsgen = obs_generator(
         settings={
@@ -199,6 +227,7 @@ def test_space_station_uses_legacy_geometry_fallback(array_and_context, monkeypa
 
     assert len(calls) == 1
     assert np.allclose(obs.scans, expected_scans(context, np.unique(obs.data["time"])))
+    assert observation_geometry.ground_station_geometry(obs) is None
 
 
 def test_geometry_cache_key_changes_when_geometry_context_changes(array_and_context):

--- a/tests/test_station_observation.py
+++ b/tests/test_station_observation.py
@@ -93,6 +93,88 @@ def test_station_metadata_reuses_cached_geometry_terms():
     assert len(cache) == 1
 
 
+def test_station_metadata_ground_path_does_not_call_ehtim_unpack(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, _ = _source_observation(obsgen)
+
+    def unexpected_unpack(*args, **kwargs):
+        raise AssertionError("Ground station metadata must use native geometry.")
+
+    monkeypatch.setattr(obs, "unpack", unexpected_unpack)
+    metadata = station_observation.station_metadata(obs, obsgen.station_context())
+
+    assert len(metadata["el1"]) == len(obs.data)
+    assert len(metadata["par1"]) == len(obs.data)
+
+
+def test_native_station_metadata_matches_ehtim_fallback(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, _ = _source_observation(obsgen)
+    context = obsgen.station_context()
+
+    native = station_observation.station_metadata(obs, context)
+    monkeypatch.setattr(
+        station_observation.observation_geometry,
+        "ground_station_geometry",
+        lambda obs: None,
+    )
+    legacy = station_observation.station_metadata(obs, context)
+
+    for field in ("el1", "el2", "par1", "par2"):
+        assert np.allclose(native[field], legacy[field], atol=1.0e-10)
+
+
+def test_native_station_geometry_preserves_generated_observations(monkeypatch):
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["naive", 0.0]
+
+    native_generator = og.obs_generator(settings=settings)
+    native_obs = native_generator.make_obs(
+        _compact_model(),
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+        addFR=True,
+    )
+
+    monkeypatch.setattr(
+        station_observation.observation_geometry,
+        "ground_station_geometry",
+        lambda obs: None,
+    )
+    fallback_generator = og.obs_generator(settings=settings)
+    fallback_obs = fallback_generator.make_obs(
+        _compact_model(),
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+        addFR=True,
+    )
+
+    assert np.array_equal(native_obs.data["t1"], fallback_obs.data["t1"])
+    assert np.array_equal(native_obs.data["t2"], fallback_obs.data["t2"])
+    for field in (
+        "time",
+        "u",
+        "v",
+        "tau1",
+        "tau2",
+        "rrvis",
+        "llvis",
+        "rlvis",
+        "lrvis",
+        "rrsigma",
+        "llsigma",
+        "rlsigma",
+        "lrsigma",
+    ):
+        assert np.allclose(native_obs.data[field], fallback_obs.data[field], atol=1.0e-10)
+
+
 def test_station_metadata_cache_key_changes_with_station_context():
     obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
     obs, _ = _source_observation(obsgen)


### PR DESCRIPTION
Calculate ground-array elevation and parallactic angles without ehtim Obsdata.unpack, retain the spacecraft fallback, and preserve generated observations with regression coverage.