### PR TITLE
Add native FPT fringe selection

### DIFF
--- a/ngehtsim/obs/fringe_selection.py
+++ b/ngehtsim/obs/fringe_selection.py
@@ -96,14 +96,16 @@ def fringe_group_mask(rows, snr_threshold, tint_reference_s, available_sites=Non
 
 def fpt_fringe_group_mask(target_rows, reference_rows, reference_snr_threshold,
                           tint_reference_s, reference_to_target_ratio,
-                          target_available_sites=None, reference_available_sites=None):
+                          target_available_sites=None, reference_available_sites=None,
+                          target_row_available=None, reference_row_available=None):
     """Return target rows detectable through native or FPT-supported fringes.
 
     ``reference_snr_threshold`` is the strong-baseline threshold at the
     reference frequency.  The corresponding target threshold is that value
     multiplied by ``reference_to_target_ratio``.  Reference and target rows
     are intentionally independent: the station graph is keyed by timestamp
-    and never by row position.
+    and never by row position.  Optional row-availability masks exclude
+    station-flagged data before either graph is assembled.
     """
     _validate_thresholds(reference_snr_threshold, tint_reference_s)
     if not np.isfinite(reference_to_target_ratio) or reference_to_target_ratio <= 0.0:
@@ -114,10 +116,20 @@ def fpt_fringe_group_mask(target_rows, reference_rows, reference_snr_threshold,
         target_rows.station2,
         target_available_sites,
     )
+    target_available &= _row_availability_mask(
+        target_row_available,
+        target_rows.row_count,
+        "target_row_available",
+    )
     reference_available = _availability_mask(
         reference_rows.station1,
         reference_rows.station2,
         reference_available_sites,
+    )
+    reference_available &= _row_availability_mask(
+        reference_row_available,
+        reference_rows.row_count,
+        "reference_row_available",
     )
     target_strong = target_available & (
         target_rows.stokes_i_snr
@@ -207,6 +219,15 @@ def _availability_mask(station1, station2, available_sites):
         return np.ones(len(station1), dtype=bool)
     available_sites = tuple(available_sites)
     return np.isin(station1, available_sites) & np.isin(station2, available_sites)
+
+
+def _row_availability_mask(values, count, name):
+    if values is None:
+        return np.ones(count, dtype=bool)
+    values = np.asarray(values, dtype=bool)
+    if values.shape != (count,):
+        raise ValueError("{0} must have one value per row.".format(name))
+    return values
 
 
 def _validate_thresholds(snr_threshold, tint_reference_s):

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -1287,7 +1287,7 @@ class obs_generator(object):
             model_path_ref = snr_args[3]
 
             # run FPT
-            master_index &= FPT(self, obs, snr_ref, tint_ref, freq_ref, model_path_ref, ephem=self.ephem, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, flagwind=flagwind, flagday=flagday, flagsun=flagsun, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, p=p, unready_sites=unready_sites)
+            master_index &= FPT(self, obs, snr_ref, tint_ref, freq_ref, model_path_ref, ephem=self.ephem, addnoise=addnoise, addgains=addgains, gainamp=gainamp, leakamp=leakamp, opacitycal=opacitycal, flagwind=flagwind, flagday=flagday, flagsun=flagsun, addFR=addFR, addleakage=addleakage, el_min=el_min, el_max=el_max, p=p, unready_sites=unready_sites, target_model=input_model)
 
         # unrecognized SNR thresholding scheme
         else:
@@ -1330,7 +1330,7 @@ class obs_generator(object):
         # return observation object
         return obs
 
-    def _native_selection_mask(self, dataset):
+    def _native_selection_mask(self, dataset, input_model=None, simulation_kwargs=None):
         """Return the native row-selection mask for availability and fringe finding."""
 
         mask = ~np.any(dataset.flags, axis=(1, 2))
@@ -1355,6 +1355,11 @@ class obs_generator(object):
                 print("Dropping {0} due to technical (un)readiness.".format(unready))
             mask &= ~np.isin(t1, unready) & ~np.isin(t2, unready)
 
+        available_sites = [
+            site for site in dataset.stations.names
+            if self.bands[site] is not None and site not in unready
+        ]
+
         snr_algorithm, snr_args = self.settings["fringe_finder"]
         snr_algorithm = snr_algorithm.lower()
         if snr_algorithm == "naive":
@@ -1374,13 +1379,63 @@ class obs_generator(object):
                 snr_args[1],
             )
         elif snr_algorithm == "fpt":
