### PR TITLE
Add native circular visibility corruptions

### DIFF
--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import numpy as np
+
+import ngehtsim.const_def as const
+from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, StationTable, VisibilityDataset
 
 
 def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
@@ -50,3 +55,171 @@ def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
         + leakage1_l * np.conj(leakage2_r) * rl
     )
     return output
+
+
+def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=True,
+                               addgains=True, opacitycal=True, addFR=True,
+                               addleakage=False):
+    """Apply circular station terms to a native single-channel dataset.
+
+    Flagged rows remain in the returned dataset. Use ``select_rows()`` before
+    converting an eligible result to ``ehtim.Obsdata``.
+    """
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if not isinstance(stations, StationTable):
+        raise TypeError("stations must be a StationTable instance.")
+    if dataset.channel_count != 1:
+        raise ValueError("Circular corruption currently requires exactly one channel.")
+    if any(
+        dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
+        for index in dataset.row_layout_id
+    ):
+        raise ValueError(
+            "Circular corruption requires RR, LL, RL, LR correlations for every row."
+        )
+
+    count = dataset.row_count
+    terms = {
+        name: _term_array(station_terms, name, count)
+        for name in (
+            "t1", "t2", "tau1", "tau2", "SEFD1", "SEFD2", "bw1", "bw2",
+            "f_el1", "f_el2", "f_par1", "f_par2", "el1", "el2", "par1",
+            "par2", "phi_off1", "phi_off2", "uptime_mask",
+        )
+    }
+    expected_t1 = np.asarray(dataset.stations.names)[dataset.antenna1]
+    expected_t2 = np.asarray(dataset.stations.names)[dataset.antenna2]
+    if not np.array_equal(terms["t1"], expected_t1) or not np.array_equal(terms["t2"], expected_t2):
+        raise ValueError("Station terms do not correspond to the dataset row order.")
+
+    visibilities = np.array(dataset.visibilities, copy=True)
+    circular = visibilities[:, 0, :]
+    tau1 = np.asarray(terms["tau1"], dtype=float)
+    tau2 = np.asarray(terms["tau2"], dtype=float)
+    if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
+        raise ValueError("Station opacity terms must be non-negative.")
+
+    if addFR:
+        feed_rotation1 = (
+            terms["f_par1"] * terms["par1"]
+            + terms["f_el1"] * terms["el1"]
+            + (np.pi / 180.0) * terms["phi_off1"]
+        )
+        feed_rotation2 = (
+            terms["f_par2"] * terms["par2"]
+            + terms["f_el2"] * terms["el2"]
+            + (np.pi / 180.0) * terms["phi_off2"]
+        )
+        feed_rotation1 = np.array(feed_rotation1, copy=True)
+        feed_rotation2 = np.array(feed_rotation2, copy=True)
+        feed_rotation1[terms["t1"] == "space"] = 0.0
+        feed_rotation2[terms["t2"] == "space"] = 0.0
+        circular[:, 0] *= np.exp(-1.0j * feed_rotation1) * np.exp(1.0j * feed_rotation2)
+        circular[:, 1] *= np.exp(1.0j * feed_rotation1) * np.exp(-1.0j * feed_rotation2)
+        circular[:, 2] *= np.exp(-1.0j * feed_rotation1) * np.exp(-1.0j * feed_rotation2)
+        circular[:, 3] *= np.exp(1.0j * feed_rotation1) * np.exp(1.0j * feed_rotation2)
+
+    if addleakage:
+        leakage_terms = {
+            name: _term_array(station_terms, name, count)
+            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
+        }
+        circular[:] = apply_circular_leakage(
+            circular,
+            leakage_terms["leak1R"],
+            leakage_terms["leak1L"],
+            leakage_terms["leak2R"],
+            leakage_terms["leak2L"],
+        )
+
+    sigma = _baseline_sigmas(
+        terms["SEFD1"],
+        terms["SEFD2"],
+        np.minimum(terms["bw1"], terms["bw2"]),
+        dataset.integration_time_s,
+        tau1,
+        tau2,
+        opacitycal,
+    )
+    if addgains:
+        gain_terms = {
+            name: _term_array(station_terms, name, count)
+            for name in (
+                "gainamp1R", "gainamp1L", "gainamp2R", "gainamp2L",
+                "gainphase1R", "gainphase1L", "gainphase2R", "gainphase2L",
+            )
+        }
+        gain1r = gain_terms["gainamp1R"] * np.exp(1.0j * gain_terms["gainphase1R"])
+        gain1l = gain_terms["gainamp1L"] * np.exp(1.0j * gain_terms["gainphase1L"])
+        gain2r = gain_terms["gainamp2R"] * np.exp(1.0j * gain_terms["gainphase2R"])
+        gain2l = gain_terms["gainamp2L"] * np.exp(1.0j * gain_terms["gainphase2L"])
+        gain_products = np.column_stack((
+            gain1r * np.conj(gain2r),
+            gain1l * np.conj(gain2l),
+            gain1r * np.conj(gain2l),
+            gain1l * np.conj(gain2r),
+        ))
+        circular *= gain_products
+        sigma *= np.abs(gain_products)
+
+    if not opacitycal:
+        circular *= np.sqrt(np.exp(-tau1 - tau2))[:, np.newaxis]
+
+    if addnoise:
+        for index in range(4):
+            circular[:, index] += sigma[:, index] * (
+                rng.normal(0.0, 1.0, count)
+                + 1.0j * rng.normal(0.0, 1.0, count)
+            )
+
+    flags = np.array(dataset.flags, copy=True)
+    flagged_sites = set(station_terms["flagsites"])
+    row_mask = (
+        ~np.isin(terms["t1"], tuple(flagged_sites))
+        & ~np.isin(terms["t2"], tuple(flagged_sites))
+        & np.asarray(terms["uptime_mask"], dtype=bool)
+    )
+    flags[:, 0, :] |= ~row_mask[:, np.newaxis]
+    weights = np.array(dataset.weights, copy=True)
+    weights[:, 0, :] = 1.0 / np.square(sigma)
+    return replace(
+        dataset,
+        stations=stations,
+        tau1=tau1,
+        tau2=tau2,
+        visibilities=visibilities,
+        weights=weights,
+        flags=flags,
+        ampcal=not addgains,
+        phasecal=not addgains,
+        opacitycal=opacitycal,
+        dcal=not addleakage,
+        frcal=not addFR,
+    )
+
+
+def _term_array(station_terms, name, count):
+    try:
+        values = np.asarray(station_terms[name])
+    except KeyError as exc:
+        raise ValueError("Missing station term: {0}.".format(name)) from exc
+    if values.shape != (count,):
+        raise ValueError(
+            "Station term {0} must have one value per visibility row.".format(name)
+        )
+    return values
+
+
+def _baseline_sigmas(sefd1, sefd2, bandwidth_hz, integration_time_s, tau1, tau2,
+                     opacitycal):
+    bandwidth_hz = np.asarray(bandwidth_hz, dtype=float)
+    if np.any(bandwidth_hz <= 0.0):
+        raise ValueError("Station bandwidths must be positive.")
+    opacity_factor = np.exp(tau1 + tau2) if opacitycal else 1.0
+    sigma = np.sqrt(
+        (np.asarray(sefd1, dtype=float) * np.asarray(sefd2, dtype=float) * opacity_factor)
+        / (2.0 * bandwidth_hz * integration_time_s)
+    ) / const.quant_eff
+    return np.broadcast_to(sigma[:, np.newaxis], (len(sigma), 4)).copy()

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -1068,6 +1068,12 @@ class obs_generator(object):
                 self.station_leakage1L = self.station_leakage1L[mask]
                 self.station_leakage2L = self.station_leakage2L[mask]
 
