### PR TITLE
Audit fringe grouping and FPT selection

### DIFF
--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -4,5 +4,11 @@ Tools for generating and plotting observations.
 
 __author__ = "Dom Pesce"
 
-__all__ = ['obs_generator', 'obs_plotter', 'simulation_result', 'visibility_dataset']
+__all__ = [
+    'fringe_selection',
+    'obs_generator',
+    'obs_plotter',
+    'simulation_result',
+    'visibility_dataset',
+]
 from . import *

--- a/ngehtsim/obs/fringe_selection.py
+++ b/ngehtsim/obs/fringe_selection.py
@@ -1,0 +1,216 @@
+"""Deterministic fringe-detection selection primitives.
+
+The routines here implement ngehtsim's published detectability proxy: at a
+given timestamp, strong baselines form a station graph and every baseline
+within a connected component is retained.  This is deliberately not a full
+implementation of the HOPS fringe-fitting or phase-calibration pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FringeRows:
+    """Visibility rows required for fringe-detection selection."""
+
+    time: np.ndarray
+    station1: np.ndarray
+    station2: np.ndarray
+    integration_time_s: np.ndarray
+    rr: np.ndarray
+    ll: np.ndarray
+    rr_sigma: np.ndarray
+    ll_sigma: np.ndarray
+
+    def __post_init__(self):
+        arrays = {
+            "time": self.time,
+            "station1": self.station1,
+            "station2": self.station2,
+            "integration_time_s": self.integration_time_s,
+            "rr": self.rr,
+            "ll": self.ll,
+            "rr_sigma": self.rr_sigma,
+            "ll_sigma": self.ll_sigma,
+        }
+        normalized = {}
+        length = None
+        for name, values in arrays.items():
+            values = np.asarray(values)
+            if values.ndim != 1:
+                raise ValueError("{0} must be one-dimensional.".format(name))
+            if length is None:
+                length = len(values)
+            elif len(values) != length:
+                raise ValueError("All FringeRows fields must have the same length.")
+            normalized[name] = values
+        for name, values in normalized.items():
+            object.__setattr__(self, name, values)
+
+        if np.any(self.integration_time_s <= 0.0):
+            raise ValueError("Integration times must be positive.")
+        if np.any(self.rr_sigma <= 0.0) or np.any(self.ll_sigma <= 0.0):
+            raise ValueError("Parallel-hand uncertainties must be positive.")
+
+    @property
+    def row_count(self):
+        """Number of visibility rows."""
+        return len(self.time)
+
+    @property
+    def stokes_i_snr(self):
+        """Aligned parallel-hand Stokes-I SNR for each row.
+
+        The proxy assumes the RR and LL products can be phase aligned before
+        being stacked.  It therefore combines their amplitudes and propagates
+        their independent thermal uncertainties.
+        """
+        amplitude = 0.5 * (np.abs(self.rr) + np.abs(self.ll))
+        sigma = 0.5 * np.hypot(self.rr_sigma, self.ll_sigma)
+        return amplitude / sigma
+
+
+def fringe_group_mask(rows, snr_threshold, tint_reference_s, available_sites=None):
+    """Return rows in timestamp-local components of strong baselines."""
+    _validate_thresholds(snr_threshold, tint_reference_s)
+    available = _availability_mask(rows.station1, rows.station2, available_sites)
+    strong = available & (
+        rows.stokes_i_snr
+        >= snr_threshold * np.sqrt(rows.integration_time_s / tint_reference_s)
+    )
+    return connected_component_mask(
+        rows.time,
+        rows.station1,
+        rows.station2,
+        strong,
+        rows.time,
+        rows.station1,
+        rows.station2,
+        query_available=available,
+    )
+
+
+def fpt_fringe_group_mask(target_rows, reference_rows, reference_snr_threshold,
+                          tint_reference_s, reference_to_target_ratio,
+                          target_available_sites=None, reference_available_sites=None):
+    """Return target rows detectable through native or FPT-supported fringes.
+
+    ``reference_snr_threshold`` is the strong-baseline threshold at the
+    reference frequency.  The corresponding target threshold is that value
+    multiplied by ``reference_to_target_ratio``.  Reference and target rows
+    are intentionally independent: the station graph is keyed by timestamp
+    and never by row position.
+    """
+    _validate_thresholds(reference_snr_threshold, tint_reference_s)
+    if not np.isfinite(reference_to_target_ratio) or reference_to_target_ratio <= 0.0:
+        raise ValueError("reference_to_target_ratio must be positive and finite.")
+
+    target_available = _availability_mask(
+        target_rows.station1,
+        target_rows.station2,
+        target_available_sites,
+    )
+    reference_available = _availability_mask(
+        reference_rows.station1,
+        reference_rows.station2,
+        reference_available_sites,
+    )
+    target_strong = target_available & (
+        target_rows.stokes_i_snr
+        >= reference_snr_threshold
+        * reference_to_target_ratio
+        * np.sqrt(target_rows.integration_time_s / tint_reference_s)
+    )
+    reference_strong = reference_available & (
+        reference_rows.stokes_i_snr
+        >= reference_snr_threshold
+        * np.sqrt(reference_rows.integration_time_s / tint_reference_s)
+    )
+
+    return connected_component_mask(
+        np.concatenate((target_rows.time, reference_rows.time)),
+        np.concatenate((target_rows.station1, reference_rows.station1)),
+        np.concatenate((target_rows.station2, reference_rows.station2)),
+        np.concatenate((target_strong, reference_strong)),
+        target_rows.time,
+        target_rows.station1,
+        target_rows.station2,
+        query_available=target_available,
+    )
+
+
+def connected_component_mask(graph_time, graph_station1, graph_station2, graph_edges,
+                             query_time, query_station1, query_station2,
+                             query_available=None):
+    """Select query rows whose stations share a graph component per timestamp."""
+    graph_time = np.asarray(graph_time)
+    graph_station1 = np.asarray(graph_station1)
+    graph_station2 = np.asarray(graph_station2)
+    graph_edges = np.asarray(graph_edges, dtype=bool)
+    query_time = np.asarray(query_time)
+    query_station1 = np.asarray(query_station1)
+    query_station2 = np.asarray(query_station2)
+
+    graph_length = len(graph_time)
+    if any(len(values) != graph_length for values in (graph_station1, graph_station2, graph_edges)):
+        raise ValueError("All graph fields must have the same length.")
+    query_length = len(query_time)
+    if any(len(values) != query_length for values in (query_station1, query_station2)):
+        raise ValueError("All query fields must have the same length.")
+    if query_available is None:
+        query_available = np.ones(query_length, dtype=bool)
+    else:
+        query_available = np.asarray(query_available, dtype=bool)
+        if query_available.shape != (query_length,):
+            raise ValueError("query_available must have one value per query row.")
+
+    selected = np.zeros(query_length, dtype=bool)
+    for timestamp in np.unique(query_time):
+        graph_indices = np.flatnonzero((graph_time == timestamp) & graph_edges)
+        if not len(graph_indices):
+            continue
+        parent = {}
+
+        def find(station):
+            parent.setdefault(station, station)
+            if parent[station] != station:
+                parent[station] = find(parent[station])
+            return parent[station]
+
+        for index in graph_indices:
+            station1 = graph_station1[index]
+            station2 = graph_station2[index]
+            root1 = find(station1)
+            root2 = find(station2)
+            if root1 != root2:
+                parent[root2] = root1
+
+        for index in np.flatnonzero(query_time == timestamp):
+            station1 = query_station1[index]
+            station2 = query_station2[index]
+            if (
+                query_available[index]
+                and station1 in parent
+                and station2 in parent
+                and find(station1) == find(station2)
+            ):
+                selected[index] = True
+    return selected
+
+
+def _availability_mask(station1, station2, available_sites):
+    if available_sites is None:
+        return np.ones(len(station1), dtype=bool)
+    available_sites = tuple(available_sites)
+    return np.isin(station1, available_sites) & np.isin(station2, available_sites)
+
+
+def _validate_thresholds(snr_threshold, tint_reference_s):
+    if not np.isfinite(snr_threshold) or snr_threshold < 0.0:
+        raise ValueError("snr_threshold must be finite and non-negative.")
+    if not np.isfinite(tint_reference_s) or tint_reference_s <= 0.0:
+        raise ValueError("tint_reference_s must be positive and finite.")

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -20,6 +20,7 @@ import ngehtsim.const_def as const
 import ngehtsim.weather.weather as nw
 from ngehtsim.weather.zarr_store import ZarrWeatherStore
 import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
+import ngehtsim.obs.fringe_selection as fringe_selection
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.station_observation as station_observation
@@ -1251,14 +1252,14 @@ class obs_generator(object):
                 master_index &= np.array([t1_list[j] not in sites_to_remove and t2_list[j] not in sites_to_remove for j in range(len(t1_list))])
 
         # identify sites that are randomly deemed to be technically unready
-        sites_to_remove = get_unready_sites(obs.tarr['site'], self.settings['tech_readiness'], rng=self.rng)
-        if len(sites_to_remove) > 0:
+        unready_sites = get_unready_sites(obs.tarr['site'], self.settings['tech_readiness'], rng=self.rng)
+        if len(unready_sites) > 0:
             if self.verbosity > 0:
-                print("Dropping {0} due to technical (un)readiness.".format(sites_to_remove))
+                print("Dropping {0} due to technical (un)readiness.".format(unready_sites))
             if len(obs.data) > 0:
                 t1_list = obs.unpack('t1')['t1']
                 t2_list = obs.unpack('t2')['t2']
-                master_index &= np.array([t1_list[j] not in sites_to_remove and t2_list[j] not in sites_to_remove for j in range(len(t1_list))])
+                master_index &= np.array([t1_list[j] not in unready_sites and t2_list[j] not in unready_sites for j in range(len(t1_list))])
 
         # apply naive SNR thresholding
         if (snr_algo.lower() == 'naive'):
@@ -1286,7 +1287,7 @@ class obs_generator(object):
             model_path_ref = snr_args[3]
 
             # run FPT
-            master_index &= FPT(self, obs, snr_ref, tint_ref, freq_ref, model_path_ref, ephem=self.ephem, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, flagwind=flagwind, flagday=flagday, flagsun=flagsun, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, p=p)
+            master_index &= FPT(self, obs, snr_ref, tint_ref, freq_ref, model_path_ref, ephem=self.ephem, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, flagwind=flagwind, flagday=flagday, flagsun=flagsun, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, p=p, unready_sites=unready_sites)
 
         # unrecognized SNR thresholding scheme
         else:
@@ -2089,75 +2090,14 @@ def fringegroups(obsgen, obs, snr_ref, tint_ref):
       (numpy.ndarray): An array of kept data indices
     """
 