-            raise NotImplementedError(
-                "Native FPT fringe selection is not implemented; use make_obs_legacy() "
-                "or observe_legacy() explicitly."
+            if input_model is None or simulation_kwargs is None:
+                raise ValueError(
+                    "Native FPT selection requires the target model and simulation settings."
+                )
+            snr_ref, tint_ref, freq_ref, model_ref = snr_args
+            mask &= self._native_fpt_selection_mask(
+                dataset,
+                input_model,
+                snr_ref,
+                tint_ref,
+                freq_ref,
+                model_ref,
+                simulation_kwargs,
+                target_available_sites=available_sites,
+                target_row_available=mask,
+                unready_sites=unready,
             )
         else:
             raise ValueError("Unknown algorithm for fringe_finder.")
         return mask
+
+    def _native_fpt_selection_mask(self, target_dataset, target_model, snr_ref,
+                                   tint_ref, freq_ref, model_ref, simulation_kwargs,
+                                   target_available_sites, target_row_available,
+                                   unready_sites):
+        """Run the FPT reference simulation without constructing ``ehtim.Obsdata``."""
+
+        reference_generator, reference_model = _fpt_reference_generator(
+            self,
+            snr_ref,
+            tint_ref,
+            freq_ref,
+            model_ref,
+            target_model,
+            ephem=self.ephem,
+        )
+        reference_result = reference_generator.simulate(
+            input_model=reference_model,
+            **simulation_kwargs
+        )
+        reference_dataset = reference_result.dataset
+        reference_available_sites = [
+            site for site in reference_dataset.stations.names
+            if reference_generator.bands[site] is not None
+            and site not in unready_sites
+        ]
+        return fringe_selection.fpt_fringe_group_mask(
+            _fringe_rows_from_dataset(target_dataset),
+            _fringe_rows_from_dataset(reference_dataset),
+            snr_ref,
+            tint_ref,
+            freq_ref / (self.freq / 1.0e9),
+            target_available_sites=target_available_sites,
+            reference_available_sites=reference_available_sites,
+            target_row_available=target_row_available,
+            reference_row_available=~np.any(reference_dataset.flags, axis=(1, 2)),
+        )
 
     def make_dataset(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
                      leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
@@ -1394,27 +1449,35 @@ class obs_generator(object):
         deleting rows from the internal data model.
         """
 
+        input_model = self._resolve_input_model(input_model, "make_dataset")
+        simulation_kwargs = {
+            "addnoise": addnoise,
+            "addgains": addgains,
+            "gainamp": gainamp,
+            "leakamp": leakamp,
+            "opacitycal": opacitycal,
+            "addFR": addFR,
+            "addleakage": addleakage,
+            "flagwind": flagwind,
+            "flagday": flagday,
+            "flagsun": flagsun,
+            "allow_mixed_basis": allow_mixed_basis,
+            "el_min": el_min,
+            "el_max": el_max,
+            "p": p,
+        }
         result = self.simulate(
             input_model=input_model,
-            addnoise=addnoise,
-            addgains=addgains,
-            gainamp=gainamp,
-            leakamp=leakamp,
-            opacitycal=opacitycal,
-            addFR=addFR,
-            addleakage=addleakage,
-            flagwind=flagwind,
-            flagday=flagday,
-            flagsun=flagsun,
-            allow_mixed_basis=allow_mixed_basis,
-            el_min=el_min,
-            el_max=el_max,
-            p=p,
+            **simulation_kwargs
         )
         if not result.dataset.row_count:
             return result
 
-        mask = self._native_selection_mask(result.dataset)
+        mask = self._native_selection_mask(
+            result.dataset,
+            input_model=input_model,
+            simulation_kwargs=simulation_kwargs,
+        )
         flags = np.array(result.dataset.flags, copy=True)
         flags[~mask] = True
         if self.verbosity > 0:
@@ -2100,16 +2163,13 @@ def fringegroups(obsgen, obs, snr_ref, tint_ref):
     )
 
 
-def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
-    """Apply the fringe-group proxy directly to a native circular dataset."""
+def _fringe_rows_from_dataset(dataset):
+    """Extract circular parallel-hand fringe-selection inputs from a native dataset."""
 
     if dataset.channel_count != 1:
-        raise ValueError("Native fringe groups require exactly one spectral channel.")
-    if dataset.row_count == 0:
-        return np.zeros(0, dtype=bool)
-
+        raise ValueError("Native fringe selection requires exactly one spectral channel.")
     names = np.asarray(dataset.stations.names)
-    rows = fringe_selection.FringeRows(
+    return fringe_selection.FringeRows(
         time=dataset.time_mjd,
         station1=names[dataset.antenna1],
         station2=names[dataset.antenna2],
@@ -2119,6 +2179,15 @@ def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
         rr_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 0]),
         ll_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 1]),
     )
+
+
+def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
+    """Apply the fringe-group proxy directly to a native circular dataset."""
+
+    if dataset.row_count == 0:
+        return np.zeros(0, dtype=bool)
+
+    rows = _fringe_rows_from_dataset(dataset)
     available_sites = [site for site in obsgen.sites if obsgen.bands[site] is not None]
     return fringe_selection.fringe_group_mask(
         rows,
@@ -2128,8 +2197,58 @@ def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
     )
 
 
+def _fpt_reference_generator(obsgen, snr_ref, tint_ref, freq_ref, model_ref,
+                             target_model=None, ephem='ephemeris/space'):
+    """Create the isolated native/legacy reference generator used by FPT."""
+
+    if target_model is None:
+        target_model = obsgen.im
+
+    new_settings = copy.copy(obsgen.settings)
+    new_settings['frequency'] = freq_ref
+    new_settings['bandwidth'] = obsgen.settings['bandwidth']
+    new_settings['fringe_finder'] = ['fringegroups', [snr_ref, tint_ref]]
+    new_settings['random_seed'] = obsgen.seed
+    if isinstance(model_ref, str):
+        new_settings['model_file'] = model_ref
+    else:
+        new_settings['model_file'] = None
+    if ((obsgen.weather == 'random') | (obsgen.weather == 'exact')):
+        new_settings['weather'] = 'exact'
+        new_settings['weather_year'] = str(obsgen.weather_year)
+        new_settings['weather_day'] = str(obsgen.weather_day)
+
+    obsgen_ref = obs_generator(
+        new_settings,
+        D_overrides=copy.deepcopy(obsgen.D_overrides),
+        receiver_configuration_overrides=copy.deepcopy(obsgen.receiver_configuration_overrides),
+        surf_rms_overrides=copy.deepcopy(obsgen.surf_rms_overrides),
+        bandwidth_overrides=copy.deepcopy(obsgen.bandwidth_overrides),
+        T_R_overrides=copy.deepcopy(obsgen.T_R_overrides),
+        sideband_ratio_overrides=copy.deepcopy(obsgen.sideband_ratio_overrides),
+        lo_freq_overrides=copy.deepcopy(obsgen.lo_freq_overrides),
+        hi_freq_overrides=copy.deepcopy(obsgen.hi_freq_overrides),
+        ap_eff_overrides=copy.deepcopy(obsgen.ap_eff_overrides),
+        wind_loading_overrides=copy.deepcopy(obsgen.wind_loading_overrides),
+        custom_receivers=copy.deepcopy(obsgen.custom_receivers),
+        station_uptimes=copy.deepcopy(obsgen.station_uptimes),
+        array=getattr(obsgen, 'array', None),
+        ephem=ephem,
+        weather_store=obsgen.weather_store,
+        weather_cadence=obsgen.weather_cadence,
+    )
+    if model_ref is None:
+        reference_model = target_model
+    elif isinstance(model_ref, str):
+        reference_model = obsgen_ref.im
+    else:
+        reference_model = model_ref
+    obsgen_ref.im = reference_model
+    return obsgen_ref, reference_model
+
+
 def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemeris/space',
-        unready_sites=(), **kwargs):
+        unready_sites=(), target_model=None, **kwargs):
     """
     Function to apply the frequency phase transfer ("FPT") SNR thresholding scheme to an observation.
     This scheme attempts to mimic the fringe-finding consequences of phase
@@ -2142,62 +2261,26 @@ def FPT(obsgen, obs, snr_ref, tint_ref, freq_ref, model_ref=None, ephem='ephemer
       snr_ref (float): strong baseline SNR threshold
       tint_ref (float): strong baseline coherence time, in seconds
       freq_ref(float): FPT reference frequency, in GHz
-      model_ref (str): path to FPT reference model, or the reference model itself
+      model_ref (str): path to FPT reference model, the reference model itself,
+                       or None to reuse the target model
 
     Returns:
       (numpy.ndarray): An array of kept data indices
     """
 
-    # frequency ratio
-    freq_rat = (freq_ref/(obsgen.freq/(1.0e9)))
-
-    # determine settings for dummy obsgen object
-    new_settings = copy.deepcopy(obsgen.settings)
-    new_settings['frequency'] = freq_ref
-    new_settings['bandwidth'] = obsgen.settings['bandwidth']
-    new_settings['fringe_finder'] = ['fringegroups', [snr_ref, tint_ref]]
-    new_settings['random_seed'] = obsgen.seed
-    if ((model_ref is None) | isinstance(model_ref, str)):
-        new_settings['model_file'] = model_ref
-    if ((obsgen.weather == 'random') | (obsgen.weather == 'exact')):
-        new_settings['weather'] = 'exact'
-        new_settings['weather_year'] = str(obsgen.weather_year)
-        new_settings['weather_day'] = str(obsgen.weather_day)
-    new_D_overrides = copy.deepcopy(obsgen.D_overrides)
-    new_surf_rms_overrides = copy.deepcopy(obsgen.surf_rms_overrides)
-    new_receiver_configuration_overrides = copy.deepcopy(obsgen.receiver_configuration_overrides)
-    new_bandwidth_overrides = copy.deepcopy(obsgen.bandwidth_overrides)
-    new_T_R_overrides = copy.deepcopy(obsgen.T_R_overrides)
-    new_sideband_ratio_overrides = copy.deepcopy(obsgen.sideband_ratio_overrides)
-    new_lo_freq_overrides = copy.deepcopy(obsgen.lo_freq_overrides)
-    new_hi_freq_overrides = copy.deepcopy(obsgen.hi_freq_overrides)
-    new_ap_eff_overrides = copy.deepcopy(obsgen.ap_eff_overrides)
-    new_wind_loading_overrides = copy.deepcopy(obsgen.wind_loading_overrides)
-    new_custom_receivers = copy.deepcopy(obsgen.custom_receivers)
-    new_station_uptimes = copy.deepcopy(obsgen.station_uptimes)
-
-    # create dummy obsgen object
-    obsgen_ref = obs_generator(new_settings,
-                               D_overrides=new_D_overrides,
-                               receiver_configuration_overrides=new_receiver_configuration_overrides,
-                               surf_rms_overrides=new_surf_rms_overrides,
-                               bandwidth_overrides=new_bandwidth_overrides,
-                               T_R_overrides=new_T_R_overrides,
-                               sideband_ratio_overrides=new_sideband_ratio_overrides,
-                               lo_freq_overrides=new_lo_freq_overrides,
-                               hi_freq_overrides=new_hi_freq_overrides,
-                               ap_eff_overrides=new_ap_eff_overrides,
-                               wind_loading_overrides=new_wind_loading_overrides,
-                               custom_receivers=new_custom_receivers,
-                               station_uptimes=new_station_uptimes,
-                               ephem=ephem,
-                               weather_store=obsgen.weather_store,
-                               weather_cadence=obsgen.weather_cadence)
-    if ((model_ref is not None) & (not isinstance(model_ref, str))):
-        obsgen_ref.im = model_ref
+    freq_rat = freq_ref / (obsgen.freq / 1.0e9)
+    obsgen_ref, reference_model = _fpt_reference_generator(
+        obsgen,
+        snr_ref,
+        tint_ref,
+        freq_ref,
+        model_ref,
+        target_model,
+        ephem=ephem,
+    )
 
     # generate observation at reference frequency
-    obs_ref = obsgen_ref.observe_legacy(obsgen_ref.im, **kwargs)
+    obs_ref = obsgen_ref.observe_legacy(reference_model, **kwargs)
 
     target_rows = _fringe_rows_from_obsdata(obs)
     reference_rows = _fringe_rows_from_obsdata(obs_ref)

--- a/tests/test_fringe_selection.py
+++ b/tests/test_fringe_selection.py
@@ -222,6 +222,37 @@ def test_fpt_respects_target_and_reference_station_availability_independently():
     assert np.array_equal(reference_unavailable, [False])
 
 
+def test_fpt_excludes_flagged_rows_from_target_and_reference_graphs():
+    target = rows(
+        [("A", "B"), ("B", "C"), ("A", "C")],
+        [0.1, 0.1, 0.1],
+    )
+    reference = rows(
+        [("A", "B"), ("B", "C")],
+        [20.0, 20.0],
+    )
+
+    reference_flagged = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+        reference_row_available=[True, False],
+    )
+    target_flagged = fpt_fringe_group_mask(
+        target,
+        reference,
+        reference_snr_threshold=20.0,
+        tint_reference_s=10.0,
+        reference_to_target_ratio=0.25,
+        target_row_available=[True, False, True],
+    )
+
+    assert np.array_equal(reference_flagged, [True, False, False])
+    assert np.array_equal(target_flagged, [True, False, True])
+
+
 def test_fpt_can_select_a_native_target_baseline_without_reference_rows():
     target = rows([("A", "B")], [5.0])
     reference = rows([], [])

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -529,6 +529,70 @@ def test_native_simulate_does_not_construct_obsdata(monkeypatch, source_factory)
     assert isinstance(result.dataset, VisibilityDataset)
 
 
+@pytest.mark.parametrize(
+    "source_factory",
+    (
+        lambda: _polarized_model().make_image(160.0 * eh.RADPERUAS, 64),
+        _polarized_model,
+        _polarized_movie,
+    ),
+)
+def test_native_fpt_selection_stays_native_and_uses_one_readiness_draw(monkeypatch, source_factory):
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["fpt", [0.0, 10.0, 86.0, None]]
+    readiness_calls = []
+
+    def unready_sites(sites, tech_readiness, rng):
+        readiness_calls.append((tuple(sites), tech_readiness))
+        return np.array(["ALMA"])
+
+    def unexpected_obsdata_conversion(*args, **kwargs):
+        raise AssertionError("Native FPT selection must not construct an ehtim Obsdata object.")
+
+    monkeypatch.setattr(og, "get_unready_sites", unready_sites)
+    monkeypatch.setattr(VisibilityDataset, "to_ehtim_obsdata", unexpected_obsdata_conversion)
+    source = source_factory()
+    original = (source.ra, source.dec, source.mjd, source.source, source.rf)
+    result = og.obs_generator(settings=settings).make_dataset(
+        source,
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    names = np.asarray(result.dataset.stations.names)
+    touches_alma = (
+        (names[result.dataset.antenna1] == "ALMA")
+        | (names[result.dataset.antenna2] == "ALMA")
+    )
+    assert isinstance(result.dataset, VisibilityDataset)
+    assert len(readiness_calls) == 1
+    assert np.all(result.dataset.flags[touches_alma])
+    assert (source.ra, source.dec, source.mjd, source.source, source.rf) == original
+
+
+def test_native_fpt_make_obs_exports_only_after_selection():
+    settings = dict(COMPACT_OBS_SETTINGS)
+    settings["fringe_finder"] = ["fpt", [0.0, 10.0, 86.0, None]]
+
+    obs = og.obs_generator(settings=settings).make_obs(
+        _compact_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert len(obs.data) > 0
+
+
 def test_native_simulation_keeps_terms_in_the_result_not_the_generator():
     settings = dict(COMPACT_OBS_SETTINGS)
     settings["fringe_finder"] = ["naive", 0.0]


### PR DESCRIPTION
Implements native FPT fringe selection without intermediate Obsdata construction.  Also defines model_ref=None to reuse the target source model and adds FPT graph, readiness, source-adapter, and export-boundary coverage.