### PR TITLE
Correct circular visibility corruptions

### DIFF
--- a/ngehtsim/files/Telescope_Site_Matrix.csv
+++ b/ngehtsim/files/Telescope_Site_Matrix.csv
@@ -96,7 +96,7 @@ OVRO,OV,US,37.231409,-118.282436,1207,Owens Valley Radio Observatory,10.4,40,,ci
 PAR,PR,Chile,-24.628155,-70.404142,2638,Paranal Observatory,,,,,,,
 PIKE,PK,US,38.840837,-105.041792,4284,Pikes Peak,,,,,,,PIKES
 PRKS,PA,Australia,-32.998328,148.263623,415,Parkes Observatory,64,1500,,linear,,,
-ROEN,FT,Brazil,-3.877487,-38.426339,28,Fortaleza Geodetic Observatory aka Radio Observatorio Espacial do Nordeste,12,100,,lienar,,,
+ROEN,FT,Brazil,-3.877487,-38.426339,28,Fortaleza Geodetic Observatory aka Radio Observatorio Espacial do Nordeste,12,100,,linear,,,
 ROT,RT,Armenia,40.352974,44.239865,1739,site of the inactive ROT54 radio telescope,,,,,,,
 SAN,SN,US,34.099287,-116.824632,3502,summit of San Gorgonio mountain,,,,,,,
 SEJ,KV,South Korea,36.520991,127.302913,146,Sejong VLBI station,22,100,,linear,,,

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -1,0 +1,52 @@
+"""Pure circular-basis visibility corruption kernels."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
+                           leakage2_l):
+    """Apply ``D_1 V D_2^H`` to circular RR, LL, RL, LR visibilities.
+
+    The final axis of ``visibilities`` must use the order ``RR, LL, RL, LR``.
+    The result is a new array so every output correlation is calculated from
+    the same, unmodified input coherency matrix.
+    """
+
+    visibilities = np.asarray(visibilities, dtype=complex)
+    if visibilities.ndim < 1 or visibilities.shape[-1] != 4:
+        raise ValueError(
+            "Circular visibility data must have a final RR, LL, RL, LR axis."
+        )
+
+    rr = visibilities[..., 0]
+    ll = visibilities[..., 1]
+    rl = visibilities[..., 2]
+    lr = visibilities[..., 3]
+    output = np.empty_like(visibilities)
+    output[..., 0] = (
+        rr
+        + leakage1_r * lr
+        + np.conj(leakage2_r) * rl
+        + leakage1_r * np.conj(leakage2_r) * ll
+    )
+    output[..., 1] = (
+        ll
+        + leakage1_l * rl
+        + np.conj(leakage2_l) * lr
+        + leakage1_l * np.conj(leakage2_l) * rr
+    )
+    output[..., 2] = (
+        rl
+        + leakage1_r * ll
+        + np.conj(leakage2_l) * rr
+        + leakage1_r * np.conj(leakage2_l) * lr
+    )
+    output[..., 3] = (
+        lr
+        + leakage1_l * rr
+        + np.conj(leakage2_r) * ll
+        + leakage1_l * np.conj(leakage2_r) * rl
+    )
+    return output

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -18,6 +18,7 @@ import warnings
 import ngehtsim.const_def as const
 import ngehtsim.weather.weather as nw
 from ngehtsim.weather.zarr_store import ZarrWeatherStore
+import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.station_observation as station_observation
@@ -771,7 +772,7 @@ class obs_generator(object):
             effective_area[site] = (np.pi/4.0)*self.eta_dict[site]*((self.D_dict[site])**2)
             mount_type[site] = const.known_mount_types.get(site, const.mount_type)
             feed_angle[site] = const.known_feed_angles.get(site, const.feed_angle)
-            polarization_basis[site] = const.known_polbases.get(site)
+            polarization_basis[site] = const.known_polbases.get(site, const.pol_basis)
 
         if self.weather_cadence == 'native':
             if times is None:
@@ -824,7 +825,7 @@ class obs_generator(object):
           flagwind (bool): flag for whether to derate sites with high wind
           flagday (bool): flag for whether to flag sites during the local daytime
           flagsun (bool): flag for whether to impose a minimum solar avoidance angle
-          allow_mixed_basis (bool): flag for whether to apply polarization basis conversions
+          allow_mixed_basis (bool): currently unsupported; must be False
           el_min (float): minimum elevation that a site can observe at, in degrees
           el_max (float): maximum elevation that a site can observe at, in degrees
           p (numpy.ndarray): list of parameters for an input ngEHTforecast.fisher.fisher_forecast.FisherForecast object
@@ -833,9 +834,11 @@ class obs_generator(object):
           (ehtim.obsdata.Obsdata): eht-imaging Obsdata object containing the generated observation
         """
 