+        obs.ampcal = not addgains
+        obs.phasecal = not addgains
+        obs.opacitycal = opacitycal
+        obs.dcal = not addleakage
+        obs.frcal = not addFR
+
         # return observation object
         return obs
 

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import numpy as np
 from astropy.constants import c as SPEED_OF_LIGHT
@@ -293,6 +293,29 @@ class VisibilityDataset:
         """Return the number of spectral channels."""
 
         return len(self.channel_frequency_hz)
+
+    def select_rows(self, row_mask):
+        """Return a dataset containing the selected visibility rows."""
+
+        row_mask = np.asarray(row_mask)
+        if row_mask.dtype != bool or row_mask.shape != (self.row_count,):
+            raise ValueError(
+                "row_mask must be a boolean array with one value per visibility row."
+            )
+        return replace(
+            self,
+            time_mjd=self.time_mjd[row_mask],
+            integration_time_s=self.integration_time_s[row_mask],
+            antenna1=self.antenna1[row_mask],
+            antenna2=self.antenna2[row_mask],
+            uvw_m=self.uvw_m[row_mask],
+            tau1=self.tau1[row_mask],
+            tau2=self.tau2[row_mask],
+            row_layout_id=self.row_layout_id[row_mask],
+            visibilities=self.visibilities[row_mask],
+            weights=self.weights[row_mask],
+            flags=self.flags[row_mask],
+        )
 
     @classmethod
     def from_ehtim_obsdata(cls, obs):

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -6,7 +6,11 @@ import ehtim as eh
 
 import ngehtsim.const_def as const
 import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