-    # get the timestamps
-    time = obs.data['time']
-    timestamps = np.unique(time)
-
-    # get the stations that are able to observe at this frequency
-    available_sites = list()
-    for site in obsgen.sites:
-        if obsgen.bands[site] is not None:
-            available_sites.append(site)
-
-    # create a running index list of baselines to flag
-    master_index = np.zeros(len(obs.data), dtype='bool')
-    count = 0
-
-    # create blank dummy obsdata objects
-    obs = obs.switch_polrep(polrep_out='circ')
-    obs_here = copy.deepcopy(obs)
-    obs_here.data = None
-    obs_search = obs_here.copy()
-
-    # check all timestamps
-    for itime, timestamp in enumerate(timestamps):
-
-        ind_t = (time == timestamp)
-        obs_here.data = obs.data[ind_t]
-
-        # scale effective SNR to the actual integration time
-        snr_scaled = snr_ref*np.sqrt(obs_here.data['tint'] / tint_ref)
-
-        # determine which baselines are "strong"
-        pseudo_I_amp = 0.5*(np.abs(obs_here.data['rrvis']) + np.abs(obs_here.data['llvis']))
-        pseudo_I_sig = obs_here.data['rrsigma'] / np.sqrt(2.0)
-        index = (pseudo_I_amp/pseudo_I_sig) >= snr_scaled
-
-        # determine which sites are available to observe at this frequency
-        t1_available = np.isin(obs_here.data['t1'], available_sites)
-        t2_available = np.isin(obs_here.data['t2'], available_sites)
-        index &= t1_available
-        index &= t2_available
-
-        # limit the searched baselines to those that are strong and available
-        obs_search.data = obs_here.data[index]
-
-        # group stations that are connected by strong baselines
-        groups = list()
-        for datum in obs_search.data:
-            bl = [datum['t1'], datum['t2']]
-            (merged, remaining) = (set(bl), [])
-            for g in groups:
-                if bl[0] in g or bl[1] in g:
-                    merged |= g
-                else:
-                    remaining.append(g)
-            groups = remaining + [merged]
-
-        # assign stations to groups
-        site_dict = {}
-        for ig, group in enumerate(groups):
-            for station in group:
-                site_dict[station] = ig
-
-        # check whether both stations on each baseline are in the same group
-        for datum in obs_here.data:
-            if ((datum['t1'] in list(site_dict.keys())) & (datum['t2'] in list(site_dict.keys()))):
-                if (site_dict[datum['t1']] == site_dict[datum['t2']]):
-                    master_index[count] = True
-            count += 1
-
-    return master_index
+    rows = _fringe_rows_from_obsdata(obs)
+    available_sites = [site for site in obsgen.sites if obsgen.bands[site] is not None]
+    return fringe_selection.fringe_group_mask(
+        rows,
+        snr_ref,
+        tint_ref,
+        available_sites=available_sites,
+    )
 
 
 def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
