### PR TITLE
Sample images into native visibility datasets

### DIFF
--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -1,8 +1,13 @@
 ###################################################
 # imports
 
+from dataclasses import replace
+
 import numpy as np
 import ehtim as eh
+from astropy.constants import c as SPEED_OF_LIGHT
+
+from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, VisibilityDataset
 
 try:
     import ngEHTforecast.fisher as fp
@@ -80,6 +85,56 @@ class EhtimImageAdapter(object):
 
         F0 = self.input_model.total_flux()
         return obs, F0
+
+    def observe_dataset(self, dataset, context):
+        """Sample an image onto a native circular single-channel dataset."""
+
+        _set_ehtim_metadata(self.input_model, context)
+        if not isinstance(dataset, VisibilityDataset):
+            raise TypeError("dataset must be a VisibilityDataset instance.")
+        if dataset.channel_count != 1:
+            raise ValueError("Native image sampling requires exactly one spectral channel.")
+        if any(
+            dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
+            for index in dataset.row_layout_id
+        ):
+            raise ValueError(
+                "Native image sampling requires circular RR, LL, RL, LR correlations."
+            )
+
+        def sample_dataset():
+            wavelength = SPEED_OF_LIGHT.to_value("m / s") / dataset.channel_frequency_hz[0]
+            uv = dataset.uvw_m[:, :2] / wavelength
+            sampled = self.input_model.sample_uv(
+                uv,
+                polrep_obs="circ",
+                ttype=context["ttype"],
+                fft_pad_factor=context["fft_pad_factor"],
+                verbose=context["verbosity"] > 0,
+            )
+            visibilities = np.array(dataset.visibilities, copy=True)
+            visibilities[:, 0, 0] = sampled[0]
+            if sampled[1] is not None:
+                visibilities[:, 0, 1] = sampled[1]
+            if sampled[2] is not None:
+                visibilities[:, 0, 2] = sampled[2]
+                visibilities[:, 0, 3] = sampled[3]
+
+            return replace(
+                dataset,
+                visibilities=visibilities,
+                source=self.input_model.source,
+                ra_hours=self.input_model.ra,
+                dec_degrees=self.input_model.dec,
+                ampcal=True,
+                phasecal=True,
+                opacitycal=True,
+                dcal=True,
+                frcal=True,
+            )
+
+        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
+        return sampled_dataset, self.input_model.total_flux()
 
 
 class EhtimMovieAdapter(object):
@@ -276,3 +331,13 @@ def adapter_for(input_model):
 
 def observe_source(input_model, obs_empty, context, p=None):
     return adapter_for(input_model).observe(obs_empty, context, p=p)
+
+
+def observe_source_dataset(input_model, dataset, context):
+    """Sample a supported source model onto a native visibility dataset."""
+
+    if not isinstance(input_model, eh.image.Image):
+        raise TypeError(
+            "Native VisibilityDataset sampling currently supports ehtim Image inputs only."
+        )
+    return EhtimImageAdapter(input_model).observe_dataset(dataset, context)

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -7,6 +7,7 @@ import numpy as np
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.source_models as source_models
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 #######################################################
 # helpers
@@ -243,6 +244,71 @@ def test_ehtim_image_adapter_matches_legacy_full_polarization_sampling():
     assert direct_F0 == pytest.approx(legacy_F0)
     for field in ("rrvis", "rlvis", "lrvis", "llvis"):
         assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+
+
+def test_ehtim_image_adapter_samples_native_visibility_dataset():
+    direct_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    legacy_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    direct_image = _polarized_model().make_image(160.0 * eh.RADPERUAS, 64)
+    legacy_image = _polarized_model().make_image(160.0 * eh.RADPERUAS, 64)
+    template = observation_geometry.ground_visibility_template(
+        direct_generator.arr,
+        direct_generator.geometry_context(),
+    )
+
+    direct, direct_F0 = source_models.observe_source_dataset(
+        direct_image,
+        template,
+        direct_generator.source_context(),
+    )
+    legacy, legacy_F0 = _legacy_image_observe(
+        legacy_image,
+        template.to_ehtim_obsdata(),
+        legacy_generator.source_context(),
+    )
+
+    assert direct.source == legacy.source
+    assert direct.ra_hours == legacy.ra
+    assert direct.dec_degrees == legacy.dec
+    assert direct.ampcal is legacy.ampcal is True
+    assert direct.phasecal is legacy.phasecal is True
+    assert direct.opacitycal is legacy.opacitycal is True
+    assert direct.dcal is legacy.dcal is True
+    assert direct.frcal is legacy.frcal is True
+    assert direct_F0 == pytest.approx(legacy_F0)
+    adapted = direct.to_ehtim_obsdata()
+    for field in ("rrvis", "llvis", "rlvis", "lrvis"):
+        assert np.allclose(adapted.data[field], legacy.data[field], atol=1.0e-12)
+
+
+def test_ehtim_image_dataset_sampler_avoids_obsdata_conversion(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    image = _polarized_model().make_image(160.0 * eh.RADPERUAS, 64)
+    template = observation_geometry.ground_visibility_template(
+        obsgen.arr,
+        obsgen.geometry_context(),
+    )
+
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("Native image sampling must not construct an Obsdata object.")
+
+    def unexpected_legacy_sampler(*args, **kwargs):
+        raise AssertionError("Native image sampling must not call observe_same_nonoise.")
+
+    monkeypatch.setattr(
+        VisibilityDataset,
+        "to_ehtim_obsdata",
+        unexpected_obsdata_conversion,
+    )
+    monkeypatch.setattr(image, "observe_same_nonoise", unexpected_legacy_sampler)
+    sampled, F0 = source_models.observe_source_dataset(
+        image,
+        template,
+        obsgen.source_context(),
+    )
+
+    assert sampled.row_count == template.row_count
+    assert F0 > 0.0
 
 
 def test_ehtim_movie_adapter_does_not_call_observe_same_nonoise(monkeypatch):


### PR DESCRIPTION
Add direct ehtim.Image sampling into ground-only, single-channel circular VisibilityDataset templates. Preserve ehtim Image input compatibility while avoiding Obsdata construction during source sampling.