+import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.obs_generator as og
+import ngehtsim.obs.source_models as source_models
+import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 
 SETTINGS = {
@@ -50,6 +54,28 @@ def _polarized_model():
     )
 
 
+def _polarized_image():
+    return _polarized_model().make_image(160.0 * eh.RADPERUAS, 64)
+
+
+def _elevation_limited(dataset):
+    geometry = observation_geometry.station_geometry_from_rows(
+        dataset.stations.position_itrs_m,
+        dataset.time_mjd,
+        dataset.antenna1,
+        dataset.antenna2,
+        dataset.ra_hours,
+        dataset.dec_degrees,
+    )
+    mask = (
+        (np.rad2deg(geometry.elevation1_rad) > const.el_min)
+        & (np.rad2deg(geometry.elevation1_rad) < const.el_max)
+        & (np.rad2deg(geometry.elevation2_rad) > const.el_min)
+        & (np.rad2deg(geometry.elevation2_rad) < const.el_max)
+    )
+    return dataset.select_rows(mask)
+
+
 def _coherency_matrices(obs):
     matrices = np.empty((len(obs.data), 2, 2), dtype=complex)
     matrices[:, 0, 0] = obs.data["rrvis"]
@@ -57,6 +83,19 @@ def _coherency_matrices(obs):
     matrices[:, 1, 0] = obs.data["lrvis"]
     matrices[:, 1, 1] = obs.data["llvis"]
     return matrices
+
+
+def _native_row_order(dataset):
+    names = np.asarray(dataset.stations.names)
+    return np.lexsort((
+        names[dataset.antenna2],
+        names[dataset.antenna1],
+        dataset.time_mjd,
+    ))
+
+
+def _obsdata_row_order(obs):
+    return np.lexsort((obs.data["t2"], obs.data["t1"], obs.data["time"]))
 
 
 def _station_jones(gain_r, gain_l, leakage_r, leakage_l, feed_rotation):
@@ -160,6 +199,16 @@ def test_circular_generator_matches_composed_station_jones_matrices():
     expected = jones1 @ _coherency_matrices(clean) @ np.swapaxes(np.conj(jones2), -1, -2)
 
     assert np.allclose(_coherency_matrices(corrupted), expected, atol=1.0e-12)
+    assert clean.ampcal is True
+    assert clean.phasecal is True
+    assert clean.opacitycal is True
+    assert clean.dcal is True
+    assert clean.frcal is True
+    assert corrupted.ampcal is False
+    assert corrupted.phasecal is False
+    assert corrupted.opacitycal is True
+    assert corrupted.dcal is False
+    assert corrupted.frcal is False
 
 
 def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
@@ -199,6 +248,261 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
             noisy.data[visibility_field] - clean.data[visibility_field],
             (1.0 + 1.0j) * noisy.data[sigma_field],
         )