@@ -2169,58 +2109,32 @@ def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
         return np.zeros(0, dtype=bool)
 
     names = np.asarray(dataset.stations.names)
-    t1 = names[dataset.antenna1]
-    t2 = names[dataset.antenna2]
-    available_sites = {
-        site for site in obsgen.sites if obsgen.bands[site] is not None
-    }
-    master_index = np.zeros(dataset.row_count, dtype=bool)
-
-    for timestamp in np.unique(dataset.time_mjd):
-        indices = np.flatnonzero(dataset.time_mjd == timestamp)
-        rr = dataset.visibilities[indices, 0, 0]
-        ll = dataset.visibilities[indices, 0, 1]
-        rr_sigma = 1.0 / np.sqrt(dataset.weights[indices, 0, 0])
-        snr_scaled = snr_ref * np.sqrt(dataset.integration_time_s[indices] / tint_ref)
-        strong = (
-            (0.5 * (np.abs(rr) + np.abs(ll)) / (rr_sigma / np.sqrt(2.0)))
-            >= snr_scaled
-        )
-        strong &= np.isin(t1[indices], tuple(available_sites))
-        strong &= np.isin(t2[indices], tuple(available_sites))
-
-        groups = []
-        for index in indices[strong]:
-            baseline = {t1[index], t2[index]}
-            merged = set(baseline)
-            remaining = []
-            for group in groups:
-                if baseline & group:
-                    merged |= group
-                else:
-                    remaining.append(group)
-            groups = remaining + [merged]
-
-        site_groups = {
-            station: group_index
-            for group_index, group in enumerate(groups)
-            for station in group
-        }
-        for index in indices:
-            if (
-                t1[index] in site_groups
-                and t2[index] in site_groups
-                and site_groups[t1[index]] == site_groups[t2[index]]
-            ):
-                master_index[index] = True
-
-    return master_index
+    rows = fringe_selection.FringeRows(
+        time=dataset.time_mjd,
+        station1=names[dataset.antenna1],
+        station2=names[dataset.antenna2],
+        integration_time_s=dataset.integration_time_s,
+        rr=dataset.visibilities[:, 0, 0],
+        ll=dataset.visibilities[:, 0, 1],
+        rr_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 0]),
+        ll_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 1]),
+    )
+    available_sites = [site for site in obsgen.sites if obsgen.bands[site] is not None]
+    return fringe_selection.fringe_group_mask(
+        rows,
+        snr_ref,
+        tint_ref,
+        available_sites=available_sites,
+    )
 
 
-def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemeris/space', **kwargs):
+def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemeris/space',
+        unready_sites=(), **kwargs):
     """
     Function to apply the frequency phase transfer ("FPT") SNR thresholding scheme to an observation.
-    This scheme attempts to mimic the fringe-fitting carried out in the HOPS calibration pipeline.
+    This scheme attempts to mimic the fringe-finding consequences of phase
+    transfer in the HOPS calibration pipeline. It only selects detectable
+    target rows; it does not apply phase-transfer corrections to visibilities.
 
     Args:
       obsgen (ngehtsim.obs.obs_generator.obs_generator): ngehtsim obs_generator object containing information about the observation
@@ -2285,70 +2199,41 @@ def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemer
     # generate observation at reference frequency
     obs_ref = obsgen_ref.observe_legacy(obsgen_ref.im, **kwargs)
 
-    # create a running index list of baselines to flag
-    master_index = np.zeros(len(obs_ref.data), dtype='bool')
+    target_rows = _fringe_rows_from_obsdata(obs)
+    reference_rows = _fringe_rows_from_obsdata(obs_ref)
+    unready_sites = set(unready_sites)
+    target_available = [
+        site for site in obsgen.sites
+        if obsgen.bands[site] is not None and site not in unready_sites
+    ]
+    reference_available = [
+        site for site in obsgen_ref.sites
+        if obsgen_ref.bands[site] is not None and site not in unready_sites
+    ]
+    return fringe_selection.fpt_fringe_group_mask(
+        target_rows,
+        reference_rows,
+        snr_ref,
+        tint_ref,
+        freq_rat,
+        target_available_sites=target_available,
+        reference_available_sites=reference_available,
+    )
 
-    # identify sites that can't observe at the reference frequency
-    sites_to_remove = list()
-    for site in obs_ref.tarr['site']:
-        if obsgen_ref.bands[site] is None:
-            sites_to_remove.append(site)
-    if len(sites_to_remove) > 0:
-        if len(obs_ref.data) > 0:
-            t1_list = obs_ref.unpack('t1')['t1']
-            t2_list = obs_ref.unpack('t2')['t2']
-            mask_ref = np.array([t1_list[j] not in sites_to_remove and t2_list[j] not in sites_to_remove for j in range(len(t1_list))])
-        else:
-            mask_ref = np.ones(len(obs_ref.data),dtype=bool)
-    else:
-        mask_ref = np.ones(len(obs_ref.data),dtype=bool)
-    wheremask_ref = np.where(mask_ref)
 
-    # identify sites that can't observe at the target frequency
-    sites_to_remove = list()
-    for site in obs_ref.tarr['site']:
-        if obsgen.bands[site] is None:
-            sites_to_remove.append(site)
-    if len(sites_to_remove) > 0:
-        if len(obs_ref.data) > 0:
-            t1_list = obs_ref.unpack('t1')['t1']
-            t2_list = obs_ref.unpack('t2')['t2']
-            mask_tar = np.array([t1_list[j] not in sites_to_remove and t2_list[j] not in sites_to_remove for j in range(len(t1_list))])
-        else:
-            mask_tar = np.ones(len(obs_ref.data),dtype=bool)
-    else:
-        mask_tar = np.ones(len(obs_ref.data),dtype=bool)
-    wheremask_tar = np.where(mask_tar)
-
-    # get detections from fringe-fitting at the reference frequency
-    obs_ref_pass = obs_ref.copy()
-    obs_ref_pass.data = obs_ref.data.copy()[wheremask_ref]
-    fringegroups_index = fringegroups(obsgen_ref, obs_ref_pass, snr_ref, tint_ref)
-    master_index[wheremask_ref] |= fringegroups_index
-
-    # compare target SNR and (scaled) reference SNR, using the larger of the two for dual-band baselines
-    pseudo_I_amp = 0.5*(np.abs(obs.data['rrvis']) + np.abs(obs.data['llvis']))
-    pseudo_I_sig = obs.data['rrsigma'] / np.sqrt(2.0)
-    snr_data = pseudo_I_amp / pseudo_I_sig
-    pseudo_I_amp_ref = 0.5*(np.abs(obs_ref.data['rrvis']) + np.abs(obs_ref.data['llvis']))
-    pseudo_I_sig_ref = obs_ref.data['rrsigma'] / np.sqrt(2.0)
-    snr_data_ref = (pseudo_I_amp_ref / pseudo_I_sig_ref)*freq_rat
-    ind_snr_boost = (snr_data_ref > snr_data) & mask_ref & mask_tar
-
-    # get any additional detections from fringe-fitting at the target frequency
-    obs_pass = obs.copy()
-    data_copy = obs.data.copy()
-    data_copy[ind_snr_boost] = obs_ref.data[ind_snr_boost]
-    data_copy['rrsigma'][ind_snr_boost] /= freq_rat
-    data_copy['llsigma'][ind_snr_boost] /= freq_rat
-    data_copy['rlsigma'][ind_snr_boost] /= freq_rat
-    data_copy['lrsigma'][ind_snr_boost] /= freq_rat
-    obs_pass.data = data_copy[wheremask_tar]
-    snr_fringegroups = snr_ref * freq_rat
-    fringegroups_index = fringegroups(obsgen, obs_pass, snr_fringegroups, tint_ref)
-    master_index[wheremask_tar] |= fringegroups_index
-
-    return master_index
+def _fringe_rows_from_obsdata(obs):
+    """Extract circular parallel-hand fringe-selection inputs from Obsdata."""
+    circular = obs.switch_polrep(polrep_out='circ')
+    return fringe_selection.FringeRows(
+        time=circular.data['time'],
+        station1=circular.data['t1'],
+        station2=circular.data['t2'],
+        integration_time_s=circular.data['tint'],
+        rr=circular.data['rrvis'],
+        ll=circular.data['llvis'],
+        rr_sigma=circular.data['rrsigma'],
+        ll_sigma=circular.data['llsigma'],
+    )
 
 
 def export_SYMBA_antennas(obsgen, output_filename='obsgen.antennas', t_coh=10.0, RMS_point=1.0,

--- a/tests/test_fringe_selection.py
+++ b/tests/test_fringe_selection.py
@@ -1,0 +1,381 @@
+"""Specification tests for ngehtsim fringe-group and FPT selection."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import ngehtsim.obs.obs_generator as obs_module
+from ngehtsim.obs.fringe_selection import FringeRows, fpt_fringe_group_mask, fringe_group_mask
+
+
+def rows(station_pairs, snr, time=None, tint=None, rr_sigma=None, ll_sigma=None):
+    """Build rows with requested aligned parallel-hand Stokes-I SNR values."""
+    count = len(station_pairs)
+    snr = np.broadcast_to(np.asarray(snr, dtype=float), (count,))
+    time = np.zeros(count, dtype=float) if time is None else np.asarray(time, dtype=float)
+    tint = np.full(count, 10.0) if tint is None else np.asarray(tint, dtype=float)
+    rr_sigma = np.ones(count) if rr_sigma is None else np.asarray(rr_sigma, dtype=float)
+    ll_sigma = np.ones(count) if ll_sigma is None else np.asarray(ll_sigma, dtype=float)
+    amplitude = snr * 0.5 * np.hypot(rr_sigma, ll_sigma)
+    return FringeRows(
+        time=time,
+        station1=np.array([pair[0] for pair in station_pairs]),
+        station2=np.array([pair[1] for pair in station_pairs]),
+        integration_time_s=tint,
+        rr=amplitude.astype(complex),
+        ll=amplitude.astype(complex),
+        rr_sigma=rr_sigma,
+        ll_sigma=ll_sigma,
+    )
+
+
+def test_stokes_i_snr_propagates_unequal_parallel_hand_uncertainties():
+    selection_rows = FringeRows(
+        time=np.array([0.0]),
+        station1=np.array(["A"]),
+        station2=np.array(["B"]),
+        integration_time_s=np.array([10.0]),
+        rr=np.array([10.0 + 0.0j]),
+        ll=np.array([10.0 + 0.0j]),
+        rr_sigma=np.array([3.0]),
+        ll_sigma=np.array([4.0]),
+    )
+
+    assert np.allclose(selection_rows.stokes_i_snr, [4.0])
+
+
+def test_fringe_groups_promote_weak_baselines_inside_a_transitive_component():
+    selection_rows = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 5.0, 0.1],
+    )
+
+    assert np.array_equal(
+        fringe_group_mask(selection_rows, snr_threshold=5.0, tint_reference_s=10.0),
+        [True, True, True],
+    )
+
+
+def test_fringe_groups_keep_disconnected_components_separate():
+    selection_rows = rows(
+        [("A", "B"), ("C", "D"), ("A", "C")],
+        [5.0, 5.0, 0.1],
+    )
+
+    assert np.array_equal(
+        fringe_group_mask(selection_rows, snr_threshold=5.0, tint_reference_s=10.0),
+        [True, True, False],
+    )
+
+
+def test_fringe_groups_are_timestamp_local_and_scale_threshold_by_integration_time():
+    selection_rows = rows(
+        [("A", "B"), ("B", "C"), ("A", "C"), ("D", "E")],
+        [5.0, 5.0, 0.1, 5.0],
+        time=[0.0, 1.0, 0.0, 0.0],
+        tint=[10.0, 10.0, 10.0, 40.0],
+    )
+
+    assert np.array_equal(
+        fringe_group_mask(selection_rows, snr_threshold=5.0, tint_reference_s=10.0),
+        [True, True, False, False],
+    )
+
+
+def test_fringe_groups_apply_station_availability_before_building_components():
+    selection_rows = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 5.0, 0.1],
+    )
+
+    assert np.array_equal(
+        fringe_group_mask(
+            selection_rows,
+            snr_threshold=5.0,
+            tint_reference_s=10.0,
+            available_sites=("A", "C"),
+        ),
+        [False, False, False],
+    )
+
+
+def test_fringe_groups_are_invariant_to_row_order_and_baseline_orientation():
+    original = rows(
+        [("A", "B"), ("B", "C"), ("A", "C"), ("D", "E")],
+        [5.0, 5.0, 0.1, 5.0],
+    )
+    order = np.array([3, 2, 0, 1])
+    shuffled = FringeRows(
+        time=original.time[order],
+        station1=original.station2[order],
+        station2=original.station1[order],
+        integration_time_s=original.integration_time_s[order],
+        rr=original.rr[order],
+        ll=original.ll[order],
+        rr_sigma=original.rr_sigma[order],
+        ll_sigma=original.ll_sigma[order],
+    )
+
+    original_mask = fringe_group_mask(original, snr_threshold=5.0, tint_reference_s=10.0)
+    shuffled_mask = fringe_group_mask(shuffled, snr_threshold=5.0, tint_reference_s=10.0)
+
+    assert np.array_equal(shuffled_mask[np.argsort(order)], original_mask)
+
+
+def test_empty_fringe_rows_are_valid_and_select_nothing():
+    empty = rows([], [])
+
+    assert np.array_equal(
+        fringe_group_mask(empty, snr_threshold=5.0, tint_reference_s=10.0),
+        np.zeros(0, dtype=bool),
+    )
+
+
+@pytest.mark.parametrize(
+    ("reference_snr", "expected"),
+    [(20.0, True), (19.9, False)],
+)
+def test_fpt_uses_the_reference_threshold_scaled_by_frequency_ratio(reference_snr, expected):
+    target = rows([("A", "B")], [4.0])
+    reference = rows([("A", "B")], [reference_snr])
+
+    selected = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+    )
+
+    assert np.array_equal(selected, [expected])
+
+
+def test_fpt_combines_target_and_reference_strong_edges_in_one_station_graph():
+    target = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 0.1, 0.1],
+    )
+    reference = rows(
+        [("C", "B"), ("D", "E")],
+        [20.0, 20.0],
+        time=[0.0, 2.0],
+    )
+
+    selected = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+    )
+
+    assert np.array_equal(selected, [True, True, True])
+
+
+def test_fpt_does_not_depend_on_matching_reference_row_order_or_count():
+    target = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [0.1, 0.1, 0.1],
+    )
+    reference = rows(
+        [("D", "E"), ("C", "B"), ("B", "A")],
+        [20.0, 20.0, 20.0],
+        time=[2.0, 0.0, 0.0],
+    )
+
+    selected = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+    )
+
+    assert np.array_equal(selected, [True, True, True])
+
+
+def test_fpt_respects_target_and_reference_station_availability_independently():
+    target = rows([("A", "B")], [0.1])
+    reference = rows([("A", "B")], [20.0])
+
+    target_unavailable = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+        target_available_sites=("A",),
+        reference_available_sites=("A", "B"),
+    )
+    reference_unavailable = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+        target_available_sites=("A", "B"),
+        reference_available_sites=("A",),
+    )
+
+    assert np.array_equal(target_unavailable, [False])
+    assert np.array_equal(reference_unavailable, [False])
+
+
+def test_fpt_can_select_a_native_target_baseline_without_reference_rows():
+    target = rows([("A", "B")], [5.0])
+    reference = rows([], [])
+
+    assert np.array_equal(
+        fpt_fringe_group_mask(
+            target,
+            reference,
+            reference_snr_threshold=20.0,
+            tint_reference_s=10.0,
+            reference_to_target_ratio=0.25,
+        ),
+        [True],
+    )
+
+
+def obsdata(selection_rows):
+    """Create the narrow Obsdata-like surface consumed by legacy selection."""
+    dtype = [
+        ("time", float), ("tint", float), ("t1", "U8"), ("t2", "U8"),
+        ("rrvis", complex), ("llvis", complex), ("rrsigma", float), ("llsigma", float),
+    ]
+    data = np.empty(selection_rows.row_count, dtype=dtype)
+    data["time"] = selection_rows.time
+    data["tint"] = selection_rows.integration_time_s
+    data["t1"] = selection_rows.station1
+    data["t2"] = selection_rows.station2
+    data["rrvis"] = selection_rows.rr
+    data["llvis"] = selection_rows.ll
+    data["rrsigma"] = selection_rows.rr_sigma
+    data["llsigma"] = selection_rows.ll_sigma
+
+    class FakeObsdata:
+        def __init__(self, values):
+            self.data = values
+
+        def switch_polrep(self, polrep_out):
+            assert polrep_out == "circ"
+            return self
+
+    return FakeObsdata(data)
+
+
+def test_legacy_fringegroups_uses_the_shared_order_independent_selector():
+    selection_rows = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 5.0, 0.1],
+    )
+
+    class Generator:
+        sites = ("A", "B", "C")
+        bands = {"A": "band", "B": "band", "C": "band"}
+
+    assert np.array_equal(
+        obs_module.fringegroups(Generator(), obsdata(selection_rows), 5.0, 10.0),
+        [True, True, True],
+    )
+
+
+def test_native_fringegroups_uses_parallel_hand_weights_and_shared_selector():
+    selection_rows = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 5.0, 0.1],
+        rr_sigma=[3.0, 3.0, 3.0],
+        ll_sigma=[4.0, 4.0, 4.0],
+    )
+    dataset = SimpleNamespace(
+        channel_count=1,
+        row_count=selection_rows.row_count,
+        stations=SimpleNamespace(names=("A", "B", "C")),
+        time_mjd=selection_rows.time,
+        integration_time_s=selection_rows.integration_time_s,
+        antenna1=np.array([0, 1, 0]),
+        antenna2=np.array([1, 2, 2]),
+        visibilities=np.column_stack((
+            selection_rows.rr,
+            selection_rows.ll,
+            np.zeros(selection_rows.row_count, dtype=complex),
+            np.zeros(selection_rows.row_count, dtype=complex),
+        ))[:, np.newaxis, :],
+        weights=np.column_stack((
+            1.0 / np.square(selection_rows.rr_sigma),
+            1.0 / np.square(selection_rows.ll_sigma),
+            np.ones(selection_rows.row_count),
+            np.ones(selection_rows.row_count),
+        ))[:, np.newaxis, :],
+    )
+
+    class Generator:
+        sites = ("A", "B", "C")
+        bands = {"A": "band", "B": "band", "C": "band"}
+
+    assert np.array_equal(
+        obs_module.fringegroups_dataset(Generator(), dataset, 5.0, 10.0),
+        [True, True, True],
+    )
+
+
+def test_fpt_wrapper_accepts_independent_target_and_reference_row_sets(monkeypatch):
+    target = obsdata(rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [5.0, 0.1, 0.1],
+    ))
+    reference = obsdata(rows(
+        [("D", "E"), ("C", "B")],
+        [20.0, 20.0],
+        time=[2.0, 0.0],
+    ))
+
+    class Generator:
+        settings = {"frequency": 345.0, "bandwidth": 2.0}
+        freq = 345.0e9
+        seed = 1
+        weather = "mean"
+        D_overrides = {}
+        surf_rms_overrides = {}
+        receiver_configuration_overrides = {}
+        bandwidth_overrides = {}
+        T_R_overrides = {}
+        sideband_ratio_overrides = {}
+        lo_freq_overrides = {}
+        hi_freq_overrides = {}
+        ap_eff_overrides = {}
+        wind_loading_overrides = {}
+        custom_receivers = {}
+        station_uptimes = {}
+        weather_store = None
+        weather_cadence = "daily"
+        sites = ("A", "B", "C", "D", "E")
+        bands = {site: "band" for site in sites}
+        im = None
+
+    reference_generator = Generator()
+    reference_generator.observe_legacy = lambda input_model, **kwargs: reference
+    monkeypatch.setattr(obs_module, "obs_generator", lambda *args, **kwargs: reference_generator)
+
+    selected = obs_module.FPT(
+        Generator(),
+        target,
+        snr_ref=20.0,
+        tint_ref=10.0,
+        freq_ref=86.25,
+    )
+
+    assert np.array_equal(selected, [True, True, True])
+
+    assert np.array_equal(
+        obs_module.FPT(
+            Generator(),
+            target,
+            snr_ref=20.0,
+            tint_ref=10.0,
+            freq_ref=86.25,
+            unready_sites=("B",),
+        ),
+        [False, False, False],
+    )


### PR DESCRIPTION
Replace order-dependent fringe grouping with a tested timestamp-local graph selector. Make FPT selection robust to independent target and reference row sets, apply technical readiness consistently, document its selection-only scope, and add focused correctness tests.