### PR TITLE
Extract native station term kernel

### DIFF
--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -124,44 +124,40 @@ def _observation_times(context):
     return np.arange(t_start, t_stop, float(context["t_rest"]) / 3600.0)
 
 
-def ground_station_geometry(obs):
-    """Calculate station angles for a UTC ground-array ``ehtim.Obsdata``.
+def station_geometry_from_rows(position_itrs_m, time_mjd, antenna1, antenna2,
+                               ra_hours, dec_degrees):
+    """Calculate ground-station angles from native row and station arrays.
 
-    Returns ``None`` for spacecraft-containing arrays or non-UTC observations,
-    which retain the established ``ehtim`` metadata path.
+    Returns ``None`` when a row cannot be represented by the ground-only
+    geometry kernel, including arrays containing spacecraft placeholders.
     """
 
-    if getattr(obs, "timetype", None) != "UTC":
-        return None
-
-    coordinates = np.column_stack((obs.tarr["x"], obs.tarr["y"], obs.tarr["z"]))
+    coordinates = np.asarray(position_itrs_m, dtype=float)
+    time_mjd = np.asarray(time_mjd, dtype=float)
+    antenna1 = np.asarray(antenna1, dtype=np.intp)
+    antenna2 = np.asarray(antenna2, dtype=np.intp)
+    if coordinates.ndim != 2 or coordinates.shape[1] != 3:
+        raise ValueError("position_itrs_m must have shape (station, 3).")
+    if time_mjd.ndim != 1 or antenna1.shape != time_mjd.shape or antenna2.shape != time_mjd.shape:
+        raise ValueError("Station geometry row arrays must have matching one-dimensional shapes.")
+    if not np.all(np.isfinite(coordinates)) or not np.all(np.isfinite(time_mjd)):
+        raise ValueError("Station geometry inputs must be finite.")
+    if np.any(antenna1 < 0) or np.any(antenna1 >= len(coordinates)):
+        raise ValueError("antenna1 contains an out-of-range station index.")
+    if np.any(antenna2 < 0) or np.any(antenna2 >= len(coordinates)):
+        raise ValueError("antenna2 contains an out-of-range station index.")
     if np.any(np.all(coordinates == 0.0, axis=1)):
         return None
 
-    station_index = {str(site): index for index, site in enumerate(obs.tarr["site"])}
-    try:
-        antenna1 = np.fromiter(
-            (station_index[str(site)] for site in obs.data["t1"]),
-            dtype=np.intp,
-            count=len(obs.data),
-        )
-        antenna2 = np.fromiter(
-            (station_index[str(site)] for site in obs.data["t2"]),
-            dtype=np.intp,
-            count=len(obs.data),
-        )
-    except KeyError:
-        return None
-
     times_sidereal = Time(
-        (np.asarray(obs.data["time"], dtype=float) / 24.0) + np.floor(float(obs.mjd)),
+        time_mjd,
         format="mjd",
         scale="utc",
     ).sidereal_time("mean", "greenwich").hour
-    ra_rad = float(obs.ra) * (np.pi / 12.0)
-    dec_rad = np.deg2rad(float(obs.dec))
+    ra_rad = float(ra_hours) * (np.pi / 12.0)
+    dec_rad = np.deg2rad(float(dec_degrees))
     hour_angle_rotation = np.mod(
-        (times_sidereal - float(obs.ra)) * (np.pi / 12.0),
+        (times_sidereal - float(ra_hours)) * (np.pi / 12.0),
         2.0 * np.pi,
     )
     source_vector = np.array((np.cos(dec_rad), 0.0, np.sin(dec_rad)))
@@ -202,6 +198,42 @@ def ground_station_geometry(obs):
         elevation2_rad=elevation2,
         parallactic_angle1_rad=parallactic_angle1,
         parallactic_angle2_rad=parallactic_angle2,
+    )
+
+
+def ground_station_geometry(obs):
+    """Calculate station angles for a UTC ground-array ``ehtim.Obsdata``.
+
+    Returns ``None`` for spacecraft-containing arrays or non-UTC observations,
+    which retain the established ``ehtim`` metadata path.
+    """
+
+    if getattr(obs, "timetype", None) != "UTC":
+        return None
+
+    coordinates = np.column_stack((obs.tarr["x"], obs.tarr["y"], obs.tarr["z"]))
+    station_index = {str(site): index for index, site in enumerate(obs.tarr["site"])}
+    try:
+        antenna1 = np.fromiter(
+            (station_index[str(site)] for site in obs.data["t1"]),
+            dtype=np.intp,
+            count=len(obs.data),
+        )
+        antenna2 = np.fromiter(
+            (station_index[str(site)] for site in obs.data["t2"]),
+            dtype=np.intp,
+            count=len(obs.data),
+        )
+    except KeyError:
+        return None
+
+    return station_geometry_from_rows(
+        coordinates,
+        np.floor(float(obs.mjd)) + (np.asarray(obs.data["time"], dtype=float) / 24.0),
+        antenna1,
+        antenna2,
+        obs.ra,
+        obs.dec,
     )
 
 

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -1,12 +1,15 @@
 ###################################################
 # imports
 
+from dataclasses import dataclass
+
 import numpy as np
 from astropy.time import Time
 from astropy.coordinates import EarthLocation, AltAz, get_sun
 
 import ngehtsim.const_def as const
 import ngehtsim.obs.observation_geometry as observation_geometry
+from ngehtsim.obs.visibility_dataset import StationTable, VisibilityDataset
 
 ###################################################
 # helpers
@@ -30,14 +33,26 @@ def _station_weather_values(value, count, name):
         return np.full(count, values, dtype=float), True
     if values.shape != (count,):
         raise ValueError(
-            'Station {0} weather must be a scalar or one value per observation row.'.format(name)
+            "Station {0} weather must be a scalar or one value per observation row.".format(name)
         )
     return values, False
 
 
-def station_metadata_cache_key(obs, station_context):
-    sites = tuple(station_context["sites"])
-    station_key = tuple(
+@dataclass(frozen=True)
+class _StationRows:
+    t1: np.ndarray
+    t2: np.ndarray
+    times: np.ndarray
+    reference_mjd: float
+    bandwidth_hz: float
+    elevation1_rad: np.ndarray
+    elevation2_rad: np.ndarray
+    parallactic_angle1_rad: np.ndarray
+    parallactic_angle2_rad: np.ndarray
+
+
+def _station_context_key(station_context):
+    return tuple(
         (
             site,
             _cache_value(station_context["bandwidth_hz"][site]),
@@ -45,173 +60,329 @@ def station_metadata_cache_key(obs, station_context):
             _cache_value(station_context["feed_angle"][site]),
             _cache_value(station_context["polarization_basis"][site]),
         )
-        for site in sites
+        for site in tuple(station_context["sites"])
     )
 
+
+def _station_metadata_key(source, ra, dec, rf, bandwidth_hz, mjd, times, t1, t2,
+                          station_context):
     return (
-        _cache_value(getattr(obs, "source", None)),
-        _cache_value(getattr(obs, "ra", None)),
-        _cache_value(getattr(obs, "dec", None)),
-        _cache_value(getattr(obs, "rf", None)),
-        _cache_value(getattr(obs, "bw", None)),
-        _cache_value(getattr(obs, "mjd", None)),
-        _cache_value(obs.data["time"]),
-        _cache_value(obs.data["t1"]),
-        _cache_value(obs.data["t2"]),
-        station_key,
+        _cache_value(source),
+        _cache_value(ra),
+        _cache_value(dec),
+        _cache_value(rf),
+        _cache_value(bandwidth_hz),
+        _cache_value(mjd),
+        _cache_value(times),
+        _cache_value(t1),
+        _cache_value(t2),
+        _station_context_key(station_context),
     )
+
+
+def station_metadata_cache_key(obs, station_context):
+    return _station_metadata_key(
+        getattr(obs, "source", None),
+        getattr(obs, "ra", None),
+        getattr(obs, "dec", None),
+        getattr(obs, "rf", None),
+        getattr(obs, "bw", None),
+        getattr(obs, "mjd", None),
+        obs.data["time"],
+        obs.data["t1"],
+        obs.data["t2"],
+        station_context,
+    )
+
+
+def _station_rows_from_obsdata(obs):
+    geometry = observation_geometry.ground_station_geometry(obs)
+    if geometry is None:
+        els = obs.unpack(["el1", "el2"], ang_unit="rad")
+        pars = obs.unpack(["par_ang1", "par_ang2"], ang_unit="rad")
+        elevation1 = els["el1"]
+        elevation2 = els["el2"]
+        parallactic_angle1 = pars["par_ang1"]
+        parallactic_angle2 = pars["par_ang2"]
+    else:
+        elevation1 = geometry.elevation1_rad
+        elevation2 = geometry.elevation2_rad
+        parallactic_angle1 = geometry.parallactic_angle1_rad
+        parallactic_angle2 = geometry.parallactic_angle2_rad
+
+    return _StationRows(
+        t1=np.asarray(obs.data["t1"]),
+        t2=np.asarray(obs.data["t2"]),
+        times=np.asarray(obs.data["time"], dtype=float),
+        reference_mjd=float(obs.mjd),
+        bandwidth_hz=float(obs.bw),
+        elevation1_rad=np.asarray(elevation1, dtype=float),
+        elevation2_rad=np.asarray(elevation2, dtype=float),
+        parallactic_angle1_rad=np.asarray(parallactic_angle1, dtype=float),
+        parallactic_angle2_rad=np.asarray(parallactic_angle2, dtype=float),
+    )
+
+
+def _dataset_reference_mjd(dataset, reference_mjd):
+    if reference_mjd is not None:
+        return float(reference_mjd)
+    if not dataset.row_count:
+        raise ValueError("Native station terms require at least one visibility row.")
+    return float(np.floor(np.min(dataset.time_mjd)))
+
+
+def _dataset_station_names(dataset):
+    names = np.asarray(dataset.stations.names)
+    return names[dataset.antenna1], names[dataset.antenna2]
+
+
+def _station_rows_from_dataset(dataset, reference_mjd):
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if dataset.channel_count != 1:
+        raise ValueError("Native station terms currently require exactly one spectral channel.")
+
+    reference_mjd = _dataset_reference_mjd(dataset, reference_mjd)
+    geometry = observation_geometry.station_geometry_from_rows(
+        dataset.stations.position_itrs_m,
+        dataset.time_mjd,
+        dataset.antenna1,
+        dataset.antenna2,
+        dataset.ra_hours,
+        dataset.dec_degrees,
+    )
+    if geometry is None:
+        raise ValueError("Native station terms do not yet support spacecraft stations.")
+
+    t1, t2 = _dataset_station_names(dataset)
+    return _StationRows(
+        t1=t1,
+        t2=t2,
+        times=(np.asarray(dataset.time_mjd, dtype=float) - reference_mjd) * 24.0,
+        reference_mjd=reference_mjd,
+        bandwidth_hz=float(dataset.channel_bandwidth_hz[0]),
+        elevation1_rad=geometry.elevation1_rad,
+        elevation2_rad=geometry.elevation2_rad,
+        parallactic_angle1_rad=geometry.parallactic_angle1_rad,
+        parallactic_angle2_rad=geometry.parallactic_angle2_rad,
+    )
+
+
+def _station_metadata_from_rows(rows, station_context):
+    t1 = rows.t1
+    t2 = rows.t2
+    sites_obs = np.unique(np.concatenate((t1, t2)))
+    elevation1 = rows.elevation1_rad
+    elevation2 = rows.elevation2_rad
+    feed_elevation1 = np.zeros_like(elevation1)
+    feed_elevation2 = np.zeros_like(elevation2)
+    feed_parallactic1 = np.zeros_like(elevation1)
+    feed_parallactic2 = np.zeros_like(elevation2)
+    feed_offset1 = np.zeros_like(elevation1)
+    feed_offset2 = np.zeros_like(elevation2)
+    bandwidth1 = np.zeros_like(elevation1)
+    bandwidth2 = np.zeros_like(elevation2)
+    site_masks = {}
+
+    for site in sites_obs:
+        index1 = t1 == site
+        index2 = t2 == site
+        site_masks[site] = (index1, index2)
+        bandwidth = station_context["bandwidth_hz"][site]
+        if bandwidth is None:
+            bandwidth = rows.bandwidth_hz
+        bandwidth1[index1] = bandwidth
+        bandwidth2[index2] = bandwidth
+
+        mount_type = station_context["mount_type"][site]
+        feed_angle = station_context["feed_angle"][site]
+        feed_elevation1[index1] = const.mount_type_dict[mount_type]["f_el"]
+        feed_elevation2[index2] = const.mount_type_dict[mount_type]["f_el"]
+        feed_parallactic1[index1] = const.mount_type_dict[mount_type]["f_par"]
+        feed_parallactic2[index2] = const.mount_type_dict[mount_type]["f_par"]
+        feed_offset1[index1] = feed_angle
+        feed_offset2[index2] = feed_angle
+
+    return {
+        "_rows": rows,
+        "sites_obs": sites_obs,
+        "site_masks": site_masks,
+        "el1": elevation1,
+        "el2": elevation2,
+        "par1": rows.parallactic_angle1_rad,
+        "par2": rows.parallactic_angle2_rad,
+        "tuniq": np.unique(rows.times),
+        "bw1": bandwidth1,
+        "bw2": bandwidth2,
+        "f_el1": feed_elevation1,
+        "f_el2": feed_elevation2,
+        "f_par1": feed_parallactic1,
+        "f_par2": feed_parallactic2,
+        "phi_off1": feed_offset1,
+        "phi_off2": feed_offset2,
+    }
 
 
 def station_metadata(obs, station_context, cache=None):
     key = station_metadata_cache_key(obs, station_context)
     if cache is not None and key in cache:
         return cache[key]
-
-    t1 = obs.data["t1"]
-    t2 = obs.data["t2"]
-    sites_obs = np.unique(np.concatenate((t1, t2)))
-    geometry = observation_geometry.ground_station_geometry(obs)
-    if geometry is None:
-        els = obs.unpack(["el1", "el2"], ang_unit="rad")
-        pars = obs.unpack(["par_ang1", "par_ang2"], ang_unit="rad")
-        el1 = els["el1"]
-        el2 = els["el2"]
-        par1 = pars["par_ang1"]
-        par2 = pars["par_ang2"]
-    else:
-        el1 = geometry.elevation1_rad
-        el2 = geometry.elevation2_rad
-        par1 = geometry.parallactic_angle1_rad
-        par2 = geometry.parallactic_angle2_rad
-    times = obs.data["time"]
-    tuniq = np.unique(times)
-
-    bw1 = np.zeros_like(el1)
-    bw2 = np.zeros_like(el2)
-    f_el1 = np.zeros_like(el1)
-    f_el2 = np.zeros_like(el2)
-    f_par1 = np.zeros_like(el1)
-    f_par2 = np.zeros_like(el2)
-    phi_off1 = np.zeros_like(el1)
-    phi_off2 = np.zeros_like(el2)
-    site_masks = {}
-
-    for site in sites_obs:
-        ind1 = (t1 == site)
-        ind2 = (t2 == site)
-        site_masks[site] = (ind1, ind2)
-
-        valhere = station_context["bandwidth_hz"][site]
-        if valhere is None:
-            valhere = obs.bw
-        bw1[ind1] = valhere
-        bw2[ind2] = valhere
-
-        mttyp = station_context["mount_type"][site]
-        fdang = station_context["feed_angle"][site]
-        f_el1[ind1] = const.mount_type_dict[mttyp]["f_el"]
-        f_el2[ind2] = const.mount_type_dict[mttyp]["f_el"]
-        f_par1[ind1] = const.mount_type_dict[mttyp]["f_par"]
-        f_par2[ind2] = const.mount_type_dict[mttyp]["f_par"]
-        phi_off1[ind1] = fdang
-        phi_off2[ind2] = fdang
-
-    metadata = {
-        "sites_obs": sites_obs,
-        "site_masks": site_masks,
-        "el1": el1,
-        "el2": el2,
-        "par1": par1,
-        "par2": par2,
-        "tuniq": tuniq,
-        "bw1": bw1,
-        "bw2": bw2,
-        "f_el1": f_el1,
-        "f_el2": f_el2,
-        "f_par1": f_par1,
-        "f_par2": f_par2,
-        "phi_off1": phi_off1,
-        "phi_off2": phi_off2,
-    }
-
+    metadata = _station_metadata_from_rows(
+        _station_rows_from_obsdata(obs),
+        station_context,
+    )
     if cache is not None:
         cache[key] = metadata
-
     return metadata
 
 
-def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.1,
-                  addgains=True, addleakage=False, flagwind=True, flagday=False,
-                  flagsun=True, allow_mixed_basis=False, solar_angle=None,
-                  verbosity=0, windspeed_sefd_modifier=None, cache=None):
-    t1 = obs.data["t1"]
-    t2 = obs.data["t2"]
-    times = obs.data["time"]
-    metadata = station_metadata(obs, station_context, cache=cache)
+def station_metadata_for_dataset(dataset, station_context, reference_mjd=None, cache=None):
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if dataset.channel_count != 1:
+        raise ValueError("Native station terms currently require exactly one spectral channel.")
+
+    reference_mjd = _dataset_reference_mjd(dataset, reference_mjd)
+    t1, t2 = _dataset_station_names(dataset)
+    times = (np.asarray(dataset.time_mjd, dtype=float) - reference_mjd) * 24.0
+    key = _station_metadata_key(
+        dataset.source,
+        dataset.ra_hours,
+        dataset.dec_degrees,
+        dataset.channel_frequency_hz[0],
+        dataset.channel_bandwidth_hz[0],
+        reference_mjd,
+        times,
+        t1,
+        t2,
+        station_context,
+    )
+    if cache is not None and key in cache:
+        return cache[key]
+    metadata = _station_metadata_from_rows(
+        _station_rows_from_dataset(dataset, reference_mjd),
+        station_context,
+    )
+    if cache is not None:
+        cache[key] = metadata
+    return metadata
+
+
+def _apply_mixed_basis(obs, metadata, station_context):
+    for site in metadata["sites_obs"]:
+        if station_context["polarization_basis"][site] != "linear":
+            continue
+        index1, index2 = metadata["site_masks"][site]
+        transform1 = np.zeros((index1.sum(), 2, 2), dtype=complex)
+        transform2 = np.zeros((index2.sum(), 2, 2), dtype=complex)
+        transform1[:] = const.circ_to_lin
+        transform2[:] = np.conj(const.circ_to_lin).T
+
+        coherence1 = np.zeros((index1.sum(), 2, 2), dtype=complex)
+        coherence1[:, 0, 0] = obs.data["rrvis"][index1]
+        coherence1[:, 0, 1] = obs.data["rlvis"][index1]
+        coherence1[:, 1, 0] = obs.data["lrvis"][index1]
+        coherence1[:, 1, 1] = obs.data["llvis"][index1]
+        coherence2 = np.zeros((index2.sum(), 2, 2), dtype=complex)
+        coherence2[:, 0, 0] = obs.data["rrvis"][index2]
+        coherence2[:, 0, 1] = obs.data["rlvis"][index2]
+        coherence2[:, 1, 0] = obs.data["lrvis"][index2]
+        coherence2[:, 1, 1] = obs.data["llvis"][index2]
+
+        transformed1 = np.matmul(transform1, coherence1)
+        transformed2 = np.matmul(coherence2, transform2)
+        obs.data["rrvis"][index1] = transformed1[:, 0, 0]
+        obs.data["rlvis"][index1] = transformed1[:, 0, 1]
+        obs.data["lrvis"][index1] = transformed1[:, 1, 0]
+        obs.data["llvis"][index1] = transformed1[:, 1, 1]
+        obs.data["rrvis"][index2] = transformed2[:, 0, 0]
+        obs.data["rlvis"][index2] = transformed2[:, 0, 1]
+        obs.data["lrvis"][index2] = transformed2[:, 1, 0]
+        obs.data["llvis"][index2] = transformed2[:, 1, 1]
+
+
+def _updated_station_table(stations, sefd_r_jy, sefd_l_jy, leakage_r, leakage_l):
+    return StationTable(
+        names=stations.names,
+        position_itrs_m=stations.position_itrs_m,
+        sefd_r_jy=sefd_r_jy,
+        sefd_l_jy=sefd_l_jy,
+        leakage_r=leakage_r,
+        leakage_l=leakage_l,
+        feed_rotation_par=stations.feed_rotation_par,
+        feed_rotation_elev=stations.feed_rotation_elev,
+        feed_rotation_offset_deg=stations.feed_rotation_offset_deg,
+    )
+
+
+def _station_terms_from_rows(rows, metadata, F0, station_context, stations, rng,
+                             gainamp=0.04, leakamp=0.1, addgains=True,
+                             addleakage=False, flagwind=True, flagday=False,
+                             flagsun=True, solar_angle=None, verbosity=0,
+                             windspeed_sefd_modifier=None):
+    t1 = rows.t1
+    t2 = rows.t2
+    times = rows.times
     sites_obs = metadata["sites_obs"]
     site_masks = metadata["site_masks"]
-    el1 = metadata["el1"]
-    el2 = metadata["el2"]
-    par1 = metadata["par1"]
-    par2 = metadata["par2"]
-    tuniq = metadata["tuniq"]
+    elevation1 = metadata["el1"]
+    elevation2 = metadata["el2"]
+    parallactic_angle1 = metadata["par1"]
+    parallactic_angle2 = metadata["par2"]
+    unique_times = metadata["tuniq"]
 
-    tau1 = np.zeros_like(el1)
-    tau2 = np.zeros_like(el2)
-    Tb1 = np.zeros_like(el1)
-    Tb2 = np.zeros_like(el2)
-    Tsys1 = np.zeros_like(el1)
-    Tsys2 = np.zeros_like(el2)
-    SEFD1 = np.zeros_like(el1)
-    SEFD2 = np.zeros_like(el2)
-    bw1 = metadata["bw1"]
-    bw2 = metadata["bw2"]
-    f_el1 = metadata["f_el1"]
-    f_el2 = metadata["f_el2"]
-    f_par1 = metadata["f_par1"]
-    f_par2 = metadata["f_par2"]
-    phi_off1 = metadata["phi_off1"]
-    phi_off2 = metadata["phi_off2"]
-
+    tau1 = np.zeros_like(elevation1)
+    tau2 = np.zeros_like(elevation2)
+    brightness1 = np.zeros_like(elevation1)
+    brightness2 = np.zeros_like(elevation2)
+    system_temperature1 = np.zeros_like(elevation1)
+    system_temperature2 = np.zeros_like(elevation2)
+    sefd1 = np.zeros_like(elevation1)
+    sefd2 = np.zeros_like(elevation2)
     if addgains:
-        gainamp1R = np.zeros_like(el1)
-        gainamp2R = np.zeros_like(el2)
-        gainphase1R = np.zeros_like(el1)
-        gainphase2R = np.zeros_like(el2)
-        gainamp1L = np.zeros_like(el1)
-        gainamp2L = np.zeros_like(el2)
-        gainphase1L = np.zeros_like(el1)
-        gainphase2L = np.zeros_like(el2)
-
+        gain_amplitude1_r = np.zeros_like(elevation1)
+        gain_amplitude2_r = np.zeros_like(elevation2)
+        gain_phase1_r = np.zeros_like(elevation1)
+        gain_phase2_r = np.zeros_like(elevation2)
+        gain_amplitude1_l = np.zeros_like(elevation1)
+        gain_amplitude2_l = np.zeros_like(elevation2)
+        gain_phase1_l = np.zeros_like(elevation1)
+        gain_phase2_l = np.zeros_like(elevation2)
     if addleakage:
-        leak1R = np.zeros_like(el1, dtype=complex)
-        leak2R = np.zeros_like(el2, dtype=complex)
-        leak1L = np.zeros_like(el1, dtype=complex)
-        leak2L = np.zeros_like(el2, dtype=complex)
+        leakage1_r = np.zeros_like(elevation1, dtype=complex)
+        leakage2_r = np.zeros_like(elevation2, dtype=complex)
+        leakage1_l = np.zeros_like(elevation1, dtype=complex)
+        leakage2_l = np.zeros_like(elevation2, dtype=complex)
 
-    flagsites = list()
-    uptime_mask = np.ones(len(obs.data), dtype=bool)
+    flagged_sites = []
+    uptime_mask = np.ones(len(times), dtype=bool)
+    sefd_r_jy = np.array(stations.sefd_r_jy, copy=True)
+    sefd_l_jy = np.array(stations.sefd_l_jy, copy=True)
+    leakage_r = np.array(stations.leakage_r, copy=True)
+    leakage_l = np.array(stations.leakage_l, copy=True)
+    station_index = {name: index for index, name in enumerate(stations.names)}
+
     for site in sites_obs:
-        tau_z, _ = _station_weather_values(
-            station_context["tau"][site], len(obs.data), 'opacity'
+        tau_zenith, _ = _station_weather_values(
+            station_context["tau"][site], len(times), "opacity"
         )
-        Tatm, _ = _station_weather_values(
-            station_context["Tatm"][site], len(obs.data), 'atmospheric temperature'
+        atmospheric_temperature, _ = _station_weather_values(
+            station_context["Tatm"][site], len(times), "atmospheric temperature"
         )
-        Tgnd, _ = _station_weather_values(
-            station_context["Tgnd"][site], len(obs.data), 'ground temperature'
+        ground_temperature, _ = _station_weather_values(
+            station_context["Tgnd"][site], len(times), "ground temperature"
         )
-        ws, windspeed_is_scalar = _station_weather_values(
-            station_context["windspeed"][site], len(obs.data), 'wind speed'
+        wind_speed, windspeed_is_scalar = _station_weather_values(
+            station_context["windspeed"][site], len(times), "wind speed"
         )
-        Aeff = station_context["effective_area"][site]
+        effective_area = station_context["effective_area"][site]
         wind_loading = station_context["wind_loading"][site]
+        site_rows = (t1 == site) | (t2 == site)
 
         if flagwind:
-            site_rows = ((t1 == site) | (t2 == site))
-            high_wind = site_rows & (ws > wind_loading["shutdown"])
+            high_wind = site_rows & (wind_speed > wind_loading["shutdown"])
             if np.any(high_wind) and windspeed_is_scalar:
-                flagsites.append(site)
+                flagged_sites.append(site)
                 if verbosity > 0:
                     print(site + " cannot observe because of high wind.")
             elif np.any(high_wind):
@@ -219,185 +390,237 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
                 if verbosity > 0:
                     print(site + " cannot observe at some timestamps because of high wind.")
 
-        if flagday:
-            if site != "space":
-                lon = const.known_longitudes[site]
-                lat = const.known_latitudes[site]
-                elev = const.known_elevations[site]
-                location = EarthLocation.from_geodetic(lon, lat, height=elev)
+        if flagday and site != "space":
+            location = EarthLocation.from_geodetic(
+                const.known_longitudes[site],
+                const.known_latitudes[site],
+                height=const.known_elevations[site],
+            )
+            timehere = Time(
+                rows.reference_mjd + 2400000.5 + (times / 24.0),
+                format="jd",
+            )
+            sun_altaz = get_sun(timehere).transform_to(AltAz(obstime=timehere, location=location))
+            uptime_mask[site_rows & (sun_altaz.alt.value > 0.0)] = False
 
-                jd = obs.mjd + 2400000.5 + (times/24.0)
-                timehere = Time(jd, format="jd")
-                altazframe = AltAz(obstime=timehere, location=location)
-                sun_altaz = get_sun(timehere).transform_to(altazframe)
-
-                ind_daytime = (((t1 == site) | (t2 == site)) & (sun_altaz.alt.value > 0.0))
-                uptime_mask[ind_daytime] = False
-
-        if flagsun:
-            if solar_angle < station_context["solar_avoidance"][site]:
-                flagsites.append(site)
-                if verbosity > 0:
-                    print(site + " cannot observe because the source is too close to the Sun.")
+        if flagsun and solar_angle < station_context["solar_avoidance"][site]:
+            flagged_sites.append(site)
+            if verbosity > 0:
+                print(site + " cannot observe because the source is too close to the Sun.")
 
         if site in station_context["station_uptimes"]:
-            ind_too_early = (((t1 == site) | (t2 == site)) & (times < station_context["station_uptimes"][site][0]))
-            ind_too_late = (((t1 == site) | (t2 == site)) & (times > station_context["station_uptimes"][site][1]))
-            uptime_mask[ind_too_early] = False
-            uptime_mask[ind_too_late] = False
+            start, stop = station_context["station_uptimes"][site]
+            uptime_mask[site_rows & (times < start)] = False
+            uptime_mask[site_rows & (times > stop)] = False
 
-        ind1, ind2 = site_masks[site]
-
-        if allow_mixed_basis:
-            if station_context["polarization_basis"][site] == "linear":
-                tform_mat1 = np.zeros((ind1.sum(), 2, 2), dtype=complex)
-                tform_mat2 = np.zeros((ind2.sum(), 2, 2), dtype=complex)
-                tform_mat1[:] = const.circ_to_lin
-                tform_mat2[:] = np.conj(const.circ_to_lin).T
-
-                coh_mat1 = np.zeros((ind1.sum(), 2, 2), dtype=complex)
-                coh_mat1[:, 0, 0] = obs.data["rrvis"][ind1]
-                coh_mat1[:, 0, 1] = obs.data["rlvis"][ind1]
-                coh_mat1[:, 1, 0] = obs.data["lrvis"][ind1]
-                coh_mat1[:, 1, 1] = obs.data["llvis"][ind1]
-                coh_mat2 = np.zeros((ind2.sum(), 2, 2), dtype=complex)
-                coh_mat2[:, 0, 0] = obs.data["rrvis"][ind2]
-                coh_mat2[:, 0, 1] = obs.data["rlvis"][ind2]
-                coh_mat2[:, 1, 0] = obs.data["lrvis"][ind2]
-                coh_mat2[:, 1, 1] = obs.data["llvis"][ind2]
-
-                coh_mat_tformed1 = np.matmul(tform_mat1, coh_mat1)
-                coh_mat_tformed2 = np.matmul(coh_mat2, tform_mat2)
-
-                obs.data["rrvis"][ind1] = coh_mat_tformed1[:, 0, 0]
-                obs.data["rlvis"][ind1] = coh_mat_tformed1[:, 0, 1]
-                obs.data["lrvis"][ind1] = coh_mat_tformed1[:, 1, 0]
-                obs.data["llvis"][ind1] = coh_mat_tformed1[:, 1, 1]
-                obs.data["rrvis"][ind2] = coh_mat_tformed2[:, 0, 0]
-                obs.data["rlvis"][ind2] = coh_mat_tformed2[:, 0, 1]
-                obs.data["lrvis"][ind2] = coh_mat_tformed2[:, 1, 0]
-                obs.data["llvis"][ind2] = coh_mat_tformed2[:, 1, 1]
-
+        index1, index2 = site_masks[site]
         if site != "space":
-            tau1[ind1] = tau_z[ind1] / np.cos((np.pi/2.0) - el1[ind1])
-            tau2[ind2] = tau_z[ind2] / np.cos((np.pi/2.0) - el2[ind2])
+            tau1[index1] = tau_zenith[index1] / np.cos((np.pi / 2.0) - elevation1[index1])
+            tau2[index2] = tau_zenith[index2] / np.cos((np.pi / 2.0) - elevation2[index2])
         else:
-            tau1[ind1] = 0.0
-            tau2[ind2] = 0.0
+            tau1[index1] = 0.0
+            tau2[index2] = 0.0
 
-        Tsource = (F0*Aeff)/(2.0*const.k)
-
+        source_temperature = (F0 * effective_area) / (2.0 * const.k)
         if site != "space":
-            Tb1[ind1] = ((const.T_CMB + Tsource)*np.exp(-tau1[ind1])) + (Tatm[ind1]*(1.0 - np.exp(-tau1[ind1])))
-            Tb2[ind2] = ((const.T_CMB + Tsource)*np.exp(-tau2[ind2])) + (Tatm[ind2]*(1.0 - np.exp(-tau2[ind2])))
+            brightness1[index1] = (
+                (const.T_CMB + source_temperature) * np.exp(-tau1[index1])
+                + atmospheric_temperature[index1] * (1.0 - np.exp(-tau1[index1]))
+            )
+            brightness2[index2] = (
+                (const.T_CMB + source_temperature) * np.exp(-tau2[index2])
+                + atmospheric_temperature[index2] * (1.0 - np.exp(-tau2[index2]))
+            )
         else:
-            Tb1[ind1] = const.T_CMB + Tsource
-            Tb2[ind2] = const.T_CMB + Tsource
+            brightness1[index1] = const.T_CMB + source_temperature
+            brightness2[index2] = const.T_CMB + source_temperature
 
-        T_R = station_context["receiver_temperature"][site]
+        receiver_temperature = station_context["receiver_temperature"][site]
         sideband_ratio = station_context["sideband_ratio"][site]
-
-        Tsys1[ind1] = (T_R + (const.eta_ff*Tb1[ind1]) + ((1.0 - const.eta_ff)*Tgnd[ind1]))*(1.0 + sideband_ratio)
-        Tsys2[ind2] = (T_R + (const.eta_ff*Tb2[ind2]) + ((1.0 - const.eta_ff)*Tgnd[ind2]))*(1.0 + sideband_ratio)
-
-        SEFD1[ind1] = (2.0*const.k*Tsys1[ind1])/Aeff
-        SEFD2[ind2] = (2.0*const.k*Tsys2[ind2])/Aeff
-
+        system_temperature1[index1] = (
+            receiver_temperature
+            + const.eta_ff * brightness1[index1]
+            + (1.0 - const.eta_ff) * ground_temperature[index1]
+        ) * (1.0 + sideband_ratio)
+        system_temperature2[index2] = (
+            receiver_temperature
+            + const.eta_ff * brightness2[index2]
+            + (1.0 - const.eta_ff) * ground_temperature[index2]
+        ) * (1.0 + sideband_ratio)
+        sefd1[index1] = (2.0 * const.k * system_temperature1[index1]) / effective_area
+        sefd2[index2] = (2.0 * const.k * system_temperature2[index2]) / effective_area
         if flagwind:
-            SEFD1[ind1] *= windspeed_sefd_modifier(
-                ws[ind1], wind_loading["v0"], wind_loading["w"]
+            sefd1[index1] *= windspeed_sefd_modifier(
+                wind_speed[index1], wind_loading["v0"], wind_loading["w"]
             )
-            SEFD2[ind2] *= windspeed_sefd_modifier(
-                ws[ind2], wind_loading["v0"], wind_loading["w"]
+            sefd2[index2] *= windspeed_sefd_modifier(
+                wind_speed[index2], wind_loading["v0"], wind_loading["w"]
             )
 
-        sefdind = (array.tarr["site"] == site)
-        sefdr_arr = np.copy(array.tarr["sefdr"])
-        sefdl_arr = np.copy(array.tarr["sefdl"])
-        sefdhere = np.mean(np.concatenate((SEFD1[ind1], SEFD2[ind2])))
-        sefdr_arr[sefdind] = sefdhere
-        sefdl_arr[sefdind] = sefdhere
-        array.tarr["sefdr"] = sefdr_arr
-        array.tarr["sefdl"] = sefdl_arr
+        try:
+            station_here = station_index[str(site)]
+        except KeyError:
+            raise ValueError("Station terms reference unknown station: {0}".format(site))
+        sefd_here = np.mean(np.concatenate((sefd1[index1], sefd2[index2])))
+        sefd_r_jy[station_here] = sefd_here
+        sefd_l_jy[station_here] = sefd_here
 
         if addgains:
-            for t in tuniq:
-                ind1here = ((times == t) & (t1 == site))
-                ind2here = ((times == t) & (t2 == site))
-                gainamphere = 10.0**(gainamp*rng.normal(0.0, 1.0))
-                gainphasehere = rng.uniform(-np.pi, np.pi)
-                gainamp1R[ind1here] = gainamphere
-                gainamp2R[ind2here] = gainamphere
-                gainphase1R[ind1here] = gainphasehere
-                gainphase2R[ind2here] = gainphasehere
-                gainamp1L[ind1here] = gainamphere
-                gainamp2L[ind2here] = gainamphere
-                gainphase1L[ind1here] = gainphasehere
-                gainphase2L[ind2here] = gainphasehere
+            for time in unique_times:
+                index1here = (times == time) & (t1 == site)
+                index2here = (times == time) & (t2 == site)
+                gain_amplitude = 10.0 ** (gainamp * rng.normal(0.0, 1.0))
+                gain_phase = rng.uniform(-np.pi, np.pi)
+                gain_amplitude1_r[index1here] = gain_amplitude
+                gain_amplitude2_r[index2here] = gain_amplitude
+                gain_phase1_r[index1here] = gain_phase
+                gain_phase2_r[index2here] = gain_phase
+                gain_amplitude1_l[index1here] = gain_amplitude
+                gain_amplitude2_l[index2here] = gain_amplitude
+                gain_phase1_l[index1here] = gain_phase
+                gain_phase2_l[index2here] = gain_phase
 
         if addleakage:
-            leakRhere = (leakamp*rng.normal(0.0, 1.0)) + ((1.0j)*leakamp*rng.normal(0.0, 1.0))
-            leakLhere = (leakamp*rng.normal(0.0, 1.0)) + ((1.0j)*leakamp*rng.normal(0.0, 1.0))
-            leak1R[ind1] = leakRhere
-            leak2R[ind2] = leakRhere
-            leak1L[ind1] = leakLhere
-            leak2L[ind2] = leakLhere
-
+            leakage_r_here = leakamp * rng.normal(0.0, 1.0) + 1.0j * leakamp * rng.normal(0.0, 1.0)
+            leakage_l_here = leakamp * rng.normal(0.0, 1.0) + 1.0j * leakamp * rng.normal(0.0, 1.0)
+            leakage1_r[index1] = leakage_r_here
+            leakage2_r[index2] = leakage_r_here
+            leakage1_l[index1] = leakage_l_here
+            leakage2_l[index2] = leakage_l_here
             if site != "space":
-                tarrind = (array.tarr["site"] == site)
-                dr_arr = np.copy(array.tarr["dr"])
-                dl_arr = np.copy(array.tarr["dl"])
-                dr_arr[tarrind] = leakRhere
-                dl_arr[tarrind] = leakLhere
-                array.tarr["dr"] = dr_arr
-                array.tarr["dl"] = dl_arr
+                leakage_r[station_here] = leakage_r_here
+                leakage_l[station_here] = leakage_l_here
 
     terms = {
         "t1": t1,
         "t2": t2,
-        "el1": el1,
-        "el2": el2,
-        "par1": par1,
-        "par2": par2,
+        "el1": elevation1,
+        "el2": elevation2,
+        "par1": parallactic_angle1,
+        "par2": parallactic_angle2,
         "times": times,
         "tau1": tau1,
         "tau2": tau2,
-        "Tb1": Tb1,
-        "Tb2": Tb2,
-        "Tsys1": Tsys1,
-        "Tsys2": Tsys2,
-        "SEFD1": SEFD1,
-        "SEFD2": SEFD2,
-        "bw1": bw1,
-        "bw2": bw2,
-        "f_el1": f_el1,
-        "f_el2": f_el2,
-        "f_par1": f_par1,
-        "f_par2": f_par2,
-        "phi_off1": phi_off1,
-        "phi_off2": phi_off2,
-        "flagsites": flagsites,
+        "Tb1": brightness1,
+        "Tb2": brightness2,
+        "Tsys1": system_temperature1,
+        "Tsys2": system_temperature2,
+        "SEFD1": sefd1,
+        "SEFD2": sefd2,
+        "bw1": metadata["bw1"],
+        "bw2": metadata["bw2"],
+        "f_el1": metadata["f_el1"],
+        "f_el2": metadata["f_el2"],
+        "f_par1": metadata["f_par1"],
+        "f_par2": metadata["f_par2"],
+        "phi_off1": metadata["phi_off1"],
+        "phi_off2": metadata["phi_off2"],
+        "flagsites": flagged_sites,
         "uptime_mask": uptime_mask,
     }
-
     if addgains:
         terms.update({
-            "gainamp1R": gainamp1R,
-            "gainamp2R": gainamp2R,
-            "gainphase1R": gainphase1R,
-            "gainphase2R": gainphase2R,
-            "gainamp1L": gainamp1L,
-            "gainamp2L": gainamp2L,
-            "gainphase1L": gainphase1L,
-            "gainphase2L": gainphase2L,
+            "gainamp1R": gain_amplitude1_r,
+            "gainamp2R": gain_amplitude2_r,
+            "gainphase1R": gain_phase1_r,
+            "gainphase2R": gain_phase2_r,
+            "gainamp1L": gain_amplitude1_l,
+            "gainamp2L": gain_amplitude2_l,
+            "gainphase1L": gain_phase1_l,
+            "gainphase2L": gain_phase2_l,
         })
-
     if addleakage:
         terms.update({
-            "leak1R": leak1R,
-            "leak2R": leak2R,
-            "leak1L": leak1L,
-            "leak2L": leak2L,
+            "leak1R": leakage1_r,
+            "leak2R": leakage2_r,
+            "leak1L": leakage1_l,
+            "leak2L": leakage2_l,
         })
 
+    return terms, _updated_station_table(
+        stations,
+        sefd_r_jy,
+        sefd_l_jy,
+        leakage_r,
+        leakage_l,
+    )
+
+
+def _apply_station_table_to_array(array, stations):
+    station_index = {str(name): index for index, name in enumerate(stations.names)}
+    for field, values in (
+        ("sefdr", stations.sefd_r_jy),
+        ("sefdl", stations.sefd_l_jy),
+        ("dr", stations.leakage_r),
+        ("dl", stations.leakage_l),
+    ):
+        updated = np.array(array.tarr[field], copy=True)
+        for index, site in enumerate(array.tarr["site"]):
+            if str(site) in station_index:
+                updated[index] = values[station_index[str(site)]]
+        array.tarr[field] = updated
+
+
+def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.1,
+                  addgains=True, addleakage=False, flagwind=True, flagday=False,
+                  flagsun=True, allow_mixed_basis=False, solar_angle=None,
+                  verbosity=0, windspeed_sefd_modifier=None, cache=None):
+    """Calculate legacy Obsdata station terms through the native row kernel."""
+
+    metadata = station_metadata(obs, station_context, cache=cache)
+    if allow_mixed_basis:
+        _apply_mixed_basis(obs, metadata, station_context)
+    terms, stations = _station_terms_from_rows(
+        metadata["_rows"],
+        metadata,
+        F0,
+        station_context,
+        StationTable.from_ehtim_tarr(array.tarr),
+        rng,
+        gainamp=gainamp,
+        leakamp=leakamp,
+        addgains=addgains,
+        addleakage=addleakage,
+        flagwind=flagwind,
+        flagday=flagday,
+        flagsun=flagsun,
+        solar_angle=solar_angle,
+        verbosity=verbosity,
+        windspeed_sefd_modifier=windspeed_sefd_modifier,
+    )
+    _apply_station_table_to_array(array, stations)
     return terms
+
+
+def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
+                              leakamp=0.1, addgains=True, addleakage=False,
+                              flagwind=True, flagday=False, flagsun=True,
+                              solar_angle=None, verbosity=0,
+                              windspeed_sefd_modifier=None, reference_mjd=None,
+                              cache=None):
+    """Calculate native station terms and return an updated StationTable."""
+
+    metadata = station_metadata_for_dataset(
+        dataset,
+        station_context,
+        reference_mjd=reference_mjd,
+        cache=cache,
+    )
+    return _station_terms_from_rows(
+        metadata["_rows"],
+        metadata,
+        F0,
+        station_context,
+        dataset.stations,
+        rng,
+        gainamp=gainamp,
+        leakamp=leakamp,
+        addgains=addgains,
+        addleakage=addleakage,
+        flagwind=flagwind,
+        flagday=flagday,
+        flagsun=flagsun,
+        solar_angle=solar_angle,
+        verbosity=verbosity,
+        windspeed_sefd_modifier=windspeed_sefd_modifier,
+    )

--- a/tests/test_station_observation.py
+++ b/tests/test_station_observation.py
@@ -1,6 +1,8 @@
 #######################################################
 # imports
 
+import copy
+
 import numpy as np
 import ehtim as eh
 
@@ -8,6 +10,7 @@ import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 #######################################################
 # helpers
@@ -343,3 +346,112 @@ def test_station_terms_populates_gain_and_leakage_arrays_when_enabled():
     assert np.any(terms["gainamp2R"] != 0.0)
     assert np.iscomplexobj(terms["leak1R"])
     assert np.iscomplexobj(terms["leak2R"])
+
+
+def test_native_station_terms_match_obsdata_terms_and_station_table():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, F0 = _source_observation(obsgen)
+    context = _time_varying_weather_context(obsgen, obs)
+    context["tau"]["ALMA"] = np.linspace(0.1, 0.2, len(obs.data))
+    context["windspeed"]["ALMA"] = np.linspace(1.0, 8.0, len(obs.data))
+    kwargs = {
+        "gainamp": 0.04,
+        "leakamp": 0.1,
+        "addgains": True,
+        "addleakage": True,
+        "flagwind": True,
+        "flagday": False,
+        "flagsun": False,
+        "solar_angle": obsgen.solar_angle,
+        "windspeed_sefd_modifier": og.windspeed_SEFD_modification,
+    }
+
+    legacy_array = copy.deepcopy(obsgen.arr)
+    legacy = station_observation.station_terms(
+        obs.copy(),
+        F0,
+        context,
+        legacy_array,
+        np.random.default_rng(17),
+        **kwargs,
+    )
+    native, native_stations = station_observation.station_terms_for_dataset(
+        VisibilityDataset.from_ehtim_obsdata(obs),
+        F0,
+        context,
+        np.random.default_rng(17),
+        reference_mjd=obs.mjd,
+        **kwargs,
+    )
+
+    assert np.array_equal(native["t1"], legacy["t1"])
+    assert np.array_equal(native["t2"], legacy["t2"])
+    assert native["flagsites"] == legacy["flagsites"]
+    for field in (
+        "times",
+        "el1",
+        "el2",
+        "par1",
+        "par2",
+        "tau1",
+        "tau2",
+        "Tb1",
+        "Tb2",
+        "Tsys1",
+        "Tsys2",
+        "SEFD1",
+        "SEFD2",
+        "bw1",
+        "bw2",
+        "f_el1",
+        "f_el2",
+        "f_par1",
+        "f_par2",
+        "phi_off1",
+        "phi_off2",
+        "gainamp1R",
+        "gainamp2R",
+        "gainphase1R",
+        "gainphase2R",
+        "gainamp1L",
+        "gainamp2L",
+        "gainphase1L",
+        "gainphase2L",
+        "leak1R",
+        "leak2R",
+        "leak1L",
+        "leak2L",
+    ):
+        assert np.allclose(native[field], legacy[field], atol=1.0e-10)
+    assert np.array_equal(native["uptime_mask"], legacy["uptime_mask"])
+    assert np.allclose(native_stations.sefd_r_jy, legacy_array.tarr["sefdr"])
+    assert np.allclose(native_stations.sefd_l_jy, legacy_array.tarr["sefdl"])
+    assert np.allclose(native_stations.leakage_r, legacy_array.tarr["dr"])
+    assert np.allclose(native_stations.leakage_l, legacy_array.tarr["dl"])
+
+
+def test_native_station_metadata_uses_cache_without_obsdata_conversion():
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    obs, _ = _source_observation(obsgen)
+    dataset = VisibilityDataset.from_ehtim_obsdata(obs)
+    cache = {}
+
+    metadata = station_observation.station_metadata_for_dataset(
+        dataset,
+        obsgen.station_context(),
+        reference_mjd=obs.mjd,
+        cache=cache,
+    )
+    metadata_again = station_observation.station_metadata_for_dataset(
+        dataset,
+        obsgen.station_context(),
+        reference_mjd=obs.mjd,
+        cache=cache,
+    )
+
+    assert metadata_again is metadata
+    assert len(cache) == 1
+    assert np.array_equal(
+        metadata["_rows"].t1,
+        np.asarray(dataset.stations.names)[dataset.antenna1],
+    )


### PR DESCRIPTION
Extract row-oriented station metadata and term calculations from ehtim Obsdata. Add a ground-only, single-channel VisibilityDataset entry point that returns terms plus an updated StationTable, while retaining station_terms() as the existing compatibility wrapper.