+
+
+def test_generator_marks_uncalibrated_opacity_in_output_metadata():
+    obs = og.obs_generator(settings=SETTINGS).make_obs(
+        _polarized_model(),
+        addnoise=False,
+        addgains=False,
+        opacitycal=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert obs.ampcal is True
+    assert obs.phasecal is True
+    assert obs.opacitycal is False
+    assert obs.dcal is True
+    assert obs.frcal is True
+
+
+def _native_dataset_and_terms(generator, image, **kwargs):
+    template = observation_geometry.ground_visibility_template(
+        generator.arr,
+        generator.geometry_context(),
+    )
+    sampled, F0 = source_models.observe_source_dataset(
+        image,
+        template,
+        generator.source_context(),
+    )
+    sampled = _elevation_limited(sampled)
+    station_keys = (
+        "gainamp",
+        "leakamp",
+        "addgains",
+        "addleakage",
+        "flagwind",
+        "flagday",
+        "flagsun",
+    )
+    station_terms, stations = station_observation.station_terms_for_dataset(
+        sampled,
+        F0,
+        generator.station_context((sampled.time_mjd - generator.mjd) * 24.0),
+        generator.rng,
+        solar_angle=generator.solar_angle,
+        windspeed_sefd_modifier=og.windspeed_SEFD_modification,
+        reference_mjd=generator.mjd,
+        cache=generator.station_term_cache,
+        **{key: kwargs[key] for key in station_keys if key in kwargs},
+    )
+    return sampled, station_terms, stations
+
+
+def _native_corrupted_dataset(generator, image, **kwargs):
+    sampled, station_terms, stations = _native_dataset_and_terms(generator, image, **kwargs)
+    corruption_keys = ("addnoise", "addgains", "opacitycal", "addFR", "addleakage")
+    return instrumental_corruptions.apply_circular_corruptions(
+        sampled,
+        station_terms,
+        stations,
+        generator.rng,
+        **{key: kwargs[key] for key in corruption_keys if key in kwargs},
+    )
+
+
+def test_native_circular_corruptions_match_legacy_generator_without_noise(monkeypatch):
+    kwargs = {
+        "addnoise": False,
+        "addgains": True,
+        "gainamp": 0.04,
+        "leakamp": 0.1,
+        "opacitycal": True,
+        "addFR": True,
+        "addleakage": True,
+        "flagwind": False,
+        "flagday": False,
+        "flagsun": False,
+    }
+    native_generator = og.obs_generator(settings=SETTINGS)
+    native_generator.rng = FixedRng()
+    native = _native_corrupted_dataset(native_generator, _polarized_image(), **kwargs)
+
+    legacy_generator = og.obs_generator(settings=SETTINGS)
+    legacy_generator.rng = FixedRng()
+    legacy_template = observation_geometry.ground_visibility_template(
+        legacy_generator.arr,
+        legacy_generator.geometry_context(),
+    )
+    legacy_empty = _elevation_limited(legacy_template).to_ehtim_obsdata()
+
+    def fixed_template(*args, **ignored_kwargs):
+        return legacy_empty, "native-test-template", {}, legacy_empty.copy()
+
+    monkeypatch.setattr(observation_geometry, "observation_template", fixed_template)
+    legacy = legacy_generator.observe(_polarized_image(), **kwargs)
+    unflagged = native.select_rows(~np.any(native.flags[:, 0, :], axis=1))
+    native_order = _native_row_order(unflagged)
+    legacy_order = _obsdata_row_order(legacy)
+    native_names = np.asarray(unflagged.stations.names)
+    native_visibilities = unflagged.visibilities[:, 0, :]
+    native_sigma = 1.0 / np.sqrt(unflagged.weights[:, 0, :])
+    legacy_visibilities = np.column_stack((
+        legacy.data["rrvis"],
+        legacy.data["llvis"],
+        legacy.data["rlvis"],
+        legacy.data["lrvis"],
+    ))
+    legacy_sigma = np.column_stack((
+        legacy.data["rrsigma"],
+        legacy.data["llsigma"],
+        legacy.data["rlsigma"],
+        legacy.data["lrsigma"],
+    ))
+
+    assert np.array_equal(
+        native_names[unflagged.antenna1][native_order],
+        legacy.data["t1"][legacy_order],
+    )
+    assert np.array_equal(
+        native_names[unflagged.antenna2][native_order],
+        legacy.data["t2"][legacy_order],
+    )
+    assert np.allclose(
+        (unflagged.time_mjd[native_order] - legacy.mjd) * 24.0,
+        legacy.data["time"][legacy_order],
+        atol=1.0e-12,
+    )
+    assert np.allclose(
+        unflagged.integration_time_s[native_order],
+        legacy.data["tint"][legacy_order],
+        atol=1.0e-12,
+    )
+    assert np.allclose(unflagged.tau1[native_order], legacy.data["tau1"][legacy_order], atol=1.0e-12)
+    assert np.allclose(unflagged.tau2[native_order], legacy.data["tau2"][legacy_order], atol=1.0e-12)
+    assert np.allclose(native_visibilities[native_order], legacy_visibilities[legacy_order], atol=1.0e-12)
+    assert np.allclose(native_sigma[native_order], legacy_sigma[legacy_order], atol=1.0e-12)
+    assert unflagged.ampcal is legacy.ampcal is False
+    assert unflagged.phasecal is legacy.phasecal is False
+    assert unflagged.opacitycal is legacy.opacitycal is True
+    assert unflagged.dcal is legacy.dcal is False
+    assert unflagged.frcal is legacy.frcal is False
+
+
+def test_native_circular_corruptions_do_not_require_obsdata_conversion(monkeypatch):
+    generator = og.obs_generator(settings=SETTINGS)
+    sampled, station_terms, stations = _native_dataset_and_terms(
+        generator,
+        _polarized_image(),
+        addgains=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("Native corruptions must not construct an Obsdata object.")
+
+    monkeypatch.setattr(
+        VisibilityDataset,
+        "to_ehtim_obsdata",
+        unexpected_obsdata_conversion,
+    )
+    corrupted = instrumental_corruptions.apply_circular_corruptions(
+        sampled,
+        station_terms,
+        stations,
+        generator.rng,
+        addnoise=False,
+        addgains=False,
+        opacitycal=False,
+        addFR=False,
+        addleakage=False,
+    )
+
+    assert isinstance(corrupted, VisibilityDataset)
+    assert corrupted.opacitycal is False
+    assert np.all(np.isfinite(corrupted.weights))
+
+
+def test_native_circular_noise_uses_reported_sigmas():
+    clean_generator = og.obs_generator(settings=SETTINGS)
+    clean_generator.rng = FixedRng()
+    clean = _native_corrupted_dataset(
+        clean_generator,
+        _polarized_image(),
+        addnoise=False,
+        addgains=True,
+        gainamp=0.04,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    noisy_generator = og.obs_generator(settings=SETTINGS)
+    noisy_generator.rng = FixedRng()
+    noisy = _native_corrupted_dataset(
+        noisy_generator,
+        _polarized_image(),
+        addnoise=True,
+        addgains=True,
+        gainamp=0.04,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    sigma = 1.0 / np.sqrt(noisy.weights)
+    assert np.allclose(noisy.weights, clean.weights)
+    assert np.allclose(noisy.visibilities - clean.visibilities, (1.0 + 1.0j) * sigma)
+
+
+def test_native_circular_corruptions_flag_rows_and_support_selection():
+    generator = og.obs_generator(settings=SETTINGS)
+    sampled, station_terms, stations = _native_dataset_and_terms(
+        generator,
+        _polarized_image(),
+        addgains=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    station_terms = dict(station_terms)
+    station_terms["uptime_mask"] = np.ones(sampled.row_count, dtype=bool)
+    station_terms["uptime_mask"][:2] = False
+    station_terms["flagsites"] = [station_terms["t1"][2]]
+
+    corrupted = instrumental_corruptions.apply_circular_corruptions(
+        sampled,
+        station_terms,
+        stations,
+        generator.rng,
+        addnoise=False,
+        addgains=False,
+        opacitycal=True,
+        addFR=False,
+        addleakage=False,
+    )
+
+    expected_flagged = (
+        ~station_terms["uptime_mask"]
+        | (station_terms["t1"] == station_terms["flagsites"][0])
+        | (station_terms["t2"] == station_terms["flagsites"][0])
+    )
+    assert np.array_equal(np.all(corrupted.flags[:, 0, :], axis=1), expected_flagged)
+    selected = corrupted.select_rows(~expected_flagged)
+    assert selected.row_count == np.count_nonzero(~expected_flagged)
+    assert not np.any(selected.flags)
 
 
 def test_mixed_basis_output_is_rejected_until_native_support_exists():

--- a/tests/test_visibility_dataset.py
+++ b/tests/test_visibility_dataset.py
@@ -64,6 +64,36 @@ def test_dataset_supports_mixed_layouts_and_multiple_channels():
     assert not data.stations.position_itrs_m.flags.writeable
 
 
+def test_dataset_select_rows_preserves_selected_rows_and_metadata():
+    original = dataset()
+
+    selected = original.select_rows(np.array((True, False)))
+
+    assert selected.row_count == 1
+    assert np.array_equal(selected.time_mjd, original.time_mjd[:1])
+    assert np.array_equal(selected.uvw_m, original.uvw_m[:1])
+    assert np.array_equal(selected.visibilities, original.visibilities[:1])
+    assert np.array_equal(selected.weights, original.weights[:1])
+    assert np.array_equal(selected.flags, original.flags[:1])
+    assert selected.stations.names == original.stations.names
+    assert np.array_equal(selected.scan_start_mjd, original.scan_start_mjd)
+    assert np.array_equal(selected.scan_stop_mjd, original.scan_stop_mjd)
+    assert not selected.visibilities.flags.writeable
+
+
+@pytest.mark.parametrize(
+    "row_mask",
+    (
+        np.array((1, 0), dtype=np.intp),
+        np.array((True,)),
+        np.array(((True, False),)),
+    ),
+)
+def test_dataset_select_rows_rejects_invalid_masks(row_mask):
+    with pytest.raises(ValueError, match="row_mask"):
+        dataset().select_rows(row_mask)
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [


### PR DESCRIPTION
Adds a native circular-basis corruption kernel, native row selection and flagging, corrected calibration metadata, and regression coverage against the legacy generator.