-        # print some warnings
         if allow_mixed_basis:
-            print('WARNING: data generated in a non-circular polarization basis does not have properly-stored metadata info.')
+            raise NotImplementedError(
+                "Mixed-polarization output requires VisibilityDataset support and "
+                "cannot be represented safely as ehtim Obsdata."
+            )
 
         # generate and elevation-limit an empty observation template
         self.obs_empty, self.obs_empty_key, self.obs_template_cache, obs_empty = observation_geometry.observation_template(
@@ -946,14 +949,23 @@ class obs_generator(object):
                 self.station_leakage2R = leak2R
                 self.station_leakage1L = leak1L
                 self.station_leakage2L = leak2L
-            RR = obs.data['rrvis']
-            LL = obs.data['llvis']
-            RL = obs.data['rlvis']
-            LR = obs.data['lrvis']
-            obs.data['rrvis'] = RR + (leak1R*LR) + (np.conj(leak2R)*RL) + (leak1R*np.conj(leak2R)*LL)
-            obs.data['llvis'] = LL + (leak1L*RL) + (np.conj(leak2L)*LR) + (leak1L*np.conj(leak2L)*RR)
-            obs.data['rlvis'] = RL + (leak1R*LL) + (np.conj(leak2L)*RR) + (leak1R*np.conj(leak2L)*LR)
-            obs.data['lrvis'] = LR + (leak1L*RR) + (np.conj(leak2R)*LL) + (leak1L*np.conj(leak2R)*RL)
+            visibilities = np.column_stack((
+                obs.data['rrvis'],
+                obs.data['llvis'],
+                obs.data['rlvis'],
+                obs.data['lrvis'],
+            ))
+            visibilities = instrumental_corruptions.apply_circular_leakage(
+                visibilities,
+                leak1R,
+                leak1L,
+                leak2R,
+                leak2L,
+            )
+            obs.data['rrvis'] = visibilities[:, 0]
+            obs.data['llvis'] = visibilities[:, 1]
+            obs.data['rlvis'] = visibilities[:, 2]
+            obs.data['lrvis'] = visibilities[:, 3]
 
         # store and apply gains
         if addgains:
@@ -1005,10 +1017,10 @@ class obs_generator(object):
 
         # add thermal noise to observations
         if addnoise:
-            obs.data['rrvis'] += sigma*(self.rng.normal(0.0, 1.0, len(obs.data['rrsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['rrsigma']))))
-            obs.data['llvis'] += sigma*(self.rng.normal(0.0, 1.0, len(obs.data['llsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['llsigma']))))
-            obs.data['rlvis'] += sigma*(self.rng.normal(0.0, 1.0, len(obs.data['rlsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['rlsigma']))))
-            obs.data['lrvis'] += sigma*(self.rng.normal(0.0, 1.0, len(obs.data['lrsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['lrsigma']))))
+            obs.data['rrvis'] += obs.data['rrsigma']*(self.rng.normal(0.0, 1.0, len(obs.data['rrsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['rrsigma']))))
+            obs.data['llvis'] += obs.data['llsigma']*(self.rng.normal(0.0, 1.0, len(obs.data['llsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['llsigma']))))
+            obs.data['rlvis'] += obs.data['rlsigma']*(self.rng.normal(0.0, 1.0, len(obs.data['rlsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['rlsigma']))))
+            obs.data['lrvis'] += obs.data['lrsigma']*(self.rng.normal(0.0, 1.0, len(obs.data['lrsigma'])) + ((1.0j)*self.rng.normal(0.0, 1.0, len(obs.data['lrsigma']))))
 
         # create mask and populate it with the sites that should not be flagged
         t1_list = obs.unpack('t1')['t1']
@@ -1080,7 +1092,7 @@ class obs_generator(object):
           flagwind (bool): flag for whether to derate sites with high wind
           flagday (bool): flag for whether to flag sites during the local daytime
           flagsun (bool): flag for whether to impose a minimum solar avoidance angle
-          allow_mixed_basis (bool): flag for whether to apply polarization basis conversions
+          allow_mixed_basis (bool): currently unsupported; must be False
           el_min (float): minimum elevation that a site can observe at, in degrees
           el_max (float): maximum elevation that a site can observe at, in degrees
           p (numpy.ndarray): list of parameters for an input ngEHTforecast.fisher.fisher_forecast.FisherForecast object

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -268,39 +268,6 @@ def station_metadata_for_dataset(dataset, station_context, reference_mjd=None, c
     return metadata
 
 
-def _apply_mixed_basis(obs, metadata, station_context):
-    for site in metadata["sites_obs"]:
-        if station_context["polarization_basis"][site] != "linear":
-            continue
-        index1, index2 = metadata["site_masks"][site]
-        transform1 = np.zeros((index1.sum(), 2, 2), dtype=complex)
-        transform2 = np.zeros((index2.sum(), 2, 2), dtype=complex)
-        transform1[:] = const.circ_to_lin
-        transform2[:] = np.conj(const.circ_to_lin).T
-
-        coherence1 = np.zeros((index1.sum(), 2, 2), dtype=complex)
-        coherence1[:, 0, 0] = obs.data["rrvis"][index1]
-        coherence1[:, 0, 1] = obs.data["rlvis"][index1]
-        coherence1[:, 1, 0] = obs.data["lrvis"][index1]
-        coherence1[:, 1, 1] = obs.data["llvis"][index1]
-        coherence2 = np.zeros((index2.sum(), 2, 2), dtype=complex)
-        coherence2[:, 0, 0] = obs.data["rrvis"][index2]
-        coherence2[:, 0, 1] = obs.data["rlvis"][index2]
-        coherence2[:, 1, 0] = obs.data["lrvis"][index2]
-        coherence2[:, 1, 1] = obs.data["llvis"][index2]
-
-        transformed1 = np.matmul(transform1, coherence1)
-        transformed2 = np.matmul(coherence2, transform2)
-        obs.data["rrvis"][index1] = transformed1[:, 0, 0]
-        obs.data["rlvis"][index1] = transformed1[:, 0, 1]
-        obs.data["lrvis"][index1] = transformed1[:, 1, 0]
-        obs.data["llvis"][index1] = transformed1[:, 1, 1]
-        obs.data["rrvis"][index2] = transformed2[:, 0, 0]
-        obs.data["rlvis"][index2] = transformed2[:, 0, 1]
-        obs.data["lrvis"][index2] = transformed2[:, 1, 0]
-        obs.data["llvis"][index2] = transformed2[:, 1, 1]
-
-
 def _updated_station_table(stations, sefd_r_jy, sefd_l_jy, leakage_r, leakage_l):
     return StationTable(
         names=stations.names,
@@ -567,9 +534,12 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
                   verbosity=0, windspeed_sefd_modifier=None, cache=None):
     """Calculate legacy Obsdata station terms through the native row kernel."""
 
-    metadata = station_metadata(obs, station_context, cache=cache)
     if allow_mixed_basis:
-        _apply_mixed_basis(obs, metadata, station_context)
+        raise NotImplementedError(
+            "Mixed-polarization station terms require VisibilityDataset support."
+        )
+
+    metadata = station_metadata(obs, station_context, cache=cache)
     terms, stations = _station_terms_from_rows(
         metadata["_rows"],
         metadata,

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -1,0 +1,212 @@
+"""Measurement-equation regression tests for circular synthetic data."""
+
+import numpy as np
+import pytest
+import ehtim as eh
+
+import ngehtsim.const_def as const
+import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
+import ngehtsim.obs.obs_generator as og
+
+
+SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 2.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "fringe_finder": ["naive", 0.0],
+    "random_seed": 1,
+}
+
+
+class FixedRng:
+    """Return deterministic draws that expose visibility/sigma mismatches."""
+
+    def normal(self, loc=0.0, scale=1.0, size=None):
+        if size is None:
+            return 1.0
+        return np.ones(size, dtype=float)
+
+    def uniform(self, low=0.0, high=1.0, size=None):
+        if size is None:
+            return 0.0
+        return np.zeros(size, dtype=float)
+
+    def choice(self, values, size=None, replace=True, p=None):
+        return np.zeros(size, dtype=int)
+
+
+def _polarized_model():
+    model = eh.model.Model()
+    return model.add_circ_gauss(
+        F0=1.0,
+        FWHM=40.0 * eh.RADPERUAS,
+        pol_frac=0.25,
+        pol_evpa=30.0 * eh.DEGREE,
+        cpol_frac=0.10,
+    )
+
+
+def _coherency_matrices(obs):
+    matrices = np.empty((len(obs.data), 2, 2), dtype=complex)
+    matrices[:, 0, 0] = obs.data["rrvis"]
+    matrices[:, 0, 1] = obs.data["rlvis"]
+    matrices[:, 1, 0] = obs.data["lrvis"]
+    matrices[:, 1, 1] = obs.data["llvis"]
+    return matrices
+
+
+def _station_jones(gain_r, gain_l, leakage_r, leakage_l, feed_rotation):
+    jones = np.empty((len(feed_rotation), 2, 2), dtype=complex)
+    jones[:, 0, 0] = gain_r * np.exp(-1.0j * feed_rotation)
+    jones[:, 0, 1] = gain_r * leakage_r * np.exp(1.0j * feed_rotation)
+    jones[:, 1, 0] = gain_l * leakage_l * np.exp(-1.0j * feed_rotation)
+    jones[:, 1, 1] = gain_l * np.exp(1.0j * feed_rotation)
+    return jones
+
+
+def test_circular_leakage_matches_jones_matrix():
+    visibilities = np.array(
+        [
+            [1.2 + 0.4j, 0.5 + 0.1j, -0.3 + 0.7j, 0.9 - 0.2j],
+            [0.7 - 0.5j, -0.1 + 0.3j, 0.4 + 0.6j, 0.2 - 0.8j],
+        ]
+    )
+    leakage1_r = np.array([0.13 - 0.08j, -0.06 + 0.04j])
+    leakage1_l = np.array([-0.05 + 0.11j, 0.08 + 0.02j])
+    leakage2_r = np.array([-0.09 + 0.06j, 0.03 - 0.07j])
+    leakage2_l = np.array([0.07 + 0.04j, -0.02 + 0.09j])
+
+    actual = instrumental_corruptions.apply_circular_leakage(
+        visibilities,
+        leakage1_r,
+        leakage1_l,
+        leakage2_r,
+        leakage2_l,
+    )
+    coherency = np.empty((len(visibilities), 2, 2), dtype=complex)
+    coherency[:, 0, 0] = visibilities[:, 0]
+    coherency[:, 0, 1] = visibilities[:, 2]
+    coherency[:, 1, 0] = visibilities[:, 3]
+    coherency[:, 1, 1] = visibilities[:, 1]
+    d1 = np.zeros_like(coherency)
+    d2 = np.zeros_like(coherency)
+    d1[:, 0, 0] = d1[:, 1, 1] = 1.0
+    d2[:, 0, 0] = d2[:, 1, 1] = 1.0
+    d1[:, 0, 1] = leakage1_r
+    d1[:, 1, 0] = leakage1_l
+    d2[:, 0, 1] = leakage2_r
+    d2[:, 1, 0] = leakage2_l
+    expected_coherency = d1 @ coherency @ np.swapaxes(np.conj(d2), -1, -2)
+    expected = np.column_stack((
+        expected_coherency[:, 0, 0],
+        expected_coherency[:, 1, 1],
+        expected_coherency[:, 0, 1],
+        expected_coherency[:, 1, 0],
+    ))
+
+    assert np.allclose(actual, expected, atol=1.0e-12)
+    assert np.allclose(visibilities, np.array([
+        [1.2 + 0.4j, 0.5 + 0.1j, -0.3 + 0.7j, 0.9 - 0.2j],
+        [0.7 - 0.5j, -0.1 + 0.3j, 0.4 + 0.6j, 0.2 - 0.8j],
+    ]))
+
+
+def test_circular_generator_matches_composed_station_jones_matrices():
+    clean_generator = og.obs_generator(settings=SETTINGS)
+    clean = clean_generator.make_obs(
+        _polarized_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    corrupted_generator = og.obs_generator(settings=SETTINGS, weight=1)
+    corrupted = corrupted_generator.make_obs(
+        _polarized_model(),
+        addnoise=False,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert np.array_equal(corrupted.data["t1"], clean.data["t1"])
+    assert np.array_equal(corrupted.data["t2"], clean.data["t2"])
+    assert np.allclose(corrupted.data["time"], clean.data["time"])
+
+    jones1 = _station_jones(
+        corrupted_generator.station_gains1R,
+        corrupted_generator.station_gains1L,
+        corrupted_generator.station_leakage1R,
+        corrupted_generator.station_leakage1L,
+        corrupted_generator.fa_1,
+    )
+    jones2 = _station_jones(
+        corrupted_generator.station_gains2R,
+        corrupted_generator.station_gains2L,
+        corrupted_generator.station_leakage2R,
+        corrupted_generator.station_leakage2L,
+        corrupted_generator.fa_2,
+    )
+    expected = jones1 @ _coherency_matrices(clean) @ np.swapaxes(np.conj(jones2), -1, -2)
+
+    assert np.allclose(_coherency_matrices(corrupted), expected, atol=1.0e-12)
+
+
+def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
+    clean_generator = og.obs_generator(settings=SETTINGS)
+    clean_generator.rng = FixedRng()
+    clean = clean_generator.make_obs(
+        _polarized_model(),
+        addnoise=False,
+        addgains=True,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    noisy_generator = og.obs_generator(settings=SETTINGS)
+    noisy_generator.rng = FixedRng()
+    noisy = noisy_generator.make_obs(
+        _polarized_model(),
+        addnoise=True,
+        addgains=True,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    for visibility_field, sigma_field in (
+        ("rrvis", "rrsigma"),
+        ("llvis", "llsigma"),
+        ("rlvis", "rlsigma"),
+        ("lrvis", "lrsigma"),
+    ):
+        assert np.allclose(noisy.data[sigma_field], clean.data[sigma_field])
+        assert np.allclose(
+            noisy.data[visibility_field] - clean.data[visibility_field],
+            (1.0 + 1.0j) * noisy.data[sigma_field],
+        )
+
+
+def test_mixed_basis_output_is_rejected_until_native_support_exists():
+    obsgen = og.obs_generator(settings=SETTINGS)
+
+    with pytest.raises(NotImplementedError, match="Mixed-polarization output"):
+        obsgen.make_obs(_polarized_model(), allow_mixed_basis=True)
+
+
+def test_station_registry_marks_roen_as_linear():
+    assert const.known_polbases["ROEN"] == "linear"


### PR DESCRIPTION
Correct D-term leakage application, align injected thermal noise with reported gain-corrupted sigmas, reject unsafe mixed-basis Obsdata output, fix the ROEN polarization metadata, and add independent Jones-matrix regression tests.