### PR TITLE
Add native UVFITS I/O

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,7 +7,7 @@ Individual package documentation organized by area.
    :maxdepth: 3
 
    ./obsgen
+   ./uvfits
    ./metrics
    ./weather
    ./calibration
-   

--- a/docs/source/uvfits.rst
+++ b/docs/source/uvfits.rst
@@ -1,0 +1,23 @@
+Native UVFITS I/O
+=================
+
+The native visibility representation can read and write standard AIPS UVFITS
+random-groups files without constructing an ``ehtim.Obsdata`` object.  This
+supports multiple spectral channels and IF spectral windows for datasets with
+a single global circular or linear correlation basis.
+
+.. code-block:: python
+
+   from ngehtsim.obs.uvfits import read_uvfits, write_uvfits
+
+   dataset = read_uvfits("observation.uvfits")
+   write_uvfits(dataset, "round_trip.uvfits")
+
+The same adapters are available on ``VisibilityDataset`` as
+``from_uvfits()`` and ``to_uvfits()``.  UVFITS has one global STOKES axis and
+cannot losslessly store arbitrary per-baseline mixed-feed layouts.  Such
+datasets remain native ``VisibilityDataset`` objects until an explicit output
+basis conversion is selected.
+
+.. automodule:: ngehtsim.obs.uvfits
+   :members:

--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -9,6 +9,22 @@ __all__ = [
     'obs_generator',
     'obs_plotter',
     'simulation_result',
+    'uvfits',
     'visibility_dataset',
 ]
-from . import *
+
+
+def __getattr__(name):
+    """Import observation submodules only when they are requested."""
+
+    if name in __all__:
+        import importlib
+
+        module = importlib.import_module("{0}.{1}".format(__name__, name))
+        globals()[name] = module
+        return module
+    raise AttributeError("module {0!r} has no attribute {1!r}".format(__name__, name))
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/ngehtsim/obs/uvfits.py
+++ b/ngehtsim/obs/uvfits.py
@@ -1,0 +1,621 @@
+"""Native AIPS UVFITS adapters for :class:`VisibilityDataset`.
+
+The UVFITS random-groups format has one global polarization axis.  It can
+therefore represent a uniformly circular or uniformly linear dataset, but not
+arbitrary per-baseline mixed-feed correlation layouts.  Mixed data remains
+lossless in ``VisibilityDataset`` and is rejected here rather than silently
+rewritten into an incorrect polarization basis.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from astropy.constants import c as SPEED_OF_LIGHT
+from astropy.io import fits
+from astropy.time import Time
+
+from ngehtsim.obs.visibility_dataset import (
+    CIRCULAR_CORRELATIONS,
+    LINEAR_CORRELATIONS,
+    StationTable,
+    VisibilityDataset,
+)
+
+
+_LIGHT_SPEED_M_S = SPEED_OF_LIGHT.to_value("m / s")
+_POLARIZATION_PRODUCTS = {
+    -1: "RR",
+    -2: "LL",
+    -3: "RL",
+    -4: "LR",
+    -5: "XX",
+    -6: "YY",
+    -7: "XY",
+    -8: "YX",
+}
+
+
+class UvfitsError(ValueError):
+    """Raised when a UVFITS file cannot be represented by ``VisibilityDataset``."""
+
+
+def read_uvfits(path):
+    """Read a standard random-groups UVFITS file without using ``ehtim``.
+
+    Circular and linear datasets with a global STOKES axis are supported.  IF
+    and frequency axes are flattened into ``VisibilityDataset``'s channel
+    axis, preserving an integer spectral-window ID for each IF.
+    """
+
+    path = Path(path)
+    with fits.open(path, memmap=False) as hdul:
+        primary = hdul[0]
+        if not isinstance(primary, fits.GroupsHDU):
+            raise UvfitsError("UVFITS input must use a random-groups primary HDU.")
+        if primary.data is None:
+            raise UvfitsError("UVFITS input contains no visibility groups.")
+
+        axes = _regular_axes(primary.header)
+        data, frequencies, channel_bandwidths, spectral_window_id, layout = _read_data(
+            primary.data,
+            primary.header,
+            axes,
+            hdul,
+        )
+        station_table, station_index = _read_station_table(hdul)
+        time_mjd = _group_parameter(primary.data, "DATE") - 2400000.5
+        integration_time_s = _group_parameter(primary.data, "INTTIM")
+        if np.any(~np.isfinite(integration_time_s)) or np.any(integration_time_s <= 0.0):
+            raise UvfitsError("UVFITS INTTIM values must be finite and positive.")
+
+        baseline = _group_parameter(primary.data, "BASELINE")
+        antenna1, antenna2 = _decode_baselines(baseline, station_index)
+        uvw_m = np.column_stack((
+            _group_parameter(primary.data, "UU---SIN"),
+            _group_parameter(primary.data, "VV---SIN"),
+            _optional_group_parameter(primary.data, "WW---SIN", 0.0),
+        )) * _LIGHT_SPEED_M_S
+        tau1 = _optional_group_parameter(primary.data, "TAU1", 0.0)
+        tau2 = _optional_group_parameter(primary.data, "TAU2", 0.0)
+
+        scan_start_mjd, scan_stop_mjd = _read_scans(hdul, time_mjd)
+        header = primary.header
+        try:
+            ra_hours = float(header["OBSRA"]) / 15.0
+            dec_degrees = float(header["OBSDEC"])
+        except KeyError as exc:
+            raise UvfitsError("UVFITS input requires OBSRA and OBSDEC metadata.") from exc
+
+        return VisibilityDataset(
+            stations=station_table,
+            time_mjd=time_mjd,
+            integration_time_s=integration_time_s,
+            antenna1=antenna1,
+            antenna2=antenna2,
+            uvw_m=uvw_m,
+            tau1=tau1,
+            tau2=tau2,
+            channel_frequency_hz=frequencies,
+            channel_bandwidth_hz=channel_bandwidths,
+            spectral_window_id=spectral_window_id,
+            correlation_layouts=(layout,),
+            row_layout_id=np.zeros(len(time_mjd), dtype=np.intp),
+            visibilities=data["visibilities"],
+            weights=data["weights"],
+            flags=data["flags"],
+            source=str(header.get("OBJECT", "UNKNOWN")).strip(),
+            ra_hours=ra_hours,
+            dec_degrees=dec_degrees,
+            ampcal=True,
+            phasecal=True,
+            opacitycal=True,
+            dcal=True,
+            frcal=True,
+            scan_start_mjd=scan_start_mjd,
+            scan_stop_mjd=scan_stop_mjd,
+        )
+
+
+def write_uvfits(dataset, path, overwrite=False):
+    """Write a uniformly circular or linear ``VisibilityDataset`` as UVFITS.
+
+    The output uses a standard global STOKES axis, a regular frequency axis,
+    and optional IF spectral windows.  Rows are time-sorted so an AIPS NX scan
+    table can describe native scan metadata correctly.
+    """
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if not dataset.row_count:
+        raise UvfitsError("UVFITS output requires at least one visibility row.")
+
+    layout = _uvfits_layout(dataset)
+    frequency_grid = _frequency_grid(dataset)
+    row_order = np.lexsort((dataset.antenna2, dataset.antenna1, dataset.time_mjd))
+    primary = _primary_hdu(dataset, layout, frequency_grid, row_order)
+    antenna = _antenna_hdu(
+        dataset,
+        layout,
+        frequency_grid["reference_frequency_hz"],
+        len(frequency_grid["channel_indices"]),
+    )
+    frequency = _frequency_hdu(frequency_grid)
+    hdus = [primary, antenna, frequency]
+    scan = _scan_hdu(dataset, row_order)
+    if scan is not None:
+        hdus.append(scan)
+    fits.HDUList(hdus).writeto(Path(path), overwrite=overwrite)
+
+
+def _read_data(group_data, header, axes, hdul):
+    values, if_count, frequency_count, polarization_codes = _visibility_values(
+        group_data,
+        header,
+        axes,
+    )
+    layout = _layout_from_stokes_codes(polarization_codes)
+    channels, channel_bandwidths, spectral_window_id = _channel_metadata(
+        header,
+        axes,
+        hdul,
+        if_count,
+        frequency_count,
+    )
+
+    row_count = values.shape[0]
+    channel_count = if_count * frequency_count
+    visibilities = np.zeros((row_count, channel_count, 4), dtype=complex)
+    weights = np.zeros((row_count, channel_count, 4), dtype=float)
+    flags = np.ones((row_count, channel_count, 4), dtype=bool)
+    real = values[..., 0].reshape(row_count, channel_count, len(polarization_codes))
+    imaginary = values[..., 1].reshape(row_count, channel_count, len(polarization_codes))
+    if values.shape[-1] == 3:
+        raw_weights = values[..., 2].reshape(
+            row_count,
+            channel_count,
+            len(polarization_codes),
+        )
+    else:
+        raw_weights = np.ones_like(real)
+
+    for source_index, product in enumerate(
+        _POLARIZATION_PRODUCTS[int(code)] for code in polarization_codes
+    ):
+        destination_index = layout.index(product)
+        valid = (
+            np.isfinite(real[..., source_index])
+            & np.isfinite(imaginary[..., source_index])
+            & np.isfinite(raw_weights[..., source_index])
+            & (raw_weights[..., source_index] > 0.0)
+        )
+        visibilities[..., destination_index] = np.where(
+            valid,
+            real[..., source_index] + 1.0j * imaginary[..., source_index],
+            0.0,
+        )
+        weights[..., destination_index] = np.where(
+            valid,
+            raw_weights[..., source_index],
+            0.0,
+        )
+        flags[..., destination_index] = ~valid
+
+    return {
+        "visibilities": visibilities,
+        "weights": weights,
+        "flags": flags,
+    }, channels, channel_bandwidths, spectral_window_id, layout
+
+
+def _regular_axes(header):
+    axes = {}
+    for number in range(2, int(header["NAXIS"]) + 1):
+        name = str(header.get("CTYPE{0}".format(number), "")).strip().upper()
+        if name:
+            axes[name] = number
+    for required in ("COMPLEX", "STOKES", "FREQ"):
+        if required not in axes:
+            raise UvfitsError("UVFITS input is missing the {0} axis.".format(required))
+    return axes
+
+
+def _visibility_values(group_data, header, axes):
+    raw = np.asarray(group_data.data)
+    source_axes = []
+    destination_axes = []
+    if "IF" in axes:
+        source_axes.append(_numpy_axis(header, axes["IF"]))
+        destination_axes.append(1)
+    source_axes.extend((
+        _numpy_axis(header, axes["FREQ"]),
+        _numpy_axis(header, axes["STOKES"]),
+        _numpy_axis(header, axes["COMPLEX"]),
+    ))
+    if "IF" in axes:
+        destination_axes.extend((2, 3, 4))
+    else:
+        destination_axes.extend((1, 2, 3))
+    values = np.moveaxis(raw, source_axes, destination_axes)
+    expected_dimensions = 5 if "IF" in axes else 4
+    if any(size != 1 for size in values.shape[expected_dimensions:]):
+        raise UvfitsError("UVFITS input has unsupported non-singleton regular axes.")
+    values = values.reshape(values.shape[:expected_dimensions])
+    if "IF" not in axes:
+        values = values[:, np.newaxis, ...]
+    if values.shape[-1] not in (2, 3):
+        raise UvfitsError("UVFITS COMPLEX axis must contain real, imaginary, and optional weight values.")
+
+    stokes = _axis_values(header, axes["STOKES"])
+    if not np.allclose(stokes, np.rint(stokes)):
+        raise UvfitsError("UVFITS STOKES coordinates must be integral polarization codes.")
+    polarization_codes = np.rint(stokes).astype(int)
+    return values, values.shape[1], values.shape[2], polarization_codes
+
+
+def _channel_metadata(header, axes, hdul, if_count, frequency_count):
+    frequency_axis = _axis_values(header, axes["FREQ"])
+    if len(frequency_axis) != frequency_count:
+        raise UvfitsError("UVFITS frequency axis is inconsistent with visibility data.")
+    frequency_step = _channel_step(frequency_axis, "UVFITS frequency axis")
+    if "AIPS FQ" in hdul:
+        fq_data = hdul["AIPS FQ"].data
+        if len(fq_data) != 1:
+            raise UvfitsError("UVFITS reader currently requires exactly one AIPS FQ row.")
+        offsets = _table_vector(fq_data["IF FREQ"][0], if_count, "IF FREQ")
+        widths = np.abs(_table_vector(fq_data["CH WIDTH"][0], if_count, "CH WIDTH"))
+    else:
+        offsets = np.zeros(if_count)
+        widths = np.full(if_count, abs(frequency_step))
+    if np.any(widths <= 0.0):
+        widths = np.full(if_count, abs(frequency_step))
+    if np.any(widths <= 0.0):
+        raise UvfitsError("UVFITS channel widths must be positive.")
+
+    channels = (offsets[:, np.newaxis] + frequency_axis[np.newaxis, :]).reshape(-1)
+    channel_bandwidths = np.repeat(widths, frequency_count)
+    spectral_window_id = np.repeat(np.arange(if_count, dtype=np.intp), frequency_count)
+    return channels, channel_bandwidths, spectral_window_id
+
+
+def _layout_from_stokes_codes(codes):
+    if not len(codes) or any(int(code) not in _POLARIZATION_PRODUCTS for code in codes):
+        raise UvfitsError("UVFITS STOKES axis must describe correlation products, not Stokes values.")
+    products = {_POLARIZATION_PRODUCTS[int(code)] for code in codes}
+    if products.issubset(set(CIRCULAR_CORRELATIONS)):
+        return CIRCULAR_CORRELATIONS
+    if products.issubset(set(LINEAR_CORRELATIONS)):
+        return LINEAR_CORRELATIONS
+    raise UvfitsError("UVFITS input mixes circular and linear correlation products.")
+
+
+def _read_station_table(hdul):
+    if "AIPS AN" not in hdul:
+        raise UvfitsError("UVFITS input is missing the AIPS AN antenna table.")
+    table = hdul["AIPS AN"].data
+    required = ("ANNAME", "STABXYZ", "NOSTA")
+    if any(name not in table.names for name in required):
+        raise UvfitsError("AIPS AN table is missing required antenna metadata.")
+    names = tuple(str(name).strip() for name in table["ANNAME"])
+    numbers = np.asarray(table["NOSTA"], dtype=int)
+    if len(set(numbers)) != len(numbers):
+        raise UvfitsError("AIPS AN antenna numbers must be unique.")
+    sefd = np.asarray(table["SEFD"], dtype=float) if "SEFD" in table.names else np.zeros(len(names))
+    sefd = np.where(np.isfinite(sefd) & (sefd >= 0.0), sefd, 0.0)
+    station_table = StationTable(
+        names=names,
+        position_itrs_m=np.asarray(table["STABXYZ"], dtype=float),
+        sefd_r_jy=sefd,
+        sefd_l_jy=sefd,
+        leakage_r=np.zeros(len(names), dtype=complex),
+        leakage_l=np.zeros(len(names), dtype=complex),
+        feed_rotation_par=np.zeros(len(names)),
+        feed_rotation_elev=np.zeros(len(names)),
+        feed_rotation_offset_deg=np.zeros(len(names)),
+    )
+    return station_table, {number: index for index, number in enumerate(numbers)}
+
+
+def _decode_baselines(values, station_index):
+    codes = np.rint(np.asarray(values, dtype=float)).astype(int)
+    antenna1_number = codes // 256
+    antenna2_number = codes % 256
+    if np.any(antenna1_number <= 0) or np.any(antenna2_number <= 0):
+        raise UvfitsError("UVFITS extended baseline codes are not yet supported.")
+    try:
+        antenna1 = np.fromiter(
+            (station_index[number] for number in antenna1_number),
+            dtype=np.intp,
+            count=len(codes),
+        )
+        antenna2 = np.fromiter(
+            (station_index[number] for number in antenna2_number),
+            dtype=np.intp,
+            count=len(codes),
+        )
+    except KeyError as exc:
+        raise UvfitsError("UVFITS BASELINE references an unknown AIPS AN antenna.") from exc
+    return antenna1, antenna2
+
+
+def _read_scans(hdul, time_mjd):
+    if "AIPS NX" not in hdul:
+        return None, None
+    table = hdul["AIPS NX"].data
+    required = ("TIME", "TIME INTERVAL")
+    if any(name not in table.names for name in required):
+        raise UvfitsError("AIPS NX table is missing TIME metadata.")
+    reference_mjd = np.floor(np.min(time_mjd))
+    center = np.asarray(table["TIME"], dtype=float)
+    interval = np.asarray(table["TIME INTERVAL"], dtype=float)
+    if np.any(~np.isfinite(center)) or np.any(~np.isfinite(interval)) or np.any(interval < 0.0):
+        raise UvfitsError("AIPS NX scan metadata must be finite and non-negative.")
+    return (
+        reference_mjd + center - (0.5 * interval),
+        reference_mjd + center + (0.5 * interval),
+    )
+
+
+def _group_parameter(group_data, name):
+    try:
+        values = np.asarray(group_data.par(name), dtype=float)
+    except (KeyError, AttributeError) as exc:
+        raise UvfitsError("UVFITS input is missing the {0} random parameter.".format(name)) from exc
+    if np.any(~np.isfinite(values)):
+        raise UvfitsError("UVFITS {0} random parameters must be finite.".format(name))
+    return values
+
+
+def _optional_group_parameter(group_data, name, default):
+    names = {str(value).strip().upper() for value in group_data.parnames}
+    if name not in names:
+        return np.full(len(group_data), default, dtype=float)
+    return _group_parameter(group_data, name)
+
+
+def _axis_values(header, number):
+    count = int(header["NAXIS{0}".format(number)])
+    return (
+        float(header["CRVAL{0}".format(number)])
+        + (np.arange(count, dtype=float) + 1.0 - float(header["CRPIX{0}".format(number)]))
+        * float(header["CDELT{0}".format(number)])
+    )
+
+
+def _numpy_axis(header, number):
+    return int(header["NAXIS"]) - number + 1
+
+
+def _channel_step(values, name):
+    values = np.asarray(values, dtype=float)
+    if len(values) == 1:
+        return 0.0
+    step = values[1] - values[0]
+    if step == 0.0 or not np.allclose(np.diff(values), step):
+        raise UvfitsError("{0} must be regularly spaced.".format(name))
+    return step
+
+
+def _table_vector(values, count, name):
+    values = np.asarray(values, dtype=float).reshape(-1)
+    if len(values) != count:
+        raise UvfitsError("AIPS FQ {0} length does not match the IF axis.".format(name))
+    return values
+
+
+def _uvfits_layout(dataset):
+    layout_ids = np.unique(dataset.row_layout_id)
+    if len(layout_ids) != 1:
+        raise UvfitsError("UVFITS output cannot represent per-row mixed correlation layouts.")
+    layout = dataset.correlation_layouts[int(layout_ids[0])]
+    if layout not in (CIRCULAR_CORRELATIONS, LINEAR_CORRELATIONS):
+        raise UvfitsError("UVFITS output requires a uniform circular or linear correlation layout.")
+    return layout
+
+
+def _frequency_grid(dataset):
+    ids = np.unique(dataset.spectral_window_id)
+    if not len(ids):
+        raise UvfitsError("UVFITS output requires at least one spectral window.")
+    channel_indices = []
+    offsets = None
+    steps = []
+    widths = []
+    reference_frequency_hz = None
+    for window_index, window_id in enumerate(ids):
+        indices = np.flatnonzero(dataset.spectral_window_id == window_id)
+        indices = indices[np.argsort(dataset.channel_frequency_hz[indices])]
+        frequencies = dataset.channel_frequency_hz[indices]
+        bandwidths = dataset.channel_bandwidth_hz[indices]
+        if not np.allclose(bandwidths, bandwidths[0]):
+            raise UvfitsError("Each UVFITS spectral window must have a uniform channel bandwidth.")
+        step = _channel_step(frequencies, "VisibilityDataset spectral-window frequencies")
+        if len(frequencies) == 1:
+            step = bandwidths[0]
+        window_offsets = frequencies - frequencies[0]
+        if offsets is None:
+            offsets = window_offsets
+            reference_frequency_hz = frequencies[0]
+        elif len(window_offsets) != len(offsets) or not np.allclose(window_offsets, offsets):
+            raise UvfitsError("UVFITS output requires matching channel grids in every spectral window.")
+        channel_indices.append(indices)
+        steps.append(step)
+        widths.append(bandwidths[0])
+    if not np.allclose(steps, steps[0]):
+        raise UvfitsError("UVFITS output requires a common frequency spacing in every spectral window.")
+    if_offsets = np.array([
+        dataset.channel_frequency_hz[indices[0]] - reference_frequency_hz
+        for indices in channel_indices
+    ])
+    return {
+        "channel_indices": tuple(channel_indices),
+        "reference_frequency_hz": float(reference_frequency_hz),
+        "frequency_step_hz": float(steps[0]),
+        "if_offsets_hz": if_offsets,
+        "channel_widths_hz": np.asarray(widths, dtype=float),
+    }
+
+
+def _primary_hdu(dataset, layout, frequency_grid, row_order):
+    channel_indices = frequency_grid["channel_indices"]
+    if_count = len(channel_indices)
+    frequency_count = len(channel_indices[0])
+    values = np.zeros(
+        (dataset.row_count, 1, 1, if_count, frequency_count, 4, 3),
+        dtype=np.float32,
+    )
+    for if_index, channel_index in enumerate(channel_indices):
+        visibility = dataset.visibilities[row_order][:, channel_index, :]
+        weight = dataset.weights[row_order][:, channel_index, :]
+        valid = ~dataset.flags[row_order][:, channel_index, :]
+        values[:, 0, 0, if_index, :, :, 0] = np.where(valid, visibility.real, 0.0)
+        values[:, 0, 0, if_index, :, :, 1] = np.where(valid, visibility.imag, 0.0)
+        values[:, 0, 0, if_index, :, :, 2] = np.where(valid, weight, -1.0)
+
+    reference_mjd = float(np.floor(np.min(dataset.time_mjd)))
+    date_jd = reference_mjd + 2400000.5
+    baseline = _encode_baselines(dataset.antenna1[row_order], dataset.antenna2[row_order])
+    group_data = fits.GroupData(
+        values,
+        parnames=["UU---SIN", "VV---SIN", "WW---SIN", "BASELINE", "DATE", "DATE", "INTTIM", "TAU1", "TAU2"],
+        pardata=(
+            dataset.uvw_m[row_order, 0] / _LIGHT_SPEED_M_S,
+            dataset.uvw_m[row_order, 1] / _LIGHT_SPEED_M_S,
+            dataset.uvw_m[row_order, 2] / _LIGHT_SPEED_M_S,
+            baseline,
+            np.full(dataset.row_count, date_jd),
+            dataset.time_mjd[row_order] - reference_mjd,
+            dataset.integration_time_s[row_order],
+            dataset.tau1[row_order],
+            dataset.tau2[row_order],
+        ),
+        bitpix=-32,
+    )
+    primary = fits.GroupsHDU(group_data)
+    header = primary.header
+    _set_common_header(header, dataset, layout, frequency_grid, reference_mjd)
+    return primary
+
+
+def _set_common_header(header, dataset, layout, frequency_grid, reference_mjd):
+    stokes_start = -1.0 if layout == CIRCULAR_CORRELATIONS else -5.0
+    header["OBSRA"] = dataset.ra_hours * 15.0
+    header["OBSDEC"] = dataset.dec_degrees
+    header["OBJECT"] = dataset.source
+    header["MJD"] = reference_mjd
+    header["DATE-OBS"] = Time(reference_mjd, format="mjd", scale="utc").iso[:10]
+    header["BUNIT"] = "JY"
+    header["EQUINOX"] = "J2000"
+    header["CTYPE2"] = "COMPLEX"
+    header["CRVAL2"] = 1.0
+    header["CDELT2"] = 1.0
+    header["CRPIX2"] = 1.0
+    header["CTYPE3"] = "STOKES"
+    header["CRVAL3"] = stokes_start
+    header["CDELT3"] = -1.0
+    header["CRPIX3"] = 1.0
+    header["CTYPE4"] = "FREQ"
+    header["CRVAL4"] = frequency_grid["reference_frequency_hz"]
+    header["CDELT4"] = frequency_grid["frequency_step_hz"]
+    header["CRPIX4"] = 1.0
+    header["CTYPE5"] = "IF"
+    header["CRVAL5"] = 1.0
+    header["CDELT5"] = 1.0
+    header["CRPIX5"] = 1.0
+    header["CTYPE6"] = "RA"
+    header["CRVAL6"] = dataset.ra_hours * 15.0
+    header["CDELT6"] = 1.0
+    header["CRPIX6"] = 1.0
+    header["CTYPE7"] = "DEC"
+    header["CRVAL7"] = dataset.dec_degrees
+    header["CDELT7"] = 1.0
+    header["CRPIX7"] = 1.0
+    header["HISTORY"] = "AIPS SORT ORDER='TB'"
+
+
+def _antenna_hdu(dataset, layout, reference_frequency_hz, if_count):
+    if any(len(name.encode("ascii")) > 8 for name in dataset.stations.names):
+        raise UvfitsError("UVFITS AIPS AN output supports station names up to eight ASCII characters.")
+    names = np.asarray(dataset.stations.names, dtype="S8")
+    count = len(names)
+    first_feed, second_feed = ("R", "L") if layout == CIRCULAR_CORRELATIONS else ("X", "Y")
+    columns = fits.ColDefs((
+        fits.Column(name="ANNAME", format="8A", array=names),
+        fits.Column(name="STABXYZ", format="3D", unit="METERS", array=dataset.stations.position_itrs_m),
+        fits.Column(name="NOSTA", format="1J", array=np.arange(1, count + 1)),
+        fits.Column(name="MNTSTA", format="1J", array=np.zeros(count, dtype=np.int32)),
+        fits.Column(name="STAXOF", format="1E", unit="METERS", array=np.zeros(count)),
+        fits.Column(name="POLTYA", format="1A", array=np.full(count, first_feed, dtype="S1")),
+        fits.Column(name="POLAA", format="1E", unit="DEGREES", array=np.zeros(count)),
+        fits.Column(name="POLCALA", format="3E", array=np.zeros((count, 3))),
+        fits.Column(name="POLTYB", format="1A", array=np.full(count, second_feed, dtype="S1")),
+        fits.Column(name="POLAB", format="1E", unit="DEGREES", array=np.full(count, 90.0)),
+        fits.Column(name="POLCALB", format="3E", array=np.zeros((count, 3))),
+        fits.Column(name="SEFD", format="1D", array=dataset.stations.sefd_r_jy),
+    ))
+    antenna = fits.BinTableHDU.from_columns(columns, name="AIPS AN")
+    header = antenna.header
+    header["EXTVER"] = 1
+    header["FREQ"] = reference_frequency_hz
+    header["NO_IF"] = if_count
+    header["TIMESYS"] = "UTC"
+    header["POLTYPE"] = "VLBI"
+    return antenna
+
+
+def _frequency_hdu(frequency_grid):
+    count = len(frequency_grid["if_offsets_hz"])
+    columns = fits.ColDefs((
+        fits.Column(name="FRQSEL", format="1J", array=np.array([1], dtype=np.int32)),
+        fits.Column(name="IF FREQ", format="{0}D".format(count), array=np.array([frequency_grid["if_offsets_hz"]])),
+        fits.Column(name="CH WIDTH", format="{0}E".format(count), array=np.array([frequency_grid["channel_widths_hz"]], dtype=np.float32)),
+        fits.Column(name="TOTAL BANDWIDTH", format="{0}E".format(count), array=np.array([frequency_grid["channel_widths_hz"] * len(frequency_grid["channel_indices"][0])], dtype=np.float32)),
+        fits.Column(name="SIDEBAND", format="{0}J".format(count), array=np.ones((1, count), dtype=np.int32)),
+    ))
+    frequency = fits.BinTableHDU.from_columns(columns, name="AIPS FQ")
+    frequency.header["EXTVER"] = 1
+    frequency.header["NO_IF"] = count
+    return frequency
+
+
+def _scan_hdu(dataset, row_order):
+    if dataset.scan_start_mjd is None:
+        return None
+    ordered_time = dataset.time_mjd[row_order]
+    reference_mjd = float(np.floor(np.min(ordered_time)))
+    starts = dataset.scan_start_mjd
+    stops = dataset.scan_stop_mjd
+    center = 0.5 * (starts + stops) - reference_mjd
+    interval = stops - starts
+    start_vis = np.empty(len(starts), dtype=np.int32)
+    stop_vis = np.empty(len(starts), dtype=np.int32)
+    tolerance = 1.0e-10
+    for index, (start, stop) in enumerate(zip(starts, stops)):
+        rows = np.flatnonzero(
+            (ordered_time >= start - tolerance) & (ordered_time <= stop + tolerance)
+        )
+        if not len(rows):
+            raise UvfitsError("Every native scan must contain at least one output visibility row.")
+        start_vis[index] = rows[0] + 1
+        stop_vis[index] = rows[-1] + 1
+    columns = fits.ColDefs((
+        fits.Column(name="TIME", format="1D", unit="DAYS", array=center),
+        fits.Column(name="TIME INTERVAL", format="1E", unit="DAYS", array=interval),
+        fits.Column(name="SOURCE ID", format="1J", array=np.ones(len(starts), dtype=np.int32)),
+        fits.Column(name="SUBARRAY", format="1J", array=np.ones(len(starts), dtype=np.int32)),
+        fits.Column(name="FREQ ID", format="1J", array=np.ones(len(starts), dtype=np.int32)),
+        fits.Column(name="START VIS", format="1J", array=start_vis),
+        fits.Column(name="END VIS", format="1J", array=stop_vis),
+    ))
+    scan = fits.BinTableHDU.from_columns(columns, name="AIPS NX")
+    scan.header["EXTVER"] = 1
+    return scan
+
+
+def _encode_baselines(antenna1, antenna2):
+    antenna1 = np.asarray(antenna1, dtype=int) + 1
+    antenna2 = np.asarray(antenna2, dtype=int) + 1
+    if np.any(antenna1 > 255) or np.any(antenna2 > 255):
+        raise UvfitsError("UVFITS extended baseline codes are not yet supported.")
+    return (256 * antenna1) + antenna2

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -458,6 +458,21 @@ class VisibilityDataset:
             frcal=self.frcal,
         )
 
+    @classmethod
+    def from_uvfits(cls, path):
+        """Read a native multi-channel UVFITS dataset without using ``ehtim``."""
+
+        from ngehtsim.obs.uvfits import read_uvfits
+
+        return read_uvfits(path)
+
+    def to_uvfits(self, path, overwrite=False):
+        """Write this dataset through the native UVFITS adapter."""
+
+        from ngehtsim.obs.uvfits import write_uvfits
+
+        return write_uvfits(self, path, overwrite=overwrite)
+
 
 def _validate_scans(scan_start_mjd, scan_stop_mjd):
     if scan_start_mjd is None and scan_stop_mjd is None:

--- a/tests/test_uvfits.py
+++ b/tests/test_uvfits.py
@@ -1,0 +1,167 @@
+"""Tests for native multi-channel UVFITS interchange."""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from ngehtsim.obs.uvfits import UvfitsError, read_uvfits, write_uvfits
+from ngehtsim.obs.visibility_dataset import (
+    CIRCULAR_CORRELATIONS,
+    LINEAR_CIRCULAR_CORRELATIONS,
+    LINEAR_CORRELATIONS,
+    StationTable,
+    VisibilityDataset,
+)
+
+
+def _stations():
+    return StationTable(
+        names=("ALMA", "APEX", "LMT"),
+        position_itrs_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0))),
+        sefd_r_jy=np.array((100.0, 110.0, 120.0)),
+        sefd_l_jy=np.array((101.0, 111.0, 121.0)),
+        leakage_r=np.zeros(3, dtype=complex),
+        leakage_l=np.zeros(3, dtype=complex),
+        feed_rotation_par=np.zeros(3),
+        feed_rotation_elev=np.zeros(3),
+        feed_rotation_offset_deg=np.zeros(3),
+    )
+
+
+def _dataset(layout=CIRCULAR_CORRELATIONS):
+    visibilities = np.arange(32, dtype=float).reshape(2, 4, 4)
+    visibilities = visibilities + 1.0j * (100.0 + visibilities)
+    weights = np.full((2, 4, 4), 4.0)
+    flags = np.zeros((2, 4, 4), dtype=bool)
+    flags[1, 3, 2] = True
+    weights[1, 3, 2] = 0.0
+    visibilities[1, 3, 2] = 0.0
+    return VisibilityDataset(
+        stations=_stations(),
+        time_mjd=np.array((60000.0, 60000.01)),
+        integration_time_s=np.array((10.0, 20.0)),
+        antenna1=np.array((0, 1)),
+        antenna2=np.array((1, 2)),
+        uvw_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))),
+        tau1=np.array((0.1, 0.2)),
+        tau2=np.array((0.3, 0.4)),
+        channel_frequency_hz=np.array((230.0e9, 230.001e9, 231.0e9, 231.001e9)),
+        channel_bandwidth_hz=np.full(4, 1.0e6),
+        spectral_window_id=np.array((0, 0, 1, 1)),
+        correlation_layouts=(layout,),
+        row_layout_id=np.zeros(2, dtype=np.intp),
+        visibilities=visibilities,
+        weights=weights,
+        flags=flags,
+        source="M87",
+        ra_hours=12.5,
+        dec_degrees=12.4,
+        scan_start_mjd=np.array((59999.999, 60000.009)),
+        scan_stop_mjd=np.array((60000.001, 60000.011)),
+    )
+
+
+@pytest.mark.parametrize("layout", (CIRCULAR_CORRELATIONS, LINEAR_CORRELATIONS))
+def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, layout):
+    original = _dataset(layout)
+    path = tmp_path / "native.uvfits"
+
+    original.to_uvfits(path)
+    with fits.open(path, memmap=False) as hdul:
+        assert hdul[0].header["NAXIS4"] == 2
+        assert hdul[0].header["NAXIS5"] == 2
+        assert hdul[0].header["CRVAL3"] == (-1.0 if layout == CIRCULAR_CORRELATIONS else -5.0)
+        assert [hdu.name for hdu in hdul] == ["PRIMARY", "AIPS AN", "AIPS FQ", "AIPS NX"]
+        expected_feeds = ("R", "L") if layout == CIRCULAR_CORRELATIONS else ("X", "Y")
+        assert tuple(hdul["AIPS AN"].data["POLTYA"][:1]) == (expected_feeds[0],)
+        assert tuple(hdul["AIPS AN"].data["POLTYB"][:1]) == (expected_feeds[1],)
+        assert np.allclose(hdul["AIPS FQ"].data["TOTAL BANDWIDTH"][0], [2.0e6, 2.0e6])
+
+    restored = VisibilityDataset.from_uvfits(path)
+
+    assert restored.correlation_layouts == (layout,)
+    assert np.allclose(restored.time_mjd, original.time_mjd)
+    assert np.array_equal(restored.antenna1, original.antenna1)
+    assert np.array_equal(restored.antenna2, original.antenna2)
+    assert np.allclose(restored.uvw_m, original.uvw_m)
+    assert np.allclose(restored.channel_frequency_hz, original.channel_frequency_hz)
+    assert np.allclose(restored.channel_bandwidth_hz, original.channel_bandwidth_hz)
+    assert np.array_equal(restored.spectral_window_id, original.spectral_window_id)
+    assert np.array_equal(restored.flags, original.flags)
+    assert np.allclose(restored.weights, original.weights)
+    assert np.allclose(restored.visibilities, original.visibilities)
+    assert np.allclose(restored.scan_start_mjd, original.scan_start_mjd)
+    assert np.allclose(restored.scan_stop_mjd, original.scan_stop_mjd)
+
+
+def test_native_uvfits_reader_loads_the_checked_in_eht_2017_file_without_ehtim():
+    path = "docs/source/EHT2017_tutorial/SR1_M87_2017_096_lo_hops_netcal_StokesI.uvfits"
+
+    dataset = read_uvfits(path)
+
+    assert dataset.row_count == 8645
+    assert dataset.channel_count == 1
+    assert dataset.correlation_layouts == (CIRCULAR_CORRELATIONS,)
+    assert dataset.stations.names == ("AA", "AP", "AZ", "JC", "LM", "PV", "SM", "SR")
+
+
+def test_native_uvfits_writer_output_is_accepted_by_ehtim(tmp_path):
+    ehtim = pytest.importorskip("ehtim")
+    path = tmp_path / "native.uvfits"
+
+    _dataset().to_uvfits(path)
+    observation = ehtim.obsdata.load_uvfits(
+        str(path),
+        channel=0,
+        IF=0,
+        polrep="circ",
+    )
+
+    assert len(observation.data) == 2
+    assert observation.rf == pytest.approx(230.0e9)
+
+
+def test_native_uvfits_module_does_not_import_ehtim():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import ngehtsim.obs.uvfits; assert 'ehtim' not in sys.modules",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_native_uvfits_writer_rejects_per_row_mixed_layouts(tmp_path):
+    original = _dataset()
+    mixed = VisibilityDataset(
+        stations=original.stations,
+        time_mjd=original.time_mjd,
+        integration_time_s=original.integration_time_s,
+        antenna1=original.antenna1,
+        antenna2=original.antenna2,
+        uvw_m=original.uvw_m,
+        tau1=original.tau1,
+        tau2=original.tau2,
+        channel_frequency_hz=original.channel_frequency_hz,
+        channel_bandwidth_hz=original.channel_bandwidth_hz,
+        spectral_window_id=original.spectral_window_id,
+        correlation_layouts=(CIRCULAR_CORRELATIONS, LINEAR_CIRCULAR_CORRELATIONS),
+        row_layout_id=np.array((0, 1), dtype=np.intp),
+        visibilities=original.visibilities,
+        weights=original.weights,
+        flags=original.flags,
+        source=original.source,
+        ra_hours=original.ra_hours,
+        dec_degrees=original.dec_degrees,
+    )
+
+    with pytest.raises(UvfitsError, match="per-row mixed"):
+        write_uvfits(mixed, tmp_path / "mixed.uvfits")


### PR DESCRIPTION
Adds native Astropy-based random-groups UVFITS read/write support for VisibilityDataset, including multi-channel and multi-IF circular or linear datasets. The implementation is independent of ehtim; mixed per-row feed layouts remain native-only and are rejected on UVFITS export. Adds documentation and interoperability tests.