### PR TITLE
Build native source observation pipeline

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,6 +2,10 @@
 
 This directory contains opt-in runtime benchmarks and profiling tools for representative synthetic-data generation workflows.
 
+The default scenarios cover clean and corrupted `ehtim.Model`, `ehtim.Image`,
+and `ehtim.Movie` inputs on the EHT2017 array. This makes the source-adapter
+cost visible separately from generator initialization.
+
 The benchmark and profiling runners are intentionally not part of the default unit-test suite. Results depend on hardware, Python version, installed dependency versions, and local system state.
 
 ## List Scenarios

--- a/benchmarks/benchmark_synthetic_data.py
+++ b/benchmarks/benchmark_synthetic_data.py
@@ -12,6 +12,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import numpy as np
+
 os.environ.setdefault("MPLBACKEND", "Agg")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -76,6 +78,30 @@ SCENARIOS = [
         "settings": base_settings("EHT2017"),
         "input_kind": "image",
         "make_obs_kwargs": {"addnoise": False, "addgains": False},
+        "reuse_generator": False,
+    },
+    {
+        "name": "eht2017_image_corruptions",
+        "description": "EHT2017 array, rasterized ehtim Image source, thermal noise and gain corruptions enabled.",
+        "settings": base_settings("EHT2017"),
+        "input_kind": "image",
+        "make_obs_kwargs": {"addnoise": True, "addgains": True},
+        "reuse_generator": False,
+    },
+    {
+        "name": "eht2017_movie_clean",
+        "description": "EHT2017 array, time-varying ehtim Movie source, no thermal noise or gain corruptions.",
+        "settings": base_settings("EHT2017"),
+        "input_kind": "movie",
+        "make_obs_kwargs": {"addnoise": False, "addgains": False},
+        "reuse_generator": False,
+    },
+    {
+        "name": "eht2017_movie_corruptions",
+        "description": "EHT2017 array, time-varying ehtim Movie source, thermal noise and gain corruptions enabled.",
+        "settings": base_settings("EHT2017"),
+        "input_kind": "movie",
+        "make_obs_kwargs": {"addnoise": True, "addgains": True},
         "reuse_generator": False,
     },
     {
@@ -231,6 +257,24 @@ def make_source(input_kind):
         return model
     if input_kind == "image":
         return model.make_image(160.0 * eh.RADPERUAS, 128)
+    if input_kind == "movie":
+        image = model.make_image(160.0 * eh.RADPERUAS, 64)
+        frame_0 = image.imvec.reshape(image.ydim, image.xdim)
+        frame_1 = 1.1 * frame_0
+        movie = eh.movie.Movie(
+            (frame_0, frame_1),
+            times=(0.0, 0.5),
+            psize=image.psize,
+            ra=image.ra,
+            dec=image.dec,
+            rf=image.rf,
+            source=image.source,
+            mjd=image.mjd,
+            bounds_error=True,
+        )
+        for polarization in ("Q", "U", "V"):
+            movie.add_pol_movie((np.zeros_like(frame_0), np.zeros_like(frame_1)), polarization)
+        return movie
 
     raise ValueError("Unknown input_kind: {0}".format(input_kind))
 

--- a/examples/example_data_generation_space/generate_observation.py
+++ b/examples/example_data_generation_space/generate_observation.py
@@ -21,7 +21,7 @@ settings = {'sites': sites,
 obsgen = og.obs_generator(settings, settings_file=yamlfile, ephem='ephemeris/space')
 
 # generate the observation
-obs = obsgen.make_obs()
+obs = obsgen.make_obs(backend='legacy')
 
 # save it as a uvfits file
 obs.save_uvfits('./example_datafile.uvfits')

--- a/examples/example_data_generation_using_ngEHTforecast/generate_observation.py
+++ b/examples/example_data_generation_using_ngEHTforecast/generate_observation.py
@@ -23,7 +23,7 @@ obsgen = og.obs_generator(settings)
 
 # generate the observation by passing the FisherForecast object and parameters
 p = [0.2, 20.0]
-obs = obsgen.make_obs(ff, p=p, addnoise=False, addgains=False)
+obs = obsgen.make_obs(ff, p=p, addnoise=False, addgains=False, backend='legacy')
 
 # save it as a uvfits file
 obs.save_uvfits('./example_datafile.uvfits')

--- a/examples/example_data_generation_with_FPT/generate_observation.py
+++ b/examples/example_data_generation_with_FPT/generate_observation.py
@@ -71,7 +71,7 @@ obsgen_fpt = og.obs_generator(settings_file=yamlfile,
                               verbosity=0)
 
 # generate the observation
-obs_fpt = obsgen_fpt.make_obs()
+obs_fpt = obsgen_fpt.make_obs(backend='legacy')
 
 # save it as a uvfits file
 obs_fpt.save_uvfits('./example_datafile_with_fpt.uvfits')

--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -4,5 +4,5 @@ Tools for generating and plotting observations.
 
 __author__ = "Dom Pesce"
 
-__all__ = ['obs_generator', 'obs_plotter', 'visibility_dataset']
+__all__ = ['obs_generator', 'obs_plotter', 'simulation_result', 'visibility_dataset']
 from . import *

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import ehtim as eh
+from dataclasses import replace
 from collections import defaultdict
 from astropy.time import Time
 from astropy import units as astrounits
@@ -22,6 +23,7 @@ import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.simulation_result import SimulationResult
 
 ###################################################
 # helpers
@@ -249,6 +251,9 @@ class obs_generator(object):
         self.obs_empty = None
         self.obs_empty_key = None
         self.obs_template_cache = {}
+        self.native_visibility_template = None
+        self.native_visibility_template_key = None
+        self.native_visibility_template_cache = {}
         self.station_term_cache = {}
 
     ###################################################
@@ -805,8 +810,99 @@ class obs_generator(object):
             "polarization_basis": polarization_basis,
         }
 
-    # generate a raw observation
-    def observe(self, input_model, addnoise=True, addgains=True, gainamp=0.04, leakamp=0.1,
+    def _resolve_input_model(self, input_model, caller):
+        if input_model is not None:
+            return input_model
+        if self.im is None:
+            raise ValueError(
+                "No input model is configured; {0} requires input_model.".format(caller)
+            )
+        if self.verbosity > 0:
+            print("No input model passed to {0}; using the configured model.".format(caller))
+        return self.im
+
+    def simulate(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
+                 leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
+                 flagwind=True, flagday=False, flagsun=True,
+                 allow_mixed_basis=False, el_min=const.el_min, el_max=const.el_max,
+                 p=None):
+        """Simulate a ground-array observation into a native result object.
+
+        This is the primary v2 simulation API. It retains all rows, including
+        rows rejected by station-based flagging, in ``result.dataset.flags``.
+        ``ehtim`` source classes are accepted as input adapters, but no
+        ``ehtim.Obsdata`` is constructed during simulation.
+        """
+
+        del p  # Native Fisher-forecast sampling is intentionally not supported.
+        input_model = self._resolve_input_model(input_model, "simulate")
+        if allow_mixed_basis:
+            raise NotImplementedError(
+                "Mixed-polarization simulation will be added to the native RIME path."
+            )
+        if "space" in self.sites:
+            raise NotImplementedError(
+                "Native spacecraft geometry is not implemented; use observe_legacy() "
+                "or make_obs_legacy() explicitly."
+            )
+        adapter = source_models.adapter_for(input_model)
+        if not hasattr(adapter, "observe_dataset"):
+            raise TypeError(
+                "Native simulation currently supports ehtim Image, Movie, and Model inputs only."
+            )
+
+        (self.native_visibility_template,
+         self.native_visibility_template_key,
+         self.native_visibility_template_cache,
+         template) = observation_geometry.native_visibility_template(
+            self.native_visibility_template,
+            self.native_visibility_template_key,
+            self.native_visibility_template_cache,
+            self.arr,
+            self.geometry_context(),
+            el_min=el_min,
+            el_max=el_max,
+        )
+        if template.row_count == 0:
+            return SimulationResult(template, {})
+
+        sampled, F0 = source_models.observe_source_dataset(
+            input_model,
+            template,
+            self.source_context(),
+        )
+        station_terms, stations = station_observation.station_terms_for_dataset(
+            sampled,
+            F0,
+            self.station_context((sampled.time_mjd - self.mjd) * 24.0),
+            self.rng,
+            gainamp=gainamp,
+            leakamp=leakamp,
+            addgains=addgains,
+            addleakage=addleakage,
+            flagwind=flagwind,
+            flagday=flagday,
+            flagsun=flagsun,
+            solar_angle=self.solar_angle,
+            verbosity=self.verbosity,
+            windspeed_sefd_modifier=windspeed_SEFD_modification,
+            reference_mjd=self.mjd,
+            cache=self.station_term_cache,
+        )
+        corrupted = instrumental_corruptions.apply_circular_corruptions(
+            sampled,
+            station_terms,
+            stations,
+            self.rng,
+            addnoise=addnoise,
+            addgains=addgains,
+            opacitycal=opacitycal,
+            addFR=addFR,
+            addleakage=addleakage,
+        )
+        return SimulationResult(corrupted, station_terms)
+
+    def observe_legacy(self, input_model, addnoise=True, addgains=True, gainamp=0.04, leakamp=0.1,
                 opacitycal=True, addFR=True, addleakage=False,
                 flagwind=True, flagday=False, flagsun=True,
                 allow_mixed_basis=False, el_min=const.el_min, el_max=const.el_max, p=None):
@@ -1077,8 +1173,10 @@ class obs_generator(object):
         # return observation object
         return obs
 
-    # generate observation
-    def make_obs(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04, leakamp=0.1,
+    # Legacy Obsdata-only observation path. It is retained for capabilities
+    # that have not yet acquired a native implementation, notably FPT and
+    # spacecraft geometry.
+    def make_obs_legacy(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04, leakamp=0.1,
                  opacitycal=True, addFR=True, addleakage=False,
                  flagwind=True, flagday=False, flagsun=True,
                  allow_mixed_basis=False, el_min=const.el_min, el_max=const.el_max, p=None):
@@ -1120,7 +1218,7 @@ class obs_generator(object):
                     print('No input model passed to make_obs; using the model provided in the settings.')
 
         # generate raw observation
-        obs = self.observe(input_model,
+        obs = self.observe_legacy(input_model,
                            addnoise=addnoise,
                            addgains=addgains,
                            gainamp=gainamp,
@@ -1230,6 +1328,198 @@ class obs_generator(object):
 
         # return observation object
         return obs
+
+    def _native_selection_mask(self, dataset):
+        """Return the native row-selection mask for availability and fringe finding."""
+
+        mask = ~np.any(dataset.flags, axis=(1, 2))
+        names = np.asarray(dataset.stations.names)
+        t1 = names[dataset.antenna1]
+        t2 = names[dataset.antenna2]
+
+        unavailable = tuple(site for site in dataset.stations.names if self.bands[site] is None)
+        if unavailable:
+            if self.verbosity > 0:
+                for site in unavailable:
+                    print(site + " cannot observe at " + str(self.freq / 1.0e9) + " GHz.")
+            mask &= ~np.isin(t1, unavailable) & ~np.isin(t2, unavailable)
+
+        unready = get_unready_sites(
+            np.asarray(dataset.stations.names),
+            self.settings["tech_readiness"],
+            rng=self.rng,
+        )
+        if len(unready):
+            if self.verbosity > 0:
+                print("Dropping {0} due to technical (un)readiness.".format(unready))
+            mask &= ~np.isin(t1, unready) & ~np.isin(t2, unready)
+
+        snr_algorithm, snr_args = self.settings["fringe_finder"]
+        snr_algorithm = snr_algorithm.lower()
+        if snr_algorithm == "naive":
+            pseudo_i_amplitude = 0.5 * (
+                np.abs(dataset.visibilities[:, 0, 0])
+                + np.abs(dataset.visibilities[:, 0, 1])
+            )
+            pseudo_i_sigma = 1.0 / np.sqrt(2.0 * dataset.weights[:, 0, 0])
+            mask &= (pseudo_i_amplitude / pseudo_i_sigma) > snr_args
+        elif snr_algorithm == "fringegroups":
+            selected_indices = np.flatnonzero(mask)
+            selected = dataset.take_rows(selected_indices)
+            mask[selected_indices] &= fringegroups_dataset(
+                self,
+                selected,
+                snr_args[0],
+                snr_args[1],
+            )
+        elif snr_algorithm == "fpt":
+            raise NotImplementedError(
+                "Native FPT fringe selection is not implemented; use make_obs_legacy() "
+                "or observe_legacy() explicitly."
+            )
+        else:
+            raise ValueError("Unknown algorithm for fringe_finder.")
+        return mask
+
+    def make_dataset(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
+                     leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
+                     flagwind=True, flagday=False, flagsun=True,
+                     allow_mixed_basis=False, el_min=const.el_min,
+                     el_max=const.el_max, p=None):
+        """Generate a fully selected native :class:`SimulationResult`.
+
+        Station, availability, technical-readiness, and fringe-selection
+        failures are represented in ``result.dataset.flags`` rather than by
+        deleting rows from the internal data model.
+        """
+
+        result = self.simulate(
+            input_model=input_model,
+            addnoise=addnoise,
+            addgains=addgains,
+            gainamp=gainamp,
+            leakamp=leakamp,
+            opacitycal=opacitycal,
+            addFR=addFR,
+            addleakage=addleakage,
+            flagwind=flagwind,
+            flagday=flagday,
+            flagsun=flagsun,
+            allow_mixed_basis=allow_mixed_basis,
+            el_min=el_min,
+            el_max=el_max,
+            p=p,
+        )
+        if not result.dataset.row_count:
+            return result
+
+        mask = self._native_selection_mask(result.dataset)
+        flags = np.array(result.dataset.flags, copy=True)
+        flags[~mask] = True
+        if self.verbosity > 0:
+            print(
+                "Flagged {0} of {1} data points during fringe-finding emulation.".format(
+                    len(mask) - np.count_nonzero(mask),
+                    len(mask),
+                )
+            )
+        return SimulationResult(replace(result.dataset, flags=flags), result.station_terms)
+
+    def observe(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
+                leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
+                flagwind=True, flagday=False, flagsun=True,
+                allow_mixed_basis=False, el_min=const.el_min,
+                el_max=const.el_max, p=None, backend="native"):
+        """Generate a raw ``ehtim.Obsdata`` export from the selected backend.
+
+        ``backend="native"`` is the default and constructs no ``Obsdata``
+        until export. ``backend="legacy"`` explicitly selects the retained
+        legacy implementation for capabilities not yet available natively.
+        """
+
+        if backend == "legacy":
+            input_model = self._resolve_input_model(input_model, "observe_legacy")
+            return self.observe_legacy(
+                input_model,
+                addnoise=addnoise,
+                addgains=addgains,
+                gainamp=gainamp,
+                leakamp=leakamp,
+                opacitycal=opacitycal,
+                addFR=addFR,
+                addleakage=addleakage,
+                flagwind=flagwind,
+                flagday=flagday,
+                flagsun=flagsun,
+                allow_mixed_basis=allow_mixed_basis,
+                el_min=el_min,
+                el_max=el_max,
+                p=p,
+            )
+        if backend != "native":
+            raise ValueError("backend must be either 'native' or 'legacy'.")
+        return self.simulate(
+            input_model=input_model,
+            addnoise=addnoise,
+            addgains=addgains,
+            gainamp=gainamp,
+            leakamp=leakamp,
+            opacitycal=opacitycal,
+            addFR=addFR,
+            addleakage=addleakage,
+            flagwind=flagwind,
+            flagday=flagday,
+            flagsun=flagsun,
+            allow_mixed_basis=allow_mixed_basis,
+            el_min=el_min,
+            el_max=el_max,
+            p=p,
+        ).to_ehtim_obsdata()
+
+    def make_obs(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
+                 leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
+                 flagwind=True, flagday=False, flagsun=True,
+                 allow_mixed_basis=False, el_min=const.el_min,
+                 el_max=const.el_max, p=None, backend="native"):
+        """Generate an ``ehtim.Obsdata`` export of a selected observation."""
+
+        if backend == "legacy":
+            return self.make_obs_legacy(
+                input_model=input_model,
+                addnoise=addnoise,
+                addgains=addgains,
+                gainamp=gainamp,
+                leakamp=leakamp,
+                opacitycal=opacitycal,
+                addFR=addFR,
+                addleakage=addleakage,
+                flagwind=flagwind,
+                flagday=flagday,
+                flagsun=flagsun,
+                allow_mixed_basis=allow_mixed_basis,
+                el_min=el_min,
+                el_max=el_max,
+                p=p,
+            )
+        if backend != "native":
+            raise ValueError("backend must be either 'native' or 'legacy'.")
+        return self.make_dataset(
+            input_model=input_model,
+            addnoise=addnoise,
+            addgains=addgains,
+            gainamp=gainamp,
+            leakamp=leakamp,
+            opacitycal=opacitycal,
+            addFR=addFR,
+            addleakage=addleakage,
+            flagwind=flagwind,
+            flagday=flagday,
+            flagsun=flagsun,
+            allow_mixed_basis=allow_mixed_basis,
+            el_min=el_min,
+            el_max=el_max,
+            p=p,
+        ).to_ehtim_obsdata()
 
     # generate multifrequency observation, assuming that FPT will be used wherever possible
     def make_obs_mf(self, freqs, input_models, addnoise=True, addgains=True, gainamp=0.04, leakamp=0.1,
@@ -1350,7 +1640,7 @@ class obs_generator(object):
                     obsgen_here.im = model_target
 
                 # generate observation at target frequency
-                obs_here = obsgen_here.make_obs(input_model=obsgen_here.im, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, flagwind=flagwind, flagday=flagday, flagsun=flagsun, p=p_target)
+                obs_here = obsgen_here.make_obs(input_model=obsgen_here.im, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, flagwind=flagwind, flagday=flagday, flagsun=flagsun, p=p_target, backend='legacy')
 
                 # add any new detections to the running datatable
                 if count == 0:
@@ -1870,6 +2160,63 @@ def fringegroups(obsgen, obs, snr_ref, tint_ref):
     return master_index
 
 
+def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
+    """Apply the fringe-group proxy directly to a native circular dataset."""
+
+    if dataset.channel_count != 1:
+        raise ValueError("Native fringe groups require exactly one spectral channel.")
+    if dataset.row_count == 0:
+        return np.zeros(0, dtype=bool)
+
+    names = np.asarray(dataset.stations.names)
+    t1 = names[dataset.antenna1]
+    t2 = names[dataset.antenna2]
+    available_sites = {
+        site for site in obsgen.sites if obsgen.bands[site] is not None
+    }
+    master_index = np.zeros(dataset.row_count, dtype=bool)
+
+    for timestamp in np.unique(dataset.time_mjd):
+        indices = np.flatnonzero(dataset.time_mjd == timestamp)
+        rr = dataset.visibilities[indices, 0, 0]
+        ll = dataset.visibilities[indices, 0, 1]
+        rr_sigma = 1.0 / np.sqrt(dataset.weights[indices, 0, 0])
+        snr_scaled = snr_ref * np.sqrt(dataset.integration_time_s[indices] / tint_ref)
+        strong = (
+            (0.5 * (np.abs(rr) + np.abs(ll)) / (rr_sigma / np.sqrt(2.0)))
+            >= snr_scaled
+        )
+        strong &= np.isin(t1[indices], tuple(available_sites))
+        strong &= np.isin(t2[indices], tuple(available_sites))
+
+        groups = []
+        for index in indices[strong]:
+            baseline = {t1[index], t2[index]}
+            merged = set(baseline)
+            remaining = []
+            for group in groups:
+                if baseline & group:
+                    merged |= group
+                else:
+                    remaining.append(group)
+            groups = remaining + [merged]
+
+        site_groups = {
+            station: group_index
+            for group_index, group in enumerate(groups)
+            for station in group
+        }
+        for index in indices:
+            if (
+                t1[index] in site_groups
+                and t2[index] in site_groups
+                and site_groups[t1[index]] == site_groups[t2[index]]
+            ):
+                master_index[index] = True
+
+    return master_index
+
+
 def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemeris/space', **kwargs):
     """
     Function to apply the frequency phase transfer ("FPT") SNR thresholding scheme to an observation.
@@ -1936,7 +2283,7 @@ def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemer
         obsgen_ref.im = model_ref
 
     # generate observation at reference frequency
-    obs_ref = obsgen_ref.observe(obsgen_ref.im, **kwargs)
+    obs_ref = obsgen_ref.observe_legacy(obsgen_ref.im, **kwargs)
 
     # create a running index list of baselines to flag
     master_index = np.zeros(len(obs_ref.data), dtype='bool')

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -376,6 +376,72 @@ def ground_visibility_template(array, context, geometry=None):
     )
 
 
+def visibility_dataset_elevation_mask(dataset, el_min, el_max):
+    """Return the native ground-array elevation-selection mask."""
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if dataset.row_count == 0:
+        return np.zeros(0, dtype=bool)
+    geometry = station_geometry_from_rows(
+        dataset.stations.position_itrs_m,
+        dataset.time_mjd,
+        dataset.antenna1,
+        dataset.antenna2,
+        dataset.ra_hours,
+        dataset.dec_degrees,
+    )
+    if geometry is None:
+        raise ValueError("Native elevation filtering does not support spacecraft stations.")
+    elevation1 = np.rad2deg(geometry.elevation1_rad)
+    elevation2 = np.rad2deg(geometry.elevation2_rad)
+    return (
+        (elevation1 > el_min)
+        & (elevation1 < el_max)
+        & (elevation2 > el_min)
+        & (elevation2 < el_max)
+    )
+
+
+def apply_visibility_dataset_elevation_limits(dataset, el_min, el_max):
+    """Return a native dataset restricted to the requested elevation range."""
+
+    return dataset.select_rows(visibility_dataset_elevation_mask(dataset, el_min, el_max))
+
+
+def canonicalize_visibility_dataset_rows(dataset):
+    """Order native rows by time and station names before stochastic processing."""
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    names = np.asarray(dataset.stations.names)
+    order = np.lexsort((
+        names[dataset.antenna2],
+        names[dataset.antenna1],
+        dataset.time_mjd,
+    ))
+    return dataset.take_rows(order)
+
+
+def native_visibility_template(template, cached_key, template_cache, array, context,
+                               el_min, el_max):
+    """Return a cached, elevation-limited native ground visibility template."""
+
+    old_key = cached_key
+    cached_key = geometry_cache_key(context)
+    if template is None or cached_key != old_key:
+        template = ground_visibility_template(array, context)
+    if template_cache is None or cached_key != old_key:
+        template_cache = {}
+
+    elevation_key = elevation_cache_key(cached_key, el_min, el_max)
+    if elevation_key not in template_cache:
+        template_cache[elevation_key] = canonicalize_visibility_dataset_rows(
+            apply_visibility_dataset_elevation_limits(template, el_min, el_max)
+        )
+    return template, cached_key, template_cache, template_cache[elevation_key]
+
+
 def _ground_geometry_obsdata(array, context, geometry):
     """Adapt the native ground visibility template to the ``ehtim`` boundary."""
 

--- a/ngehtsim/obs/simulation_result.py
+++ b/ngehtsim/obs/simulation_result.py
@@ -1,0 +1,67 @@
+"""Native observation simulation results and optional ehtim export."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import numpy as np
+
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """A native synthetic observation and its station-based simulation terms.
+
+    ``dataset`` retains flagged rows. Consumers that need an ehtim-compatible
+    view can use :meth:`to_ehtim_obsdata`, which drops those rows at the export
+    boundary because ``ehtim.Obsdata`` has no sample-flag representation.
+    """
+
+    dataset: VisibilityDataset
+    station_terms: Mapping[str, Any]
+
+    def __post_init__(self):
+        if not isinstance(self.dataset, VisibilityDataset):
+            raise TypeError("dataset must be a VisibilityDataset instance.")
+        station_terms = {}
+        for name, value in self.station_terms.items():
+            if isinstance(value, np.ndarray):
+                value = np.array(value, copy=True)
+                value.setflags(write=False)
+            elif isinstance(value, list):
+                value = tuple(value)
+            station_terms[name] = value
+        object.__setattr__(self, "station_terms", MappingProxyType(station_terms))
+
+    @property
+    def row_mask(self):
+        """Rows retained after station and fringe-selection flagging."""
+
+        return ~np.any(self.dataset.flags, axis=(1, 2))
+
+    @property
+    def unflagged_dataset(self):
+        """Return the visibility rows representable by ``ehtim.Obsdata``."""
+
+        return self.dataset.select_rows(self.row_mask)
+
+    def to_ehtim_obsdata(self):
+        """Export unflagged circular single-channel data to ``ehtim.Obsdata``.
+
+        The empty-result case is handled only here to preserve the optional
+        ehtim boundary; an empty :class:`VisibilityDataset` remains valid.
+        """
+
+        unflagged = self.unflagged_dataset
+        if unflagged.row_count:
+            return unflagged.to_ehtim_obsdata()
+
+        # ehtim refuses to construct an Obsdata from zero rows. Construct a
+        # valid temporary export and then expose its representable empty view.
+        temporary = replace(self.dataset, flags=np.zeros_like(self.dataset.flags))
+        obs = temporary.to_ehtim_obsdata()
+        obs.data = obs.data[:0]
+        return obs

--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -32,6 +32,47 @@ def _run_quietly(function, verbosity):
             return function()
     return function()
 
+
+def _require_native_circular_dataset(dataset):
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if dataset.channel_count != 1:
+        raise ValueError("Native source sampling requires exactly one spectral channel.")
+    if any(
+        dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
+        for index in dataset.row_layout_id
+    ):
+        raise ValueError(
+            "Native source sampling requires circular RR, LL, RL, LR correlations."
+        )
+
+
+def _dataset_uv(dataset):
+    wavelength = SPEED_OF_LIGHT.to_value("m / s") / dataset.channel_frequency_hz[0]
+    return dataset.uvw_m[:, :2] / wavelength
+
+
+def _with_circular_samples(dataset, sampled, context):
+    visibilities = np.array(dataset.visibilities, copy=True)
+    visibilities[:, 0, 0] = sampled[0]
+    if sampled[1] is not None:
+        visibilities[:, 0, 1] = sampled[1]
+    if sampled[2] is not None:
+        visibilities[:, 0, 2] = sampled[2]
+        visibilities[:, 0, 3] = sampled[3]
+    return replace(
+        dataset,
+        visibilities=visibilities,
+        source=context["source"],
+        ra_hours=context["ra"],
+        dec_degrees=context["dec"],
+        ampcal=True,
+        phasecal=True,
+        opacitycal=True,
+        dcal=True,
+        frcal=True,
+    )
+
 ###################################################
 # adapters
 
@@ -89,48 +130,20 @@ class EhtimImageAdapter(object):
     def observe_dataset(self, dataset, context):
         """Sample an image onto a native circular single-channel dataset."""
 
-        _set_ehtim_metadata(self.input_model, context)
-        if not isinstance(dataset, VisibilityDataset):
-            raise TypeError("dataset must be a VisibilityDataset instance.")
-        if dataset.channel_count != 1:
-            raise ValueError("Native image sampling requires exactly one spectral channel.")
-        if any(
-            dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
-            for index in dataset.row_layout_id
-        ):
-            raise ValueError(
-                "Native image sampling requires circular RR, LL, RL, LR correlations."
-            )
+        _require_native_circular_dataset(dataset)
 
         def sample_dataset():
-            wavelength = SPEED_OF_LIGHT.to_value("m / s") / dataset.channel_frequency_hz[0]
-            uv = dataset.uvw_m[:, :2] / wavelength
             sampled = self.input_model.sample_uv(
-                uv,
+                _dataset_uv(dataset),
                 polrep_obs="circ",
                 ttype=context["ttype"],
                 fft_pad_factor=context["fft_pad_factor"],
                 verbose=context["verbosity"] > 0,
             )
-            visibilities = np.array(dataset.visibilities, copy=True)
-            visibilities[:, 0, 0] = sampled[0]
-            if sampled[1] is not None:
-                visibilities[:, 0, 1] = sampled[1]
-            if sampled[2] is not None:
-                visibilities[:, 0, 2] = sampled[2]
-                visibilities[:, 0, 3] = sampled[3]
-
-            return replace(
+            return _with_circular_samples(
                 dataset,
-                visibilities=visibilities,
-                source=self.input_model.source,
-                ra_hours=self.input_model.ra,
-                dec_degrees=self.input_model.dec,
-                ampcal=True,
-                phasecal=True,
-                opacitycal=True,
-                dcal=True,
-                frcal=True,
+                sampled,
+                context,
             )
 
         sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
@@ -233,6 +246,55 @@ class EhtimMovieAdapter(object):
         F0 = np.mean(self.input_model.lightcurve)
         return obs, F0
 
+    def observe_dataset(self, dataset, context):
+        """Sample a repeating movie onto a native circular dataset."""
+
+        _require_native_circular_dataset(dataset)
+
+        def sample_dataset():
+            visibilities = np.array(dataset.visibilities, copy=True)
+            uv = _dataset_uv(dataset)
+            observation_times = (dataset.time_mjd - float(context["mjd"])) * 24.0
+
+            for time in np.unique(observation_times):
+                sample_time = time
+                if self.input_model.bounds_error:
+                    if time < self.input_model.start_hr or time > self.input_model.stop_hr:
+                        sample_time = self.input_model.start_hr + np.mod(
+                            time - self.input_model.start_hr,
+                            self.input_model.duration,
+                        )
+                row_mask = observation_times == time
+                sampled = self.input_model.get_image(sample_time).sample_uv(
+                    uv[row_mask],
+                    polrep_obs="circ",
+                    ttype=context["ttype"],
+                    fft_pad_factor=context["fft_pad_factor"],
+                    verbose=False,
+                )
+                visibilities[row_mask, 0, 0] = sampled[0]
+                if sampled[1] is not None:
+                    visibilities[row_mask, 0, 1] = sampled[1]
+                if sampled[2] is not None:
+                    visibilities[row_mask, 0, 2] = sampled[2]
+                    visibilities[row_mask, 0, 3] = sampled[3]
+
+            return replace(
+                dataset,
+                visibilities=visibilities,
+                source=context["source"],
+                ra_hours=context["ra"],
+                dec_degrees=context["dec"],
+                ampcal=True,
+                phasecal=True,
+                opacitycal=True,
+                dcal=True,
+                frcal=True,
+            )
+
+        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
+        return sampled_dataset, np.mean(self.input_model.lightcurve)
+
 
 class EhtimModelAdapter(object):
     def __init__(self, input_model):
@@ -274,6 +336,26 @@ class EhtimModelAdapter(object):
 
         F0 = np.abs(self.input_model.sample_uv(0.0, 0.0))
         return obs, F0
+
+    def observe_dataset(self, dataset, context):
+        """Sample an analytic model onto a native circular dataset."""
+
+        _require_native_circular_dataset(dataset)
+
+        def sample_dataset():
+            uv = _dataset_uv(dataset)
+            rr = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="RR")
+            ll = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="LL")
+            rl = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="RL")
+            lr = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="LR")
+            return _with_circular_samples(
+                dataset,
+                (rr, ll, rl, lr),
+                context,
+            )
+
+        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
+        return sampled_dataset, np.abs(self.input_model.sample_uv(0.0, 0.0))
 
 
 class FisherForecastAdapter(object):
@@ -336,8 +418,10 @@ def observe_source(input_model, obs_empty, context, p=None):
 def observe_source_dataset(input_model, dataset, context):
     """Sample a supported source model onto a native visibility dataset."""
 
-    if not isinstance(input_model, eh.image.Image):
+    adapter = adapter_for(input_model)
+    if not hasattr(adapter, "observe_dataset"):
         raise TypeError(
-            "Native VisibilityDataset sampling currently supports ehtim Image inputs only."
+            "Native VisibilityDataset sampling currently supports ehtim Image, Movie, "
+            "and Model inputs only."
         )
-    return EhtimImageAdapter(input_model).observe_dataset(dataset, context)
+    return adapter.observe_dataset(dataset, context)

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -302,19 +302,29 @@ class VisibilityDataset:
             raise ValueError(
                 "row_mask must be a boolean array with one value per visibility row."
             )
+        return self.take_rows(np.flatnonzero(row_mask))
+
+    def take_rows(self, row_indices):
+        """Return a dataset containing rows selected in the given order."""
+
+        row_indices = np.asarray(row_indices)
+        if row_indices.ndim != 1 or not np.issubdtype(row_indices.dtype, np.integer):
+            raise ValueError("row_indices must be a one-dimensional integer array.")
+        if np.any(row_indices < 0) or np.any(row_indices >= self.row_count):
+            raise ValueError("row_indices contains an out-of-range visibility row.")
         return replace(
             self,
-            time_mjd=self.time_mjd[row_mask],
-            integration_time_s=self.integration_time_s[row_mask],
-            antenna1=self.antenna1[row_mask],
-            antenna2=self.antenna2[row_mask],
-            uvw_m=self.uvw_m[row_mask],
-            tau1=self.tau1[row_mask],
-            tau2=self.tau2[row_mask],
-            row_layout_id=self.row_layout_id[row_mask],
-            visibilities=self.visibilities[row_mask],
-            weights=self.weights[row_mask],
-            flags=self.flags[row_mask],
+            time_mjd=self.time_mjd[row_indices],
+            integration_time_s=self.integration_time_s[row_indices],
+            antenna1=self.antenna1[row_indices],
+            antenna2=self.antenna2[row_indices],
+            uvw_m=self.uvw_m[row_indices],
+            tau1=self.tau1[row_indices],
+            tau2=self.tau2[row_indices],
+            row_layout_id=self.row_layout_id[row_indices],
+            visibilities=self.visibilities[row_indices],
+            weights=self.weights[row_indices],
+            flags=self.flags[row_indices],
         )
 
     @classmethod

--- a/tests/test_generate_observation_space.py
+++ b/tests/test_generate_observation_space.py
@@ -21,7 +21,7 @@ settings = {'sites': sites,
 obsgen = og.obs_generator(settings, settings_file=yamlfile, ephem='./tests/data_generation_space/ephemeris/space')
 
 # generate the observation
-obs = obsgen.make_obs()
+obs = obsgen.make_obs(backend='legacy')
 
 # save it as a uvfits file
 obs.save_uvfits('./tests/data_generation_space/example_datafile.uvfits')

--- a/tests/test_generate_observation_using_ngEHTforecast.py
+++ b/tests/test_generate_observation_using_ngEHTforecast.py
@@ -23,7 +23,7 @@ obsgen = og.obs_generator(settings)
 
 # generate the observation by passing the FisherForecast object and parameters
 p = [0.2, 20.0]
-obs = obsgen.make_obs(ff, p=p, addnoise=False, addgains=False)
+obs = obsgen.make_obs(ff, p=p, addnoise=False, addgains=False, backend='legacy')
 
 # save it as a uvfits file
 obs.save_uvfits('./tests/example_datafile.uvfits')

--- a/tests/test_generate_observation_with_FPT.py
+++ b/tests/test_generate_observation_with_FPT.py
@@ -71,7 +71,7 @@ obsgen_fpt = og.obs_generator(settings_file=yamlfile,
                               verbosity=0)
 
 # generate the observation
-obs_fpt = obsgen_fpt.make_obs()
+obs_fpt = obsgen_fpt.make_obs(backend='legacy')
 
 # save it as a uvfits file
 obs_fpt.save_uvfits('./tests/data_generation_with_FPT/example_datafile_with_fpt.uvfits')

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -156,7 +156,7 @@ def test_circular_leakage_matches_jones_matrix():
 
 def test_circular_generator_matches_composed_station_jones_matrices():
     clean_generator = og.obs_generator(settings=SETTINGS)
-    clean = clean_generator.make_obs(
+    clean = clean_generator.make_dataset(
         _polarized_model(),
         addnoise=False,
         addgains=False,
@@ -167,7 +167,7 @@ def test_circular_generator_matches_composed_station_jones_matrices():
         flagsun=False,
     )
     corrupted_generator = og.obs_generator(settings=SETTINGS, weight=1)
-    corrupted = corrupted_generator.make_obs(
+    corrupted_result = corrupted_generator.make_dataset(
         _polarized_model(),
         addnoise=False,
         addgains=True,
@@ -177,44 +177,60 @@ def test_circular_generator_matches_composed_station_jones_matrices():
         flagday=False,
         flagsun=False,
     )
+    terms = corrupted_result.station_terms
+    row_mask = corrupted_result.row_mask
 
-    assert np.array_equal(corrupted.data["t1"], clean.data["t1"])
-    assert np.array_equal(corrupted.data["t2"], clean.data["t2"])
-    assert np.allclose(corrupted.data["time"], clean.data["time"])
+    assert np.array_equal(clean.row_mask, row_mask)
 
     jones1 = _station_jones(
-        corrupted_generator.station_gains1R,
-        corrupted_generator.station_gains1L,
-        corrupted_generator.station_leakage1R,
-        corrupted_generator.station_leakage1L,
-        corrupted_generator.fa_1,
+        terms["gainamp1R"][row_mask] * np.exp(1.0j * terms["gainphase1R"][row_mask]),
+        terms["gainamp1L"][row_mask] * np.exp(1.0j * terms["gainphase1L"][row_mask]),
+        terms["leak1R"][row_mask],
+        terms["leak1L"][row_mask],
+        (terms["f_par1"][row_mask] * terms["par1"][row_mask])
+        + (terms["f_el1"][row_mask] * terms["el1"][row_mask])
+        + ((np.pi / 180.0) * terms["phi_off1"][row_mask]),
     )
     jones2 = _station_jones(
-        corrupted_generator.station_gains2R,
-        corrupted_generator.station_gains2L,
-        corrupted_generator.station_leakage2R,
-        corrupted_generator.station_leakage2L,
-        corrupted_generator.fa_2,
+        terms["gainamp2R"][row_mask] * np.exp(1.0j * terms["gainphase2R"][row_mask]),
+        terms["gainamp2L"][row_mask] * np.exp(1.0j * terms["gainphase2L"][row_mask]),
+        terms["leak2R"][row_mask],
+        terms["leak2L"][row_mask],
+        (terms["f_par2"][row_mask] * terms["par2"][row_mask])
+        + (terms["f_el2"][row_mask] * terms["el2"][row_mask])
+        + ((np.pi / 180.0) * terms["phi_off2"][row_mask]),
     )
-    expected = jones1 @ _coherency_matrices(clean) @ np.swapaxes(np.conj(jones2), -1, -2)
+    clean_visibility = clean.dataset.visibilities[row_mask, 0]
+    clean_coherency = np.empty((len(clean_visibility), 2, 2), dtype=complex)
+    clean_coherency[:, 0, 0] = clean_visibility[:, 0]
+    clean_coherency[:, 0, 1] = clean_visibility[:, 2]
+    clean_coherency[:, 1, 0] = clean_visibility[:, 3]
+    clean_coherency[:, 1, 1] = clean_visibility[:, 1]
+    expected = jones1 @ clean_coherency @ np.swapaxes(np.conj(jones2), -1, -2)
 
-    assert np.allclose(_coherency_matrices(corrupted), expected, atol=1.0e-12)
-    assert clean.ampcal is True
-    assert clean.phasecal is True
-    assert clean.opacitycal is True
-    assert clean.dcal is True
-    assert clean.frcal is True
-    assert corrupted.ampcal is False
-    assert corrupted.phasecal is False
-    assert corrupted.opacitycal is True
-    assert corrupted.dcal is False
-    assert corrupted.frcal is False
+    corrupted_visibility = corrupted_result.dataset.visibilities[row_mask, 0]
+    corrupted_coherency = np.empty_like(expected)
+    corrupted_coherency[:, 0, 0] = corrupted_visibility[:, 0]
+    corrupted_coherency[:, 0, 1] = corrupted_visibility[:, 2]
+    corrupted_coherency[:, 1, 0] = corrupted_visibility[:, 3]
+    corrupted_coherency[:, 1, 1] = corrupted_visibility[:, 1]
+    assert np.allclose(corrupted_coherency, expected, atol=1.0e-12)
+    assert clean.dataset.ampcal is True
+    assert clean.dataset.phasecal is True
+    assert clean.dataset.opacitycal is True
+    assert clean.dataset.dcal is True
+    assert clean.dataset.frcal is True
+    assert corrupted_result.dataset.ampcal is False
+    assert corrupted_result.dataset.phasecal is False
+    assert corrupted_result.dataset.opacitycal is True
+    assert corrupted_result.dataset.dcal is False
+    assert corrupted_result.dataset.frcal is False
 
 
 def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
     clean_generator = og.obs_generator(settings=SETTINGS)
     clean_generator.rng = FixedRng()
-    clean = clean_generator.make_obs(
+    clean = clean_generator.simulate(
         _polarized_model(),
         addnoise=False,
         addgains=True,
@@ -226,7 +242,7 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
     )
     noisy_generator = og.obs_generator(settings=SETTINGS)
     noisy_generator.rng = FixedRng()
-    noisy = noisy_generator.make_obs(
+    noisy = noisy_generator.simulate(
         _polarized_model(),
         addnoise=True,
         addgains=True,
@@ -237,17 +253,13 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
         flagsun=False,
     )
 
-    for visibility_field, sigma_field in (
-        ("rrvis", "rrsigma"),
-        ("llvis", "llsigma"),
-        ("rlvis", "rlsigma"),
-        ("lrvis", "lrsigma"),
-    ):
-        assert np.allclose(noisy.data[sigma_field], clean.data[sigma_field])
-        assert np.allclose(
-            noisy.data[visibility_field] - clean.data[visibility_field],
-            (1.0 + 1.0j) * noisy.data[sigma_field],
-        )
+    clean_sigma = 1.0 / np.sqrt(clean.dataset.weights)
+    noisy_sigma = 1.0 / np.sqrt(noisy.dataset.weights)
+    assert np.allclose(noisy_sigma, clean_sigma)
+    assert np.allclose(
+        noisy.dataset.visibilities - clean.dataset.visibilities,
+        (1.0 + 1.0j) * noisy_sigma,
+    )
 
 
 def test_generator_marks_uncalibrated_opacity_in_output_metadata():
@@ -345,7 +357,7 @@ def test_native_circular_corruptions_match_legacy_generator_without_noise(monkey
         return legacy_empty, "native-test-template", {}, legacy_empty.copy()
 
     monkeypatch.setattr(observation_geometry, "observation_template", fixed_template)
-    legacy = legacy_generator.observe(_polarized_image(), **kwargs)
+    legacy = legacy_generator.observe_legacy(_polarized_image(), **kwargs)
     unflagged = native.select_rows(~np.any(native.flags[:, 0, :], axis=1))
     native_order = _native_row_order(unflagged)
     legacy_order = _obsdata_row_order(legacy)
@@ -508,7 +520,7 @@ def test_native_circular_corruptions_flag_rows_and_support_selection():
 def test_mixed_basis_output_is_rejected_until_native_support_exists():
     obsgen = og.obs_generator(settings=SETTINGS)
 
-    with pytest.raises(NotImplementedError, match="Mixed-polarization output"):
+    with pytest.raises(NotImplementedError, match="Mixed-polarization simulation"):
         obsgen.make_obs(_polarized_model(), allow_mixed_basis=True)
 
 

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -77,6 +77,67 @@ def test_ground_visibility_template_preserves_legacy_visibility_rows(array_name)
     assert np.allclose(adapted.scans, expected_scans(context, np.unique(geometry.time_hours)))
 
 
+@pytest.mark.parametrize("array_name", ["EHT2017", "ngEHT"])
+def test_native_visibility_template_matches_legacy_elevation_selection(array_name):
+    array = make_array(const.known_arrays[array_name])
+    context = geometry_context(array_name)
+    _, _, _, legacy = observation_geometry.observation_template(
+        None,
+        None,
+        {},
+        array,
+        context,
+        el_min=const.el_min,
+        el_max=const.el_max,
+    )
+    _, _, _, native = observation_geometry.native_visibility_template(
+        None,
+        None,
+        {},
+        array,
+        context,
+        el_min=const.el_min,
+        el_max=const.el_max,
+    )
+    names = np.asarray(native.stations.names)
+
+    assert np.array_equal(names[native.antenna1], legacy.data["t1"])
+    assert np.array_equal(names[native.antenna2], legacy.data["t2"])
+    assert np.allclose(
+        (native.time_mjd - legacy.mjd) * 24.0,
+        legacy.data["time"],
+        atol=1.0e-12,
+    )
+    assert np.allclose(native.integration_time_s, legacy.data["tint"], atol=1.0e-12)
+
+
+def test_native_visibility_template_reuses_cached_selection(array_and_context):
+    array, context = array_and_context
+    template, cached_key, template_cache, limited = observation_geometry.native_visibility_template(
+        None,
+        None,
+        {},
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+    template_again, cached_key_again, template_cache, limited_again = observation_geometry.native_visibility_template(
+        template,
+        cached_key,
+        template_cache,
+        array,
+        context,
+        el_min=0.0,
+        el_max=90.0,
+    )
+
+    assert template_again is template
+    assert cached_key_again == cached_key
+    assert limited_again is limited
+    assert len(template_cache) == 1
+
+
 def test_ground_geometry_scan_groups_preserve_individual_snapshots():
     array = make_array(const.known_arrays["EHT2017"])
     context = geometry_context("EHT2017")

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -7,6 +7,7 @@ import numpy as np
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.source_models as source_models
+import ngehtsim.obs.station_observation as station_observation
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 #######################################################
@@ -311,6 +312,58 @@ def test_ehtim_image_dataset_sampler_avoids_obsdata_conversion(monkeypatch):
     assert F0 > 0.0
 
 
+def test_ehtim_model_adapter_samples_native_visibility_dataset():
+    direct_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    legacy_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    direct_model = _polarized_model()
+    legacy_model = _polarized_model()
+    template = observation_geometry.ground_visibility_template(
+        direct_generator.arr,
+        direct_generator.geometry_context(),
+    )
+
+    direct, direct_F0 = source_models.observe_source_dataset(
+        direct_model,
+        template,
+        direct_generator.source_context(),
+    )
+    legacy, legacy_F0 = _legacy_model_observe(
+        legacy_model,
+        template.to_ehtim_obsdata(),
+        legacy_generator.source_context(),
+    )
+
+    assert direct_F0 == pytest.approx(legacy_F0)
+    adapted = direct.to_ehtim_obsdata()
+    for field in ("rrvis", "llvis", "rlvis", "lrvis"):
+        assert np.allclose(adapted.data[field], legacy.data[field], atol=1.0e-12)
+
+
+def test_ehtim_model_dataset_sampler_avoids_obsdata_conversion(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    template = observation_geometry.ground_visibility_template(
+        obsgen.arr,
+        obsgen.geometry_context(),
+    )
+
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("Native model sampling must not construct an Obsdata object.")
+
+    monkeypatch.setattr(
+        VisibilityDataset,
+        "to_ehtim_obsdata",
+        unexpected_obsdata_conversion,
+    )
+    sampled, F0 = source_models.observe_source_dataset(
+        _polarized_model(),
+        template,
+        obsgen.source_context(),
+    )
+
+    assert sampled.row_count == template.row_count
+    assert F0 > 0.0
+
+
 def test_ehtim_movie_adapter_does_not_call_observe_same_nonoise(monkeypatch):
     obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
     movie = _polarized_movie()
@@ -322,6 +375,57 @@ def test_ehtim_movie_adapter_does_not_call_observe_same_nonoise(monkeypatch):
     obs, F0 = source_models.observe_source(movie, _empty_observation(obsgen), obsgen.source_context())
 
     assert len(obs.data) > 0
+    assert F0 > 0.0
+
+
+def test_ehtim_movie_adapter_samples_native_visibility_dataset():
+    direct_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    legacy_generator = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    direct_movie = _polarized_movie()
+    legacy_movie = _polarized_movie()
+    template = VisibilityDataset.from_ehtim_obsdata(
+        _empty_observation(direct_generator)
+    )
+
+    direct, direct_F0 = source_models.observe_source_dataset(
+        direct_movie,
+        template,
+        direct_generator.source_context(),
+    )
+    legacy, legacy_F0 = source_models.observe_source(
+        legacy_movie,
+        _empty_observation(legacy_generator),
+        legacy_generator.source_context(),
+    )
+
+    assert direct_F0 == pytest.approx(legacy_F0)
+    adapted = direct.to_ehtim_obsdata()
+    for field in ("rrvis", "llvis", "rlvis", "lrvis"):
+        assert np.allclose(adapted.data[field], legacy.data[field], atol=1.0e-12)
+
+
+def test_ehtim_movie_dataset_sampler_avoids_obsdata_conversion(monkeypatch):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
+    template = observation_geometry.ground_visibility_template(
+        obsgen.arr,
+        obsgen.geometry_context(),
+    )
+
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("Native movie sampling must not construct an Obsdata object.")
+
+    monkeypatch.setattr(
+        VisibilityDataset,
+        "to_ehtim_obsdata",
+        unexpected_obsdata_conversion,
+    )
+    sampled, F0 = source_models.observe_source_dataset(
+        _polarized_movie(),
+        template,
+        obsgen.source_context(),
+    )
+
+    assert sampled.row_count == template.row_count
     assert F0 > 0.0
 
 
@@ -361,123 +465,77 @@ def test_ehtim_movie_adapter_matches_legacy_full_polarization_sampling(polrep, f
         assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
 
 
-def test_direct_ehtim_image_sampling_preserves_seeded_corruptions(monkeypatch):
-    settings = dict(COMPACT_OBS_SETTINGS)
-    settings["fringe_finder"] = ["naive", 0.0]
-    direct_generator = og.obs_generator(settings=settings)
-    direct = direct_generator.make_obs(
-        _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
-        addnoise=True,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
+@pytest.mark.parametrize(
+    "source_factory",
+    (
+        lambda: _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
+        _polarized_model,
+        _polarized_movie,
+    ),
+)
+def test_obs_generator_routes_supported_sources_through_native_path(monkeypatch, source_factory):
+    obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
 
-    def legacy_adapter_observe(self, obs_empty, context, p=None):
-        return _legacy_image_observe(self.input_model, obs_empty, context)
+    def unexpected_legacy_path(*args, **kwargs):
+        raise AssertionError("Supported ground-array sources must use the native path.")
 
     monkeypatch.setattr(
-        source_models.EhtimImageAdapter,
-        "observe",
-        legacy_adapter_observe,
+        observation_geometry,
+        "observation_template",
+        unexpected_legacy_path,
     )
-    legacy_generator = og.obs_generator(settings=settings)
-    legacy = legacy_generator.make_obs(
-        _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
-        addnoise=True,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
+    monkeypatch.setattr(source_models, "observe_source", unexpected_legacy_path)
+    monkeypatch.setattr(station_observation, "station_terms", unexpected_legacy_path)
+    obs = obsgen.observe(
+        source_factory(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
         flagwind=False,
         flagday=False,
         flagsun=False,
     )
 
-    assert np.array_equal(direct.data["t1"], legacy.data["t1"])
-    assert np.array_equal(direct.data["t2"], legacy.data["t2"])
-    for field in (
-        "time",
-        "u",
-        "v",
-        "tau1",
-        "tau2",
-        "rrvis",
-        "llvis",
-        "rlvis",
-        "lrvis",
-        "rrsigma",
-        "llsigma",
-        "rlsigma",
-        "lrsigma",
-    ):
-        assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+    assert len(obs.data) > 0
 
 
-def test_direct_ehtim_movie_sampling_preserves_seeded_corruptions(monkeypatch):
-    settings = dict(COMPACT_OBS_SETTINGS)
-    settings["fringe_finder"] = ["naive", 0.0]
-    direct_generator = og.obs_generator(settings=settings)
-    direct = direct_generator.make_obs(
-        _polarized_movie(),
-        addnoise=True,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
-
-    def legacy_adapter_observe(self, obs_empty, context, p=None):
-        return _legacy_movie_observe(self.input_model, obs_empty, context)
+@pytest.mark.parametrize(
+    "source_factory",
+    (
+        lambda: _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
+        _polarized_model,
+        _polarized_movie,
+    ),
+)
+def test_native_simulate_does_not_construct_obsdata(monkeypatch, source_factory):
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("simulate() must not construct an ehtim Obsdata object.")
 
     monkeypatch.setattr(
-        source_models.EhtimMovieAdapter,
-        "observe",
-        legacy_adapter_observe,
+        VisibilityDataset,
+        "to_ehtim_obsdata",
+        unexpected_obsdata_conversion,
     )
-    legacy_generator = og.obs_generator(settings=settings)
-    legacy = legacy_generator.make_obs(
-        _polarized_movie(),
-        addnoise=True,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
+    result = og.obs_generator(settings=COMPACT_OBS_SETTINGS).simulate(
+        source_factory(),
+        addnoise=False,
+        addgains=False,
         flagwind=False,
         flagday=False,
         flagsun=False,
     )
 
-    assert np.array_equal(direct.data["t1"], legacy.data["t1"])
-    assert np.array_equal(direct.data["t2"], legacy.data["t2"])
-    for field in (
-        "time",
-        "u",
-        "v",
-        "tau1",
-        "tau2",
-        "rrvis",
-        "llvis",
-        "rlvis",
-        "lrvis",
-        "rrsigma",
-        "llsigma",
-        "rlsigma",
-        "lrsigma",
-    ):
-        assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+    assert isinstance(result.dataset, VisibilityDataset)
 
 
-def test_direct_ehtim_model_sampling_preserves_seeded_corruptions(monkeypatch):
+def test_native_simulation_keeps_terms_in_the_result_not_the_generator():
     settings = dict(COMPACT_OBS_SETTINGS)
     settings["fringe_finder"] = ["naive", 0.0]
-    direct_generator = og.obs_generator(settings=settings)
-    direct = direct_generator.make_obs(
+    generator = og.obs_generator(settings=settings, weight=1)
+    result = generator.make_dataset(
         _polarized_model(),
-        addnoise=True,
+        addnoise=False,
         addgains=True,
         addFR=True,
         addleakage=True,
@@ -486,44 +544,136 @@ def test_direct_ehtim_model_sampling_preserves_seeded_corruptions(monkeypatch):
         flagsun=False,
     )
 
-    def legacy_adapter_observe(self, obs_empty, context, p=None):
-        return _legacy_model_observe(self.input_model, obs_empty, context)
-
-    monkeypatch.setattr(
-        source_models.EhtimModelAdapter,
-        "observe",
-        legacy_adapter_observe,
-    )
-    legacy_generator = og.obs_generator(settings=settings)
-    legacy = legacy_generator.make_obs(
-        _polarized_model(),
-        addnoise=True,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
-
-    assert np.array_equal(direct.data["t1"], legacy.data["t1"])
-    assert np.array_equal(direct.data["t2"], legacy.data["t2"])
-    for field in (
-        "time",
-        "u",
-        "v",
+    for name in (
+        "Tsys1",
+        "Tsys2",
         "tau1",
         "tau2",
-        "rrvis",
-        "llvis",
-        "rlvis",
-        "lrvis",
-        "rrsigma",
-        "llsigma",
-        "rlsigma",
-        "lrsigma",
+        "Tb1",
+        "Tb2",
+        "SEFD1",
+        "SEFD2",
+        "gainamp1R",
+        "gainamp2R",
+        "gainamp1L",
+        "gainamp2L",
+        "gainphase1R",
+        "gainphase2R",
+        "gainphase1L",
+        "gainphase2L",
+        "leak1R",
+        "leak2R",
+        "leak1L",
+        "leak2L",
     ):
-        assert np.allclose(direct.data[field], legacy.data[field], atol=1.0e-12)
+        assert name in result.station_terms
+        assert len(result.station_terms[name]) == result.dataset.row_count
+    assert not result.station_terms["tau1"].flags.writeable
+    assert not hasattr(generator, "timestamps")
+    assert not hasattr(generator, "SEFD1")
+
+
+def test_native_simulation_is_reproducible_with_a_fixed_seed():
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["naive", 0.0]
+    first = og.obs_generator(settings=settings).make_dataset(
+        _polarized_model(), addnoise=True, addgains=True, addFR=True,
+        addleakage=True, flagwind=False, flagday=False, flagsun=False,
+    )
+    second = og.obs_generator(settings=settings).make_dataset(
+        _polarized_model(), addnoise=True, addgains=True, addFR=True,
+        addleakage=True, flagwind=False, flagday=False, flagsun=False,
+    )
+
+    assert np.array_equal(first.dataset.time_mjd, second.dataset.time_mjd)
+    assert np.array_equal(first.dataset.flags, second.dataset.flags)
+    assert np.allclose(first.dataset.visibilities, second.dataset.visibilities)
+    assert np.allclose(first.dataset.weights, second.dataset.weights)
+
+
+def test_native_simulation_retains_all_flagged_rows_and_exports_an_empty_obsdata():
+    station_uptimes = {
+        "ALMA": (8.0, 9.0),
+        "APEX": (8.0, 9.0),
+        "LMT": (8.0, 9.0),
+        "SMT": (8.0, 9.0),
+    }
+    obsgen = og.obs_generator(
+        settings=COMPACT_OBS_SETTINGS,
+        station_uptimes=station_uptimes,
+    )
+
+    result = obsgen.simulate(
+        _compact_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert result.dataset.row_count > 0
+    assert not np.any(result.row_mask)
+    obs = result.to_ehtim_obsdata()
+    assert len(obs.data) == 0
+    assert obs.ampcal is True
+    assert obs.phasecal is True
+    assert obs.opacitycal is True
+    assert obs.dcal is True
+    assert obs.frcal is True
+
+
+@pytest.mark.parametrize(
+    "source_factory",
+    (
+        lambda: _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
+        _polarized_model,
+        _polarized_movie,
+    ),
+)
+def test_native_source_adapters_do_not_mutate_input_metadata(source_factory):
+    source = source_factory()
+    original = (source.ra, source.dec, source.mjd, source.source, source.rf)
+
+    og.obs_generator(settings=COMPACT_OBS_SETTINGS).simulate(
+        source,
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert (source.ra, source.dec, source.mjd, source.source, source.rf) == original
+
+
+def test_make_obs_exports_updated_station_terms_without_mutating_configuration():
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["naive", 0.0]
+    generator = og.obs_generator(settings=settings)
+    configured_tarr = generator.arr.tarr.copy()
+
+    result = generator.make_dataset(
+        _compact_model(),
+        addnoise=False,
+        addgains=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    obs = result.to_ehtim_obsdata()
+
+    assert np.array_equal(generator.arr.tarr, configured_tarr)
+    expected_sefd = dict(zip(
+        result.dataset.stations.names,
+        result.dataset.stations.sefd_r_jy,
+    ))
+    assert all(
+        obs.tarr["sefdr"][index] == pytest.approx(expected_sefd[site])
+        for index, site in enumerate(obs.tarr["site"])
+    )
 
 
 def test_obs_generator_still_accepts_ehtim_image():

--- a/tests/test_visibility_dataset.py
+++ b/tests/test_visibility_dataset.py
@@ -94,6 +94,29 @@ def test_dataset_select_rows_rejects_invalid_masks(row_mask):
         dataset().select_rows(row_mask)
 
 
+def test_dataset_take_rows_reorders_selected_rows():
+    original = dataset()
+
+    reordered = original.take_rows(np.array((1, 0), dtype=np.intp))
+
+    assert np.array_equal(reordered.time_mjd, original.time_mjd[::-1])
+    assert np.array_equal(reordered.antenna1, original.antenna1[::-1])
+    assert np.array_equal(reordered.visibilities, original.visibilities[::-1])
+
+
+@pytest.mark.parametrize(
+    "row_indices",
+    (
+        np.array((0.0,)),
+        np.array(((0, 1),)),
+        np.array((2,), dtype=np.intp),
+    ),
+)
+def test_dataset_take_rows_rejects_invalid_indices(row_indices):
+    with pytest.raises(ValueError, match="row_indices"):
+        dataset().take_rows(row_indices)
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [


### PR DESCRIPTION
Make VisibilityDataset the primary ground-array simulation representation. Add native Image, Model, and Movie adapters; preserve Obsdata as an export boundary; retain explicit legacy routes for space, FPT, and forecast behavior; and expand tests and benchmarks.