### PR TITLE
Sample ehtim movies directly

### DIFF
--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -89,15 +89,91 @@ class EhtimMovieAdapter(object):
     def observe(self, obs_empty, context, p=None):
         _set_ehtim_metadata(self.input_model, context)
 
-        obs = _run_quietly(
-            lambda: self.input_model.observe_same_nonoise(
-                obs_empty,
-                ttype=context["ttype"],
-                fft_pad_factor=context["fft_pad_factor"],
-                repeat=True,
-            ),
-            context["verbosity"],
-        )
+        def sample_observation():
+            # This reproduces ehtim.Movie.observe_same_nonoise() without
+            # constructing another Obsdata object around each time slice.
+            obs = obs_empty.copy()
+            obslist = obs_empty.tlist()
+            obstimes = np.array([obsdata[0]["time"] for obsdata in obslist])
+
+            if context["ttype"] not in ("direct", "fast", "nfft"):
+                raise Exception(
+                    "ttype={0}, options for ttype are 'direct', 'fast', 'nfft'".format(
+                        context["ttype"]
+                    )
+                )
+            if context["verbosity"] > 0:
+                print("Producing clean visibilities from movie with " + context["ttype"] + " FT . . . ")
+
+            if (obstimes < self.input_model.start_hr).any():
+                if context["verbosity"] > 0:
+                    print(
+                        "Some observation times before movie start time %f"
+                        % self.input_model.start_hr
+                    )
+                    print("Looping movie before start\\n")
+            if (obstimes > self.input_model.stop_hr).any():
+                if context["verbosity"] > 0:
+                    print(
+                        "Some observation times after movie stop time %f"
+                        % self.input_model.stop_hr
+                    )
+                    print("Looping movie after stop\\n")
+
+            sampled_rows = []
+            for obsdata in obslist:
+                time = obsdata[0]["time"]
+                if self.input_model.bounds_error:
+                    if time < self.input_model.start_hr or time > self.input_model.stop_hr:
+                        time = self.input_model.start_hr + np.mod(
+                            time - self.input_model.start_hr,
+                            self.input_model.duration,
+                        )
+
+                image = self.input_model.get_image(time)
+                uv = np.column_stack((obsdata["u"], obsdata["v"]))
+                sampled = image.sample_uv(
+                    uv,
+                    polrep_obs=obs.polrep,
+                    ttype=context["ttype"],
+                    fft_pad_factor=context["fft_pad_factor"],
+                    verbose=False,
+                )
+
+                if obs.polrep == "circ":
+                    obsdata["rrvis"] = sampled[0]
+                    if sampled[1] is not None:
+                        obsdata["llvis"] = sampled[1]
+                    if sampled[2] is not None:
+                        obsdata["rlvis"] = sampled[2]
+                        obsdata["lrvis"] = sampled[3]
+                elif obs.polrep == "stokes":
+                    obsdata["vis"] = sampled[0]
+                    if sampled[1] is not None:
+                        obsdata["qvis"] = sampled[1]
+                        obsdata["uvis"] = sampled[2]
+                        obsdata["vvis"] = sampled[3]
+                else:
+                    raise ValueError(
+                        "Unsupported ehtim observation polarization representation: {0}".format(
+                            obs.polrep
+                        )
+                    )
+
+                sampled_rows.append(obsdata)
+
+            if sampled_rows:
+                obs.data = np.hstack(sampled_rows)
+            obs.source = self.input_model.source
+            obs.mjd = np.floor(obs_empty.mjd)
+            obs.ampcal = True
+            obs.phasecal = True
+            obs.opacitycal = True
+            obs.dcal = True
+            obs.frcal = True
+            return obs
+
+        obs = _run_quietly(sample_observation, context["verbosity"])
 
         F0 = np.mean(self.input_model.lightcurve)
         return obs, F0

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -49,6 +49,29 @@ def _polarized_model():
     )
 
 
+def _polarized_movie():
+    grid = np.linspace(-1.0, 1.0, 32)
+    x, y = np.meshgrid(grid, grid)
+    frame_0 = np.exp(-6.0 * ((x + 0.20) ** 2 + (y - 0.10) ** 2))
+    frame_1 = 1.25 * np.exp(-6.0 * ((x - 0.20) ** 2 + (y + 0.10) ** 2))
+    frames = (frame_0, frame_1)
+    movie = eh.movie.Movie(
+        frames,
+        times=(0.0, 0.5),
+        psize=10.0 * eh.RADPERUAS,
+        ra=0.0,
+        dec=0.0,
+        rf=230.0e9,
+        source="M87",
+        mjd=57849,
+        bounds_error=True,
+    )
+    movie.add_pol_movie((0.20 * frame_0, 0.15 * frame_1), "Q")
+    movie.add_pol_movie((0.05 * frame_0, -0.10 * frame_1), "U")
+    movie.add_pol_movie((0.10 * frame_0, -0.05 * frame_1), "V")
+    return movie
+
+
 def _observe_without_corruptions(obsgen, input_model):
     return obsgen.observe(
         input_model,
@@ -90,6 +113,18 @@ def _legacy_image_observe(input_model, obs_empty, context):
     F0 = input_model.total_flux()
     return obs, F0
 
+
+def _legacy_movie_observe(input_model, obs_empty, context):
+    source_models._set_ehtim_metadata(input_model, context)
+    obs = input_model.observe_same_nonoise(
+        obs_empty,
+        ttype=context["ttype"],
+        fft_pad_factor=context["fft_pad_factor"],
+        repeat=True,
+    )
+    F0 = np.mean(input_model.lightcurve)
+    return obs, F0
+
 #######################################################
 # tests
 
@@ -105,6 +140,12 @@ def test_adapter_for_ehtim_image():
     adapter = source_models.adapter_for(image)
 
     assert isinstance(adapter, source_models.EhtimImageAdapter)
+
+
+def test_adapter_for_ehtim_movie():
+    adapter = source_models.adapter_for(_polarized_movie())
+
+    assert isinstance(adapter, source_models.EhtimMovieAdapter)
 
 
 def test_adapter_rejects_unsupported_model_type():
@@ -204,6 +245,56 @@ def test_ehtim_image_adapter_matches_legacy_full_polarization_sampling():
         assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
 
 
+def test_ehtim_movie_adapter_does_not_call_observe_same_nonoise(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    movie = _polarized_movie()
+
+    def unexpected_legacy_sampler(*args, **kwargs):
+        raise AssertionError("The movie adapter must sample the cached template directly.")
+
+    monkeypatch.setattr(movie, "observe_same_nonoise", unexpected_legacy_sampler)
+    obs, F0 = source_models.observe_source(movie, _empty_observation(obsgen), obsgen.source_context())
+
+    assert len(obs.data) > 0
+    assert F0 > 0.0
+
+
+@pytest.mark.parametrize(
+    ("polrep", "fields"),
+    (
+        ("circ", ("rrvis", "rlvis", "lrvis", "llvis")),
+        ("stokes", ("vis", "qvis", "uvis", "vvis")),
+    ),
+)
+def test_ehtim_movie_adapter_matches_legacy_full_polarization_sampling(polrep, fields):
+    direct_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    legacy_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    direct_movie = _polarized_movie()
+    legacy_movie = _polarized_movie()
+
+    direct, direct_F0 = source_models.observe_source(
+        direct_movie,
+        _empty_observation(direct_generator).switch_polrep(polrep_out=polrep),
+        direct_generator.source_context(),
+    )
+    legacy, legacy_F0 = _legacy_movie_observe(
+        legacy_movie,
+        _empty_observation(legacy_generator).switch_polrep(polrep_out=polrep),
+        legacy_generator.source_context(),
+    )
+
+    assert direct.source == legacy.source
+    assert direct.mjd == legacy.mjd
+    assert direct.ampcal is legacy.ampcal is True
+    assert direct.phasecal is legacy.phasecal is True
+    assert direct.opacitycal is legacy.opacitycal is True
+    assert direct.dcal is legacy.dcal is True
+    assert direct.frcal is legacy.frcal is True
+    assert direct_F0 == pytest.approx(legacy_F0)
+    for field in fields:
+        assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+
+
 def test_direct_ehtim_image_sampling_preserves_seeded_corruptions(monkeypatch):
     settings = dict(COMPACT_OBS_SETTINGS)
     settings["fringe_finder"] = ["naive", 0.0]
@@ -230,6 +321,61 @@ def test_direct_ehtim_image_sampling_preserves_seeded_corruptions(monkeypatch):
     legacy_generator = og.obs_generator(settings=settings)
     legacy = legacy_generator.make_obs(
         _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
+        addnoise=True,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert np.array_equal(direct.data["t1"], legacy.data["t1"])
+    assert np.array_equal(direct.data["t2"], legacy.data["t2"])
+    for field in (
+        "time",
+        "u",
+        "v",
+        "tau1",
+        "tau2",
+        "rrvis",
+        "llvis",
+        "rlvis",
+        "lrvis",
+        "rrsigma",
+        "llsigma",
+        "rlsigma",
+        "lrsigma",
+    ):
+        assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+
+
+def test_direct_ehtim_movie_sampling_preserves_seeded_corruptions(monkeypatch):
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["naive", 0.0]
+    direct_generator = og.obs_generator(settings=settings)
+    direct = direct_generator.make_obs(
+        _polarized_movie(),
+        addnoise=True,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    def legacy_adapter_observe(self, obs_empty, context, p=None):
+        return _legacy_movie_observe(self.input_model, obs_empty, context)
+
+    monkeypatch.setattr(
+        source_models.EhtimMovieAdapter,
+        "observe",
+        legacy_adapter_observe,
+    )
+    legacy_generator = og.obs_generator(settings=settings)
+    legacy = legacy_generator.make_obs(
+        _polarized_movie(),
         addnoise=True,
         addgains=True,
         addFR=True,


### PR DESCRIPTION
Replace ehtim.Movie.observe_same_nonoise with direct per-time-frame Image.sample_uv calls on the cached template. Preserve movie looping, circular and Stokes sampling, metadata, and seeded-corruption behavior.