### PR TITLE
Add native visibility dataset and FITS-EHT archive

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,7 @@ Individual package documentation organized by area.
    :maxdepth: 3
 
    ./obsgen
+   ./ehtfits
    ./uvfits
    ./metrics
    ./weather

--- a/docs/source/ehtfits.rst
+++ b/docs/source/ehtfits.rst
@@ -1,0 +1,37 @@
+FITS-EHT I/O
+============
+
+FITS-EHT is ngehtsim's lossless FITS-based native visibility format. It is a
+project-owned convention, not a FITS-IDI variant that existing FITS-IDI readers
+can interpret. It uses FITS binary tables and retains the familiar station,
+frequency, source, and UV-data organization, while adding explicit receptor and
+correlation-product metadata needed for mixed-polarization arrays.
+
+Use the module functions or the matching ``VisibilityDataset`` methods:
+
+.. code-block:: python
+
+   from ngehtsim.obs.ehtfits import read_ehtfits, write_ehtfits
+
+   dataset = read_ehtfits("observation.ehtfits")
+   write_ehtfits(dataset, "round_trip.ehtfits")
+
+Each receiver signal path has an ``EHT_RECEPTORS`` row that identifies its
+station, local feed identifier, polarization label, and basis. ``UV_DATA``
+records reference ordered pairs of those receptors through variable-length
+product IDs. This permits, for example, a two-receptor linear station, a
+two-receptor circular station, and a three-receptor mixed station to coexist
+without inventing a global polarization axis or a fixed four-product layout.
+
+Visibility payloads contain real and imaginary components, ``SIGMA`` values in
+Jy, and explicit flags. ``SIGMA`` is the one-standard-deviation uncertainty of
+each real or imaginary component. FITS-EHT has no weight field. An unflagged
+sample requires a finite positive uncertainty; a flagged sample may have
+``NaN`` uncertainty when the originating format did not provide one.
+
+``to_uvfits()`` remains available for standard uniformly circular or linear
+datasets. It converts ``sigma_jy`` to UVFITS's required inverse-variance field
+only at that export boundary. Mixed-receptor datasets should use FITS-EHT.
+
+.. automodule:: ngehtsim.obs.ehtfits
+   :members:

--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -6,6 +6,7 @@ __author__ = "Dom Pesce"
 
 __all__ = [
     'fringe_selection',
+    'ehtfits',
     'obs_generator',
     'obs_plotter',
     'simulation_result',

--- a/ngehtsim/obs/ehtfits.py
+++ b/ngehtsim/obs/ehtfits.py
@@ -1,0 +1,387 @@
+"""FITS-EHT interchange for native :class:`VisibilityDataset` objects.
+
+FITS-EHT is a project-owned FITS binary-table convention. It deliberately does
+not claim FITS-IDI compatibility: it replaces FITS-IDI's global polarization
+axis and weight component with explicit station-receptor product metadata and
+per-sample ``SIGMA`` values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+
+from ngehtsim.obs.visibility_dataset import (
+    CorrelationProductTable,
+    ReceptorTable,
+    StationTable,
+    VisibilityDataset,
+)
+
+
+FORMAT_NAME = "FITS-EHT"
+FORMAT_VERSION = "0.1.0"
+
+
+class EhtfitsError(ValueError):
+    """Raised when a FITS-EHT file cannot be represented natively."""
+
+
+def write_ehtfits(dataset, path, overwrite=False):
+    """Write a native dataset as a lossless FITS-EHT file.
+
+    Visibility payloads use variable-length FITS binary-table arrays. Their
+    order is channel-major then product-major, with every product ID resolving
+    to an ordered pair of station-local receptors.
+    """
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if not dataset.row_count:
+        raise EhtfitsError("FITS-EHT output requires at least one visibility row.")
+
+    hdus = [
+        _primary_hdu(dataset),
+        _array_geometry_hdu(dataset),
+        _frequency_hdu(dataset),
+        _source_hdu(dataset),
+        _receptors_hdu(dataset),
+        _correlation_products_hdu(dataset),
+        _channels_hdu(dataset),
+    ]
+    if dataset.scan_start_mjd is not None:
+        hdus.append(_scans_hdu(dataset))
+    hdus.append(_uv_data_hdu(dataset))
+    fits.HDUList(hdus).writeto(Path(path), overwrite=overwrite)
+
+
+def read_ehtfits(path):
+    """Read a FITS-EHT file into a native :class:`VisibilityDataset`."""
+
+    with fits.open(Path(path), memmap=False) as hdul:
+        header = hdul[0].header
+        if str(header.get("EHTFMT", "")).strip() != FORMAT_NAME:
+            raise EhtfitsError("Input is not a FITS-EHT file.")
+        version = str(header.get("EHTVER", "")).strip()
+        if not version.startswith("0.1."):
+            raise EhtfitsError("Unsupported FITS-EHT version: {0!r}.".format(version))
+
+        stations = _read_station_table(_required_table(hdul, "ARRAY_GEOMETRY"))
+        receptors = _read_receptor_table(_required_table(hdul, "EHT_RECEPTORS"))
+        products = _read_product_table(_required_table(hdul, "EHT_CORRELATION_PRODUCTS"))
+        channel_frequency_hz, channel_bandwidth_hz, spectral_window_id = _read_channels(
+            _required_table(hdul, "EHT_CHANNELS")
+        )
+        scans = _read_scans(hdul)
+        uv_data = _required_table(hdul, "UV_DATA")
+        decoded = _read_uv_data(uv_data, len(channel_frequency_hz))
+
+        return VisibilityDataset(
+            stations=stations,
+            receptors=receptors,
+            correlation_products=products,
+            time_mjd=decoded["time_mjd"],
+            integration_time_s=decoded["integration_time_s"],
+            antenna1=decoded["antenna1"],
+            antenna2=decoded["antenna2"],
+            uvw_m=decoded["uvw_m"],
+            tau1=decoded["tau1"],
+            tau2=decoded["tau2"],
+            channel_frequency_hz=channel_frequency_hz,
+            channel_bandwidth_hz=channel_bandwidth_hz,
+            spectral_window_id=spectral_window_id,
+            row_product_id=decoded["row_product_id"],
+            visibilities=decoded["visibilities"],
+            sigma_jy=decoded["sigma_jy"],
+            flags=decoded["flags"],
+            source=str(header.get("OBJECT", "UNKNOWN")).strip(),
+            ra_hours=float(header["OBSRA"]),
+            dec_degrees=float(header["OBSDEC"]),
+            ampcal=bool(header.get("AMPCAL", True)),
+            phasecal=bool(header.get("PHSCAL", True)),
+            opacitycal=bool(header.get("OPACAL", True)),
+            dcal=bool(header.get("DCAL", True)),
+            frcal=bool(header.get("FRCAL", True)),
+            scan_start_mjd=scans[0],
+            scan_stop_mjd=scans[1],
+        )
+
+
+def _primary_hdu(dataset):
+    primary = fits.PrimaryHDU()
+    header = primary.header
+    header["EHTFMT"] = (FORMAT_NAME, "Project FITS-EHT interchange convention")
+    header["EHTVER"] = (FORMAT_VERSION, "FITS-EHT schema version")
+    header["OBJECT"] = dataset.source
+    header["OBSRA"] = (dataset.ra_hours, "Source right ascension (hours)")
+    header["OBSDEC"] = (dataset.dec_degrees, "Source declination (degrees)")
+    header["TIMESYS"] = "UTC"
+    header["BUNIT"] = "JY"
+    header["AMPCAL"] = bool(dataset.ampcal)
+    header["PHSCAL"] = bool(dataset.phasecal)
+    header["OPACAL"] = bool(dataset.opacitycal)
+    header["DCAL"] = bool(dataset.dcal)
+    header["FRCAL"] = bool(dataset.frcal)
+    header["HISTORY"] = "FITS-EHT is not FITS-IDI compatible."
+    header["HISTORY"] = "Visibility uncertainties are stored in UV_DATA SIGMA (Jy)."
+    return primary
+
+
+def _array_geometry_hdu(dataset):
+    stations = dataset.stations
+    count = len(stations.names)
+    columns = fits.ColDefs((
+        fits.Column(name="ANTENNA_ID", format="1J", array=np.arange(1, count + 1, dtype=np.int32)),
+        fits.Column(name="ANNAME", format="64A", array=np.asarray(stations.names, dtype="S64")),
+        fits.Column(name="STABXYZ", format="3D", unit="M", array=stations.position_itrs_m),
+        fits.Column(name="SEFDR", format="1D", unit="JY", array=stations.sefd_r_jy),
+        fits.Column(name="SEFDL", format="1D", unit="JY", array=stations.sefd_l_jy),
+        fits.Column(name="DR_REAL", format="1D", array=stations.leakage_r.real),
+        fits.Column(name="DR_IMAG", format="1D", array=stations.leakage_r.imag),
+        fits.Column(name="DL_REAL", format="1D", array=stations.leakage_l.real),
+        fits.Column(name="DL_IMAG", format="1D", array=stations.leakage_l.imag),
+        fits.Column(name="FR_PAR", format="1D", array=stations.feed_rotation_par),
+        fits.Column(name="FR_ELEV", format="1D", array=stations.feed_rotation_elev),
+        fits.Column(name="FR_OFFSET", format="1D", unit="DEG", array=stations.feed_rotation_offset_deg),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="ARRAY_GEOMETRY")
+
+
+def _frequency_hdu(dataset):
+    columns = fits.ColDefs((
+        fits.Column(name="FREQ_ID", format="1J", array=np.array((1,), dtype=np.int32)),
+        fits.Column(name="CHANNEL_COUNT", format="1J", array=np.array((dataset.channel_count,), dtype=np.int32)),
+        fits.Column(name="REFERENCE_HZ", format="1D", unit="HZ", array=np.array((dataset.channel_frequency_hz[0],))),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="FREQUENCY")
+
+
+def _source_hdu(dataset):
+    columns = fits.ColDefs((
+        fits.Column(name="SOURCE_ID", format="1J", array=np.array((1,), dtype=np.int32)),
+        fits.Column(name="SOURCE", format="64A", array=np.array((dataset.source,), dtype="S64")),
+        fits.Column(name="RA_HOURS", format="1D", unit="HOUR", array=np.array((dataset.ra_hours,))),
+        fits.Column(name="DEC_DEG", format="1D", unit="DEG", array=np.array((dataset.dec_degrees,))),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="SOURCE")
+
+
+def _receptors_hdu(dataset):
+    receptors = dataset.receptors
+    count = receptors.count
+    columns = fits.ColDefs((
+        fits.Column(name="RECEPTOR_ID", format="1J", array=np.arange(1, count + 1, dtype=np.int32)),
+        fits.Column(name="ANTENNA_ID", format="1J", array=receptors.station_index.astype(np.int32) + 1),
+        fits.Column(name="FEED_ID", format="32A", array=np.asarray(receptors.feed_id, dtype="S32")),
+        fits.Column(name="POL_LABEL", format="32A", array=np.asarray(receptors.polarization_label, dtype="S32")),
+        fits.Column(name="BASIS", format="32A", array=np.asarray(receptors.basis, dtype="S32")),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="EHT_RECEPTORS")
+
+
+def _correlation_products_hdu(dataset):
+    products = dataset.correlation_products
+    count = products.count
+    columns = fits.ColDefs((
+        fits.Column(name="PRODUCT_ID", format="1J", array=np.arange(1, count + 1, dtype=np.int32)),
+        fits.Column(name="RECEPTOR1_ID", format="1J", array=products.receptor1_id.astype(np.int32) + 1),
+        fits.Column(name="RECEPTOR2_ID", format="1J", array=products.receptor2_id.astype(np.int32) + 1),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="EHT_CORRELATION_PRODUCTS")
+
+
+def _channels_hdu(dataset):
+    count = dataset.channel_count
+    columns = fits.ColDefs((
+        fits.Column(name="CHANNEL_ID", format="1J", array=np.arange(1, count + 1, dtype=np.int32)),
+        fits.Column(name="FREQUENCY_HZ", format="1D", unit="HZ", array=dataset.channel_frequency_hz),
+        fits.Column(name="BANDWIDTH_HZ", format="1D", unit="HZ", array=dataset.channel_bandwidth_hz),
+        fits.Column(name="SPECTRAL_WINDOW_ID", format="1J", array=dataset.spectral_window_id.astype(np.int32)),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="EHT_CHANNELS")
+
+
+def _scans_hdu(dataset):
+    columns = fits.ColDefs((
+        fits.Column(name="START_MJD", format="1D", unit="D", array=dataset.scan_start_mjd),
+        fits.Column(name="STOP_MJD", format="1D", unit="D", array=dataset.scan_stop_mjd),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="EHT_SCANS")
+
+
+def _uv_data_hdu(dataset):
+    row_count = dataset.row_count
+    product_ids = np.empty(row_count, dtype=object)
+    visibility = np.empty(row_count, dtype=object)
+    sigma_jy = np.empty(row_count, dtype=object)
+    flags = np.empty(row_count, dtype=object)
+    product_count = np.empty(row_count, dtype=np.int32)
+
+    for row, row_products in enumerate(dataset.row_product_id):
+        slots = np.flatnonzero(row_products >= 0)
+        product_count[row] = len(slots)
+        product_ids[row] = row_products[slots].astype(np.int32) + 1
+        row_visibility = dataset.visibilities[row][:, slots]
+        row_sigma = dataset.sigma_jy[row][:, slots]
+        row_flags = dataset.flags[row][:, slots]
+        visibility[row] = np.column_stack((row_visibility.real.ravel(), row_visibility.imag.ravel())).ravel()
+        sigma_jy[row] = row_sigma.ravel()
+        flags[row] = row_flags.astype(np.uint8).ravel()
+
+    columns = fits.ColDefs((
+        fits.Column(name="TIME_MJD", format="1D", unit="D", array=dataset.time_mjd),
+        fits.Column(name="INTEGRATION_S", format="1D", unit="S", array=dataset.integration_time_s),
+        fits.Column(name="ANTENNA1", format="1J", array=dataset.antenna1.astype(np.int32) + 1),
+        fits.Column(name="ANTENNA2", format="1J", array=dataset.antenna2.astype(np.int32) + 1),
+        fits.Column(name="UU_M", format="1D", unit="M", array=dataset.uvw_m[:, 0]),
+        fits.Column(name="VV_M", format="1D", unit="M", array=dataset.uvw_m[:, 1]),
+        fits.Column(name="WW_M", format="1D", unit="M", array=dataset.uvw_m[:, 2]),
+        fits.Column(name="TAU1", format="1D", array=dataset.tau1),
+        fits.Column(name="TAU2", format="1D", array=dataset.tau2),
+        fits.Column(name="NCHANNEL", format="1J", array=np.full(row_count, dataset.channel_count, dtype=np.int32)),
+        fits.Column(name="NPRODUCT", format="1J", array=product_count),
+        fits.Column(name="PRODUCT_ID", format="QJ()", array=product_ids),
+        fits.Column(name="VISIBILITY", format="QD()", unit="JY", array=visibility),
+        fits.Column(name="SIGMA", format="QD()", unit="JY", array=sigma_jy),
+        fits.Column(name="FLAG", format="QB()", array=flags),
+    ))
+    return fits.BinTableHDU.from_columns(columns, name="UV_DATA")
+
+
+def _required_table(hdul, name):
+    if name not in hdul or not isinstance(hdul[name], fits.BinTableHDU):
+        raise EhtfitsError("FITS-EHT input is missing the {0} table.".format(name))
+    return hdul[name].data
+
+
+def _text(value):
+    if isinstance(value, bytes):
+        return value.decode("ascii").strip()
+    return str(value).strip()
+
+
+def _required_columns(table, names, extension):
+    if table.names is None or any(name not in table.names for name in names):
+        raise EhtfitsError("{0} is missing required columns.".format(extension))
+
+
+def _read_station_table(table):
+    _required_columns(
+        table,
+        ("ANTENNA_ID", "ANNAME", "STABXYZ", "SEFDR", "SEFDL", "DR_REAL", "DR_IMAG", "DL_REAL", "DL_IMAG", "FR_PAR", "FR_ELEV", "FR_OFFSET"),
+        "ARRAY_GEOMETRY",
+    )
+    identifiers = np.asarray(table["ANTENNA_ID"], dtype=np.intp)
+    if not np.array_equal(identifiers, np.arange(1, len(identifiers) + 1)):
+        raise EhtfitsError("ARRAY_GEOMETRY antenna IDs must be contiguous and one-based.")
+    return StationTable(
+        names=tuple(_text(value) for value in table["ANNAME"]),
+        position_itrs_m=np.asarray(table["STABXYZ"], dtype=float),
+        sefd_r_jy=np.asarray(table["SEFDR"], dtype=float),
+        sefd_l_jy=np.asarray(table["SEFDL"], dtype=float),
+        leakage_r=np.asarray(table["DR_REAL"], dtype=float) + 1.0j * np.asarray(table["DR_IMAG"], dtype=float),
+        leakage_l=np.asarray(table["DL_REAL"], dtype=float) + 1.0j * np.asarray(table["DL_IMAG"], dtype=float),
+        feed_rotation_par=np.asarray(table["FR_PAR"], dtype=float),
+        feed_rotation_elev=np.asarray(table["FR_ELEV"], dtype=float),
+        feed_rotation_offset_deg=np.asarray(table["FR_OFFSET"], dtype=float),
+    )
+
+
+def _read_receptor_table(table):
+    _required_columns(table, ("RECEPTOR_ID", "ANTENNA_ID", "FEED_ID", "POL_LABEL", "BASIS"), "EHT_RECEPTORS")
+    identifiers = np.asarray(table["RECEPTOR_ID"], dtype=np.intp)
+    if not np.array_equal(identifiers, np.arange(1, len(identifiers) + 1)):
+        raise EhtfitsError("EHT_RECEPTORS IDs must be contiguous and one-based.")
+    return ReceptorTable(
+        station_index=np.asarray(table["ANTENNA_ID"], dtype=np.intp) - 1,
+        feed_id=tuple(_text(value) for value in table["FEED_ID"]),
+        polarization_label=tuple(_text(value) for value in table["POL_LABEL"]),
+        basis=tuple(_text(value) for value in table["BASIS"]),
+    )
+
+
+def _read_product_table(table):
+    _required_columns(table, ("PRODUCT_ID", "RECEPTOR1_ID", "RECEPTOR2_ID"), "EHT_CORRELATION_PRODUCTS")
+    identifiers = np.asarray(table["PRODUCT_ID"], dtype=np.intp)
+    if not np.array_equal(identifiers, np.arange(1, len(identifiers) + 1)):
+        raise EhtfitsError("EHT_CORRELATION_PRODUCTS IDs must be contiguous and one-based.")
+    return CorrelationProductTable(
+        receptor1_id=np.asarray(table["RECEPTOR1_ID"], dtype=np.intp) - 1,
+        receptor2_id=np.asarray(table["RECEPTOR2_ID"], dtype=np.intp) - 1,
+    )
+
+
+def _read_channels(table):
+    _required_columns(table, ("CHANNEL_ID", "FREQUENCY_HZ", "BANDWIDTH_HZ", "SPECTRAL_WINDOW_ID"), "EHT_CHANNELS")
+    identifiers = np.asarray(table["CHANNEL_ID"], dtype=np.intp)
+    if not np.array_equal(identifiers, np.arange(1, len(identifiers) + 1)):
+        raise EhtfitsError("EHT_CHANNELS IDs must be contiguous and one-based.")
+    return (
+        np.asarray(table["FREQUENCY_HZ"], dtype=float),
+        np.asarray(table["BANDWIDTH_HZ"], dtype=float),
+        np.asarray(table["SPECTRAL_WINDOW_ID"], dtype=np.intp),
+    )
+
+
+def _read_scans(hdul):
+    if "EHT_SCANS" not in hdul:
+        return None, None
+    table = hdul["EHT_SCANS"].data
+    _required_columns(table, ("START_MJD", "STOP_MJD"), "EHT_SCANS")
+    return np.asarray(table["START_MJD"], dtype=float), np.asarray(table["STOP_MJD"], dtype=float)
+
+
+def _read_uv_data(table, channel_count):
+    required = (
+        "TIME_MJD", "INTEGRATION_S", "ANTENNA1", "ANTENNA2", "UU_M", "VV_M", "WW_M", "TAU1", "TAU2",
+        "NCHANNEL", "NPRODUCT", "PRODUCT_ID", "VISIBILITY", "SIGMA", "FLAG",
+    )
+    _required_columns(table, required, "UV_DATA")
+    row_count = len(table)
+    nproduct = np.asarray(table["NPRODUCT"], dtype=np.intp)
+    if np.any(nproduct <= 0):
+        raise EhtfitsError("UV_DATA NPRODUCT values must be positive.")
+    if not np.all(np.asarray(table["NCHANNEL"], dtype=np.intp) == channel_count):
+        raise EhtfitsError("UV_DATA rows must use the file's complete EHT_CHANNELS table.")
+    slot_count = int(np.max(nproduct))
+    row_product_id = np.full((row_count, slot_count), -1, dtype=np.intp)
+    visibilities = np.full((row_count, channel_count, slot_count), np.nan + 1.0j * np.nan, dtype=complex)
+    sigma_jy = np.full((row_count, channel_count, slot_count), np.nan, dtype=float)
+    flags = np.ones((row_count, channel_count, slot_count), dtype=bool)
+
+    for row in range(row_count):
+        count = int(nproduct[row])
+        product_ids = np.asarray(table["PRODUCT_ID"][row], dtype=np.intp)
+        visibility = np.asarray(table["VISIBILITY"][row], dtype=float)
+        sigma = np.asarray(table["SIGMA"][row], dtype=float)
+        flag = np.asarray(table["FLAG"][row], dtype=np.uint8)
+        sample_count = channel_count * count
+        if len(product_ids) != count:
+            raise EhtfitsError("UV_DATA PRODUCT_ID length does not match NPRODUCT.")
+        if len(visibility) != 2 * sample_count or len(sigma) != sample_count or len(flag) != sample_count:
+            raise EhtfitsError("UV_DATA variable-length payload has an inconsistent size.")
+        row_product_id[row, :count] = product_ids - 1
+        pairs = visibility.reshape(channel_count, count, 2)
+        visibilities[row, :, :count] = pairs[..., 0] + 1.0j * pairs[..., 1]
+        sigma_jy[row, :, :count] = sigma.reshape(channel_count, count)
+        flags[row, :, :count] = flag.reshape(channel_count, count).astype(bool)
+
+    return {
+        "time_mjd": np.asarray(table["TIME_MJD"], dtype=float),
+        "integration_time_s": np.asarray(table["INTEGRATION_S"], dtype=float),
+        "antenna1": np.asarray(table["ANTENNA1"], dtype=np.intp) - 1,
+        "antenna2": np.asarray(table["ANTENNA2"], dtype=np.intp) - 1,
+        "uvw_m": np.column_stack((
+            np.asarray(table["UU_M"], dtype=float),
+            np.asarray(table["VV_M"], dtype=float),
+            np.asarray(table["WW_M"], dtype=float),
+        )),
+        "tau1": np.asarray(table["TAU1"], dtype=float),
+        "tau2": np.asarray(table["TAU2"], dtype=float),
+        "row_product_id": row_product_id,
+        "visibilities": visibilities,
+        "sigma_jy": sigma_jy,
+        "flags": flags,
+    }

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 import numpy as np
 
 import ngehtsim.const_def as const
-from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, StationTable, VisibilityDataset
+from ngehtsim.obs.visibility_dataset import StationTable, VisibilityDataset
 
 
 def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
@@ -72,13 +72,12 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
         raise TypeError("stations must be a StationTable instance.")
     if dataset.channel_count != 1:
         raise ValueError("Circular corruption currently requires exactly one channel.")
-    if any(
-        dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
-        for index in dataset.row_layout_id
-    ):
+    try:
+        circular_slots = dataset.circular_product_slots()
+    except ValueError as exc:
         raise ValueError(
-            "Circular corruption requires RR, LL, RL, LR correlations for every row."
-        )
+            "Circular corruption requires exactly RR, LL, RL, LR correlations for every row."
+        ) from exc
 
     count = dataset.row_count
     terms = {
@@ -94,8 +93,9 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
     if not np.array_equal(terms["t1"], expected_t1) or not np.array_equal(terms["t2"], expected_t2):
         raise ValueError("Station terms do not correspond to the dataset row order.")
 
+    row_index = np.arange(count)[:, np.newaxis]
     visibilities = np.array(dataset.visibilities, copy=True)
-    circular = visibilities[:, 0, :]
+    circular = np.array(visibilities[row_index, 0, circular_slots], copy=True)
     tau1 = np.asarray(terms["tau1"], dtype=float)
     tau2 = np.asarray(terms["tau2"], dtype=float)
     if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
@@ -181,16 +181,17 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
         & ~np.isin(terms["t2"], tuple(flagged_sites))
         & np.asarray(terms["uptime_mask"], dtype=bool)
     )
-    flags[:, 0, :] |= ~row_mask[:, np.newaxis]
-    weights = np.array(dataset.weights, copy=True)
-    weights[:, 0, :] = 1.0 / np.square(sigma)
+    flags[row_index, 0, circular_slots] |= ~row_mask[:, np.newaxis]
+    sigma_jy = np.array(dataset.sigma_jy, copy=True)
+    sigma_jy[row_index, 0, circular_slots] = sigma
+    visibilities[row_index, 0, circular_slots] = circular
     return replace(
         dataset,
         stations=stations,
         tau1=tau1,
         tau2=tau2,
         visibilities=visibilities,
-        weights=weights,
+        sigma_jy=sigma_jy,
         flags=flags,
         ampcal=not addgains,
         phasecal=not addgains,

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -1333,7 +1333,7 @@ class obs_generator(object):
     def _native_selection_mask(self, dataset, input_model=None, simulation_kwargs=None):
         """Return the native row-selection mask for availability and fringe finding."""
 
-        mask = ~np.any(dataset.flags, axis=(1, 2))
+        mask = ~np.any(dataset.flags & dataset.sample_present, axis=(1, 2))
         names = np.asarray(dataset.stations.names)
         t1 = names[dataset.antenna1]
         t2 = names[dataset.antenna2]
@@ -1363,11 +1363,13 @@ class obs_generator(object):
         snr_algorithm, snr_args = self.settings["fringe_finder"]
         snr_algorithm = snr_algorithm.lower()
         if snr_algorithm == "naive":
+            circular_slots = dataset.circular_product_slots()
+            rows = np.arange(dataset.row_count)
             pseudo_i_amplitude = 0.5 * (
-                np.abs(dataset.visibilities[:, 0, 0])
-                + np.abs(dataset.visibilities[:, 0, 1])
+                np.abs(dataset.visibilities[rows, 0, circular_slots[:, 0]])
+                + np.abs(dataset.visibilities[rows, 0, circular_slots[:, 1]])
             )
-            pseudo_i_sigma = 1.0 / np.sqrt(2.0 * dataset.weights[:, 0, 0])
+            pseudo_i_sigma = dataset.sigma_jy[rows, 0, circular_slots[:, 0]] / np.sqrt(2.0)
             mask &= (pseudo_i_amplitude / pseudo_i_sigma) > snr_args
         elif snr_algorithm == "fringegroups":
             selected_indices = np.flatnonzero(mask)
@@ -1434,7 +1436,10 @@ class obs_generator(object):
             target_available_sites=target_available_sites,
             reference_available_sites=reference_available_sites,
             target_row_available=target_row_available,
-            reference_row_available=~np.any(reference_dataset.flags, axis=(1, 2)),
+            reference_row_available=~np.any(
+                reference_dataset.flags & reference_dataset.sample_present,
+                axis=(1, 2),
+            ),
         )
 
     def make_dataset(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
@@ -2168,16 +2173,18 @@ def _fringe_rows_from_dataset(dataset):
 
     if dataset.channel_count != 1:
         raise ValueError("Native fringe selection requires exactly one spectral channel.")
+    circular_slots = dataset.circular_product_slots()
+    rows = np.arange(dataset.row_count)
     names = np.asarray(dataset.stations.names)
     return fringe_selection.FringeRows(
         time=dataset.time_mjd,
         station1=names[dataset.antenna1],
         station2=names[dataset.antenna2],
         integration_time_s=dataset.integration_time_s,
-        rr=dataset.visibilities[:, 0, 0],
-        ll=dataset.visibilities[:, 0, 1],
-        rr_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 0]),
-        ll_sigma=1.0 / np.sqrt(dataset.weights[:, 0, 1]),
+        rr=dataset.visibilities[rows, 0, circular_slots[:, 0]],
+        ll=dataset.visibilities[rows, 0, circular_slots[:, 1]],
+        rr_sigma=dataset.sigma_jy[rows, 0, circular_slots[:, 0]],
+        ll_sigma=dataset.sigma_jy[rows, 0, circular_slots[:, 1]],
     )
 
 

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -9,9 +9,11 @@ from astropy.time import Time
 import ehtim as eh
 
 from ngehtsim.obs.visibility_dataset import (
-    CIRCULAR_CORRELATIONS,
+    CIRCULAR_PRODUCT_LABELS,
+    ReceptorTable,
     StationTable,
     VisibilityDataset,
+    standard_products_for_rows,
 )
 
 
@@ -319,7 +321,7 @@ def ground_geometry(array, context):
 def ground_visibility_template(array, context, geometry=None):
     """Build a native visibility template for a ground-only array.
 
-    The template carries geometry and thermal weights but contains zero-valued
+    The template carries geometry and thermal uncertainties but contains zero-valued
     circular visibilities. Source sampling remains at the ``ehtim`` adapter
     boundary until native source adapters are introduced.
     """
@@ -346,8 +348,22 @@ def ground_visibility_template(array, context, geometry=None):
     scan_start_mjd = reference_mjd + (scan_times / 24.0) - (scan_half_width_s / 86400.0)
     scan_stop_mjd = reference_mjd + (scan_times / 24.0) + (scan_half_width_s / 86400.0)
 
+    stations = StationTable.from_ehtim_tarr(array.tarr)
+    receptors = ReceptorTable.from_station_labels(
+        len(stations.names),
+        ("R", "L"),
+        "CIRCULAR",
+    )
+    correlation_products, row_product_id = standard_products_for_rows(
+        receptors,
+        geometry.station1_indices,
+        geometry.station2_indices,
+        CIRCULAR_PRODUCT_LABELS,
+    )
     return VisibilityDataset(
-        stations=StationTable.from_ehtim_tarr(array.tarr),
+        stations=stations,
+        receptors=receptors,
+        correlation_products=correlation_products,
         time_mjd=time_mjd,
         integration_time_s=np.full(len(time_mjd), float(context["t_int"])),
         antenna1=geometry.station1_indices,
@@ -358,10 +374,9 @@ def ground_visibility_template(array, context, geometry=None):
         channel_frequency_hz=np.array((float(context["rf"]),)),
         channel_bandwidth_hz=np.array((float(context["bandwidth_hz"]),)),
         spectral_window_id=np.array((0,), dtype=np.intp),
-        correlation_layouts=(CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.zeros(len(time_mjd), dtype=np.intp),
+        row_product_id=row_product_id,
         visibilities=np.zeros((len(time_mjd), 1, 4), dtype=complex),
-        weights=(1.0 / np.square(sigma))[:, np.newaxis, :],
+        sigma_jy=sigma[:, np.newaxis, :],
         flags=np.zeros((len(time_mjd), 1, 4), dtype=bool),
         source=str(context["ra"]) + ":" + str(context["dec"]),
         ra_hours=float(context["ra"]),

--- a/ngehtsim/obs/simulation_result.py
+++ b/ngehtsim/obs/simulation_result.py
@@ -40,7 +40,10 @@ class SimulationResult:
     def row_mask(self):
         """Rows retained after station and fringe-selection flagging."""
 
-        return ~np.any(self.dataset.flags, axis=(1, 2))
+        return ~np.any(
+            self.dataset.flags & self.dataset.sample_present,
+            axis=(1, 2),
+        )
 
     @property
     def unflagged_dataset(self):
@@ -61,7 +64,9 @@ class SimulationResult:
 
         # ehtim refuses to construct an Obsdata from zero rows. Construct a
         # valid temporary export and then expose its representable empty view.
-        temporary = replace(self.dataset, flags=np.zeros_like(self.dataset.flags))
+        temporary_flags = np.array(self.dataset.flags, copy=True)
+        temporary_flags[self.dataset.sample_present] = False
+        temporary = replace(self.dataset, flags=temporary_flags)
         obs = temporary.to_ehtim_obsdata()
         obs.data = obs.data[:0]
         return obs

--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -7,7 +7,7 @@ import numpy as np
 import ehtim as eh
 from astropy.constants import c as SPEED_OF_LIGHT
 
-from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, VisibilityDataset
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 try:
     import ngEHTforecast.fisher as fp
@@ -62,13 +62,12 @@ def _require_native_circular_dataset(dataset):
         raise TypeError("dataset must be a VisibilityDataset instance.")
     if dataset.channel_count != 1:
         raise ValueError("Native source sampling requires exactly one spectral channel.")
-    if any(
-        dataset.correlation_layouts[index] != CIRCULAR_CORRELATIONS
-        for index in dataset.row_layout_id
-    ):
+    try:
+        return dataset.circular_product_slots()
+    except ValueError as exc:
         raise ValueError(
-            "Native source sampling requires circular RR, LL, RL, LR correlations."
-        )
+            "Native source sampling requires exactly circular RR, LL, RL, LR correlations."
+        ) from exc
 
 
 def _dataset_uv(dataset):
@@ -76,14 +75,26 @@ def _dataset_uv(dataset):
     return dataset.uvw_m[:, :2] / wavelength
 
 
+def _write_circular_samples(visibilities, slots, rows, sampled):
+    """Write RR, LL, RL, LR samples into explicitly mapped product slots."""
+
+    rows = np.asarray(rows, dtype=np.intp)
+    visibilities[rows, 0, slots[rows, 0]] = sampled[0]
+    if sampled[1] is not None:
+        visibilities[rows, 0, slots[rows, 1]] = sampled[1]
+    if sampled[2] is not None:
+        visibilities[rows, 0, slots[rows, 2]] = sampled[2]
+        visibilities[rows, 0, slots[rows, 3]] = sampled[3]
+
+
 def _with_circular_samples(dataset, sampled, context):
     visibilities = np.array(dataset.visibilities, copy=True)
-    visibilities[:, 0, 0] = sampled[0]
-    if sampled[1] is not None:
-        visibilities[:, 0, 1] = sampled[1]
-    if sampled[2] is not None:
-        visibilities[:, 0, 2] = sampled[2]
-        visibilities[:, 0, 3] = sampled[3]
+    _write_circular_samples(
+        visibilities,
+        dataset.circular_product_slots(),
+        np.arange(dataset.row_count),
+        sampled,
+    )
     return replace(
         dataset,
         visibilities=visibilities,
@@ -270,7 +281,7 @@ class EhtimMovieAdapter(object):
     def observe_dataset(self, dataset, context):
         """Sample a repeating movie onto a native circular dataset."""
 
-        _require_native_circular_dataset(dataset)
+        circular_slots = _require_native_circular_dataset(dataset)
         _validate_raster_ttype(self.input_model, context)
 
         def sample_dataset():
@@ -294,12 +305,12 @@ class EhtimMovieAdapter(object):
                     fft_pad_factor=context["fft_pad_factor"],
                     verbose=False,
                 )
-                visibilities[row_mask, 0, 0] = sampled[0]
-                if sampled[1] is not None:
-                    visibilities[row_mask, 0, 1] = sampled[1]
-                if sampled[2] is not None:
-                    visibilities[row_mask, 0, 2] = sampled[2]
-                    visibilities[row_mask, 0, 3] = sampled[3]
+                _write_circular_samples(
+                    visibilities,
+                    circular_slots,
+                    np.flatnonzero(row_mask),
+                    sampled,
+                )
 
             return replace(
                 dataset,

--- a/ngehtsim/obs/uvfits.py
+++ b/ngehtsim/obs/uvfits.py
@@ -17,10 +17,12 @@ from astropy.io import fits
 from astropy.time import Time
 
 from ngehtsim.obs.visibility_dataset import (
-    CIRCULAR_CORRELATIONS,
-    LINEAR_CORRELATIONS,
+    CIRCULAR_PRODUCT_LABELS,
+    LINEAR_PRODUCT_LABELS,
+    ReceptorTable,
     StationTable,
     VisibilityDataset,
+    standard_products_for_rows,
 )
 
 
@@ -72,6 +74,21 @@ def read_uvfits(path):
 
         baseline = _group_parameter(primary.data, "BASELINE")
         antenna1, antenna2 = _decode_baselines(baseline, station_index)
+        if layout == CIRCULAR_PRODUCT_LABELS:
+            receptor_labels, basis = ("R", "L"), "CIRCULAR"
+        else:
+            receptor_labels, basis = ("X", "Y"), "LINEAR"
+        receptors = ReceptorTable.from_station_labels(
+            len(station_table.names),
+            receptor_labels,
+            basis,
+        )
+        correlation_products, row_product_id = standard_products_for_rows(
+            receptors,
+            antenna1,
+            antenna2,
+            layout,
+        )
         uvw_m = np.column_stack((
             _group_parameter(primary.data, "UU---SIN"),
             _group_parameter(primary.data, "VV---SIN"),
@@ -90,6 +107,8 @@ def read_uvfits(path):
 
         return VisibilityDataset(
             stations=station_table,
+            receptors=receptors,
+            correlation_products=correlation_products,
             time_mjd=time_mjd,
             integration_time_s=integration_time_s,
             antenna1=antenna1,
@@ -100,10 +119,9 @@ def read_uvfits(path):
             channel_frequency_hz=frequencies,
             channel_bandwidth_hz=channel_bandwidths,
             spectral_window_id=spectral_window_id,
-            correlation_layouts=(layout,),
-            row_layout_id=np.zeros(len(time_mjd), dtype=np.intp),
+            row_product_id=row_product_id,
             visibilities=data["visibilities"],
-            weights=data["weights"],
+            sigma_jy=data["sigma_jy"],
             flags=data["flags"],
             source=str(header.get("OBJECT", "UNKNOWN")).strip(),
             ra_hours=ra_hours,
@@ -131,10 +149,10 @@ def write_uvfits(dataset, path, overwrite=False):
     if not dataset.row_count:
         raise UvfitsError("UVFITS output requires at least one visibility row.")
 
-    layout = _uvfits_layout(dataset)
+    layout, product_slots = _uvfits_layout(dataset)
     frequency_grid = _frequency_grid(dataset)
     row_order = np.lexsort((dataset.antenna2, dataset.antenna1, dataset.time_mjd))
-    primary = _primary_hdu(dataset, layout, frequency_grid, row_order)
+    primary = _primary_hdu(dataset, layout, product_slots, frequency_grid, row_order)
     antenna = _antenna_hdu(
         dataset,
         layout,
@@ -167,7 +185,7 @@ def _read_data(group_data, header, axes, hdul):
     row_count = values.shape[0]
     channel_count = if_count * frequency_count
     visibilities = np.zeros((row_count, channel_count, 4), dtype=complex)
-    weights = np.zeros((row_count, channel_count, 4), dtype=float)
+    sigma_jy = np.full((row_count, channel_count, 4), np.nan, dtype=float)
     flags = np.ones((row_count, channel_count, 4), dtype=bool)
     real = values[..., 0].reshape(row_count, channel_count, len(polarization_codes))
     imaginary = values[..., 1].reshape(row_count, channel_count, len(polarization_codes))
@@ -195,16 +213,14 @@ def _read_data(group_data, header, axes, hdul):
             real[..., source_index] + 1.0j * imaginary[..., source_index],
             0.0,
         )
-        weights[..., destination_index] = np.where(
-            valid,
-            raw_weights[..., source_index],
-            0.0,
-        )
+        sigma_values = np.full(valid.shape, np.nan, dtype=float)
+        sigma_values[valid] = 1.0 / np.sqrt(raw_weights[..., source_index][valid])
+        sigma_jy[..., destination_index] = sigma_values
         flags[..., destination_index] = ~valid
 
     return {
         "visibilities": visibilities,
-        "weights": weights,
+        "sigma_jy": sigma_jy,
         "flags": flags,
     }, channels, channel_bandwidths, spectral_window_id, layout
 
@@ -283,10 +299,10 @@ def _layout_from_stokes_codes(codes):
     if not len(codes) or any(int(code) not in _POLARIZATION_PRODUCTS for code in codes):
         raise UvfitsError("UVFITS STOKES axis must describe correlation products, not Stokes values.")
     products = {_POLARIZATION_PRODUCTS[int(code)] for code in codes}
-    if products.issubset(set(CIRCULAR_CORRELATIONS)):
-        return CIRCULAR_CORRELATIONS
-    if products.issubset(set(LINEAR_CORRELATIONS)):
-        return LINEAR_CORRELATIONS
+    if products.issubset(set(CIRCULAR_PRODUCT_LABELS)):
+        return CIRCULAR_PRODUCT_LABELS
+    if products.issubset(set(LINEAR_PRODUCT_LABELS)):
+        return LINEAR_PRODUCT_LABELS
     raise UvfitsError("UVFITS input mixes circular and linear correlation products.")
 
 
@@ -405,13 +421,17 @@ def _table_vector(values, count, name):
 
 
 def _uvfits_layout(dataset):
-    layout_ids = np.unique(dataset.row_layout_id)
-    if len(layout_ids) != 1:
-        raise UvfitsError("UVFITS output cannot represent per-row mixed correlation layouts.")
-    layout = dataset.correlation_layouts[int(layout_ids[0])]
-    if layout not in (CIRCULAR_CORRELATIONS, LINEAR_CORRELATIONS):
-        raise UvfitsError("UVFITS output requires a uniform circular or linear correlation layout.")
-    return layout
+    try:
+        return CIRCULAR_PRODUCT_LABELS, dataset.circular_product_slots()
+    except ValueError:
+        pass
+    try:
+        return LINEAR_PRODUCT_LABELS, dataset.linear_product_slots()
+    except ValueError as exc:
+        raise UvfitsError(
+            "UVFITS output requires exactly the same circular RR, LL, RL, LR or "
+            "linear XX, YY, XY, YX products for every row."
+        ) from exc
 
 
 def _frequency_grid(dataset):
@@ -457,7 +477,7 @@ def _frequency_grid(dataset):
     }
 
 
-def _primary_hdu(dataset, layout, frequency_grid, row_order):
+def _primary_hdu(dataset, layout, product_slots, frequency_grid, row_order):
     channel_indices = frequency_grid["channel_indices"]
     if_count = len(channel_indices)
     frequency_count = len(channel_indices[0])
@@ -465,13 +485,17 @@ def _primary_hdu(dataset, layout, frequency_grid, row_order):
         (dataset.row_count, 1, 1, if_count, frequency_count, 4, 3),
         dtype=np.float32,
     )
+    ordered_slots = product_slots[row_order]
     for if_index, channel_index in enumerate(channel_indices):
-        visibility = dataset.visibilities[row_order][:, channel_index, :]
-        weight = dataset.weights[row_order][:, channel_index, :]
-        valid = ~dataset.flags[row_order][:, channel_index, :]
+        row_index = row_order[:, np.newaxis, np.newaxis]
+        channel_axis = channel_index[np.newaxis, :, np.newaxis]
+        product_axis = ordered_slots[:, np.newaxis, :]
+        visibility = dataset.visibilities[row_index, channel_axis, product_axis]
+        sigma_jy = dataset.sigma_jy[row_index, channel_axis, product_axis]
+        valid = ~dataset.flags[row_index, channel_axis, product_axis]
         values[:, 0, 0, if_index, :, :, 0] = np.where(valid, visibility.real, 0.0)
         values[:, 0, 0, if_index, :, :, 1] = np.where(valid, visibility.imag, 0.0)
-        values[:, 0, 0, if_index, :, :, 2] = np.where(valid, weight, -1.0)
+        values[:, 0, 0, if_index, :, :, 2] = np.where(valid, 1.0 / np.square(sigma_jy), -1.0)
 
     reference_mjd = float(np.floor(np.min(dataset.time_mjd)))
     date_jd = reference_mjd + 2400000.5
@@ -499,7 +523,7 @@ def _primary_hdu(dataset, layout, frequency_grid, row_order):
 
 
 def _set_common_header(header, dataset, layout, frequency_grid, reference_mjd):
-    stokes_start = -1.0 if layout == CIRCULAR_CORRELATIONS else -5.0
+    stokes_start = -1.0 if layout == CIRCULAR_PRODUCT_LABELS else -5.0
     header["OBSRA"] = dataset.ra_hours * 15.0
     header["OBSDEC"] = dataset.dec_degrees
     header["OBJECT"] = dataset.source
@@ -539,7 +563,7 @@ def _antenna_hdu(dataset, layout, reference_frequency_hz, if_count):
         raise UvfitsError("UVFITS AIPS AN output supports station names up to eight ASCII characters.")
     names = np.asarray(dataset.stations.names, dtype="S8")
     count = len(names)
-    first_feed, second_feed = ("R", "L") if layout == CIRCULAR_CORRELATIONS else ("X", "Y")
+    first_feed, second_feed = ("R", "L") if layout == CIRCULAR_PRODUCT_LABELS else ("X", "Y")
     columns = fits.ColDefs((
         fits.Column(name="ANNAME", format="8A", array=names),
         fits.Column(name="STABXYZ", format="3D", unit="METERS", array=dataset.stations.position_itrs_m),

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -1,4 +1,4 @@
-"""Internal visibility data structures and ``ehtim.Obsdata`` compatibility adapters."""
+"""Native visibility data structures and optional ``ehtim.Obsdata`` adapters."""
 
 from __future__ import annotations
 
@@ -8,13 +8,8 @@ import numpy as np
 from astropy.constants import c as SPEED_OF_LIGHT
 
 
-CIRCULAR_CORRELATIONS = ("RR", "LL", "RL", "LR")
-LINEAR_CORRELATIONS = ("XX", "YY", "XY", "YX")
-LINEAR_CIRCULAR_CORRELATIONS = ("XR", "XL", "YR", "YL")
-CIRCULAR_LINEAR_CORRELATIONS = ("RX", "RY", "LX", "LY")
-_VALID_CORRELATION_PRODUCTS = frozenset(
-    first + second for first in "RLXY" for second in "RLXY"
-)
+CIRCULAR_PRODUCT_LABELS = ("RR", "LL", "RL", "LR")
+LINEAR_PRODUCT_LABELS = ("XX", "YY", "XY", "YX")
 
 
 def _readonly_array(values, dtype=None):
@@ -136,17 +131,177 @@ class StationTable:
 
 
 @dataclass(frozen=True)
-class VisibilityDataset:
-    """Visibility data supporting multiple channels and per-row correlation layouts.
+class ReceptorTable:
+    """Station-local receiver signal paths used by a visibility dataset.
 
-    ``visibilities``, ``weights``, and ``flags`` have shape
-    ``(row, channel, correlation)``. Every row has four correlation slots; the
-    corresponding labels are selected from ``correlation_layouts`` by
-    ``row_layout_id``. This supports circular, linear, and mixed-feed baselines
-    without a global polarization representation.
+    A receptor is one voltage stream, not a two-polarization feed assembly.
+    ``receptor_id`` is the zero-based index of a row in this table. The
+    ``feed_id`` and ``polarization_label`` fields are descriptive rather than
+    inferred calibration instructions, so non-standard receiver arrangements
+    remain representable.
+    """
+
+    station_index: np.ndarray
+    feed_id: tuple[str, ...]
+    polarization_label: tuple[str, ...]
+    basis: tuple[str, ...]
+
+    def __post_init__(self):
+        station_index = _integer_array(self.station_index, "station_index")
+        count = len(station_index)
+        feed_id = tuple(str(value) for value in self.feed_id)
+        polarization_label = tuple(str(value) for value in self.polarization_label)
+        basis = tuple(str(value) for value in self.basis)
+        if not count:
+            raise ValueError("ReceptorTable requires at least one receptor.")
+        if len(feed_id) != count or len(polarization_label) != count or len(basis) != count:
+            raise ValueError("ReceptorTable fields must contain one value per receptor.")
+        if np.any(station_index < 0):
+            raise ValueError("ReceptorTable station_index values must be non-negative.")
+        if any(not value for value in feed_id):
+            raise ValueError("ReceptorTable feed_id values must be non-empty.")
+        if any(not value for value in polarization_label):
+            raise ValueError("ReceptorTable polarization_label values must be non-empty.")
+        if any(not value for value in basis):
+            raise ValueError("ReceptorTable basis values must be non-empty.")
+        station_feed_pairs = tuple(zip(station_index.tolist(), feed_id))
+        if len(set(station_feed_pairs)) != count:
+            raise ValueError("ReceptorTable station/feed pairs must be unique.")
+
+        object.__setattr__(self, "station_index", station_index)
+        object.__setattr__(self, "feed_id", feed_id)
+        object.__setattr__(self, "polarization_label", polarization_label)
+        object.__setattr__(self, "basis", basis)
+
+    @property
+    def count(self):
+        """Return the number of station-local receptor signal paths."""
+
+        return len(self.station_index)
+
+    @classmethod
+    def from_station_labels(cls, station_count, labels, basis):
+        """Create identical labelled receptors for every station.
+
+        This is a convenience constructor for standard all-circular or
+        all-linear arrays. More general arrays should construct a table
+        directly with station-local ``feed_id`` values.
+        """
+
+        if not isinstance(station_count, (int, np.integer)) or station_count <= 0:
+            raise ValueError("station_count must be a positive integer.")
+        labels = tuple(str(value) for value in labels)
+        if not labels or len(set(labels)) != len(labels) or any(not value for value in labels):
+            raise ValueError("labels must contain distinct non-empty values.")
+        return cls(
+            station_index=np.repeat(np.arange(station_count, dtype=np.intp), len(labels)),
+            feed_id=labels * station_count,
+            polarization_label=labels * station_count,
+            basis=(str(basis),) * (station_count * len(labels)),
+        )
+
+    def index_for(self, station_index, polarization_label):
+        """Return the unique receptor index for a station and label."""
+
+        matches = np.flatnonzero(
+            (self.station_index == station_index)
+            & (np.asarray(self.polarization_label, dtype=object) == str(polarization_label))
+        )
+        if len(matches) != 1:
+            raise ValueError(
+                "Expected exactly one {0!r} receptor at station index {1}.".format(
+                    polarization_label,
+                    station_index,
+                )
+            )
+        return int(matches[0])
+
+
+@dataclass(frozen=True)
+class CorrelationProductTable:
+    """Ordered pairs of receptor IDs that define stored correlations."""
+
+    receptor1_id: np.ndarray
+    receptor2_id: np.ndarray
+
+    def __post_init__(self):
+        receptor1_id = _integer_array(self.receptor1_id, "receptor1_id")
+        receptor2_id = _integer_array(self.receptor2_id, "receptor2_id")
+        if receptor1_id.ndim != 1 or receptor2_id.ndim != 1 or receptor1_id.shape != receptor2_id.shape:
+            raise ValueError("Correlation product receptor IDs must be matching one-dimensional arrays.")
+        if np.any(receptor1_id < 0) or np.any(receptor2_id < 0):
+            raise ValueError("Correlation product receptor IDs must be non-negative.")
+        pairs = tuple(zip(receptor1_id.tolist(), receptor2_id.tolist()))
+        if len(set(pairs)) != len(pairs):
+            raise ValueError("Correlation product receptor pairs must be unique.")
+        object.__setattr__(self, "receptor1_id", receptor1_id)
+        object.__setattr__(self, "receptor2_id", receptor2_id)
+
+    @property
+    def count(self):
+        """Return the number of distinct correlation-product definitions."""
+
+        return len(self.receptor1_id)
+
+
+def standard_products_for_rows(receptors, antenna1, antenna2, product_labels):
+    """Build explicit receptor-pair products for standard labelled rows.
+
+    ``product_labels`` supplies ordered two-character correlation labels, such
+    as ``("RR", "LL", "RL", "LR")``. The returned product table contains
+    each unique station/receptor pair once, while ``row_product_id`` maps every
+    input row to the relevant ordered product IDs.
+    """
+
+    if not isinstance(receptors, ReceptorTable):
+        raise TypeError("receptors must be a ReceptorTable.")
+    antenna1 = _integer_array(antenna1, "antenna1")
+    antenna2 = _integer_array(antenna2, "antenna2")
+    if antenna1.ndim != 1 or antenna2.shape != antenna1.shape:
+        raise ValueError("antenna1 and antenna2 must be matching one-dimensional arrays.")
+    product_labels = tuple(str(value) for value in product_labels)
+    if not product_labels or any(len(value) != 2 for value in product_labels):
+        raise ValueError("product_labels must contain non-empty two-label products.")
+
+    product_id_by_pair = {}
+    first_receptor = []
+    second_receptor = []
+    row_product_id = np.empty((len(antenna1), len(product_labels)), dtype=np.intp)
+    for row, (station1, station2) in enumerate(zip(antenna1, antenna2)):
+        for slot, label in enumerate(product_labels):
+            receptor1 = receptors.index_for(int(station1), label[0])
+            receptor2 = receptors.index_for(int(station2), label[1])
+            pair = (receptor1, receptor2)
+            product_id = product_id_by_pair.get(pair)
+            if product_id is None:
+                product_id = len(first_receptor)
+                product_id_by_pair[pair] = product_id
+                first_receptor.append(receptor1)
+                second_receptor.append(receptor2)
+            row_product_id[row, slot] = product_id
+    return (
+        CorrelationProductTable(
+            receptor1_id=np.asarray(first_receptor, dtype=np.intp),
+            receptor2_id=np.asarray(second_receptor, dtype=np.intp),
+        ),
+        row_product_id,
+    )
+
+
+@dataclass(frozen=True)
+class VisibilityDataset:
+    """Native visibility data with explicit station-receptor correlations.
+
+    ``visibilities``, ``sigma_jy``, and ``flags`` have shape ``(row, channel,
+    product_slot)``. ``row_product_id`` maps each populated product slot to an
+    ordered receptor pair in ``correlation_products``. A value of ``-1`` marks
+    padding introduced by the dense in-memory representation; padding is
+    always flagged and is never written to a FITS-EHT archive.
     """
 
     stations: StationTable
+    receptors: ReceptorTable
+    correlation_products: CorrelationProductTable
     time_mjd: np.ndarray
     integration_time_s: np.ndarray
     antenna1: np.ndarray
@@ -157,10 +312,9 @@ class VisibilityDataset:
     channel_frequency_hz: np.ndarray
     channel_bandwidth_hz: np.ndarray
     spectral_window_id: np.ndarray
-    correlation_layouts: tuple[tuple[str, str, str, str], ...]
-    row_layout_id: np.ndarray
+    row_product_id: np.ndarray
     visibilities: np.ndarray
-    weights: np.ndarray
+    sigma_jy: np.ndarray
     flags: np.ndarray
     source: str
     ra_hours: float
@@ -176,6 +330,10 @@ class VisibilityDataset:
     def __post_init__(self):
         if not isinstance(self.stations, StationTable):
             raise TypeError("stations must be a StationTable.")
+        if not isinstance(self.receptors, ReceptorTable):
+            raise TypeError("receptors must be a ReceptorTable.")
+        if not isinstance(self.correlation_products, CorrelationProductTable):
+            raise TypeError("correlation_products must be a CorrelationProductTable.")
 
         time_mjd = _readonly_array(self.time_mjd, dtype=float)
         integration_time_s = _readonly_array(self.integration_time_s, dtype=float)
@@ -187,28 +345,33 @@ class VisibilityDataset:
         channel_frequency_hz = _readonly_array(self.channel_frequency_hz, dtype=float)
         channel_bandwidth_hz = _readonly_array(self.channel_bandwidth_hz, dtype=float)
         spectral_window_id = _integer_array(self.spectral_window_id, "spectral_window_id")
-        row_layout_id = _integer_array(self.row_layout_id, "row_layout_id")
+        row_product_id = _integer_array(self.row_product_id, "row_product_id")
         visibilities = _readonly_array(self.visibilities, dtype=complex)
-        weights = _readonly_array(self.weights, dtype=float)
+        sigma_jy = _readonly_array(self.sigma_jy, dtype=float)
         flags = _readonly_array(self.flags, dtype=bool)
 
         row_count = len(time_mjd)
         channel_count = len(channel_frequency_hz)
+        if row_product_id.ndim != 2 or row_product_id.shape[0] != row_count:
+            raise ValueError("row_product_id must have shape (row, product_slot).")
+        product_slot_count = row_product_id.shape[1]
+        if row_count and product_slot_count == 0:
+            raise ValueError("Visibility rows require at least one product slot.")
         for name, values in (
             ("integration_time_s", integration_time_s),
             ("antenna1", antenna1),
             ("antenna2", antenna2),
             ("tau1", tau1),
             ("tau2", tau2),
-            ("row_layout_id", row_layout_id),
         ):
             _require_shape(values, (row_count,), name)
         _require_shape(uvw_m, (row_count, 3), "uvw_m")
         _require_shape(channel_bandwidth_hz, (channel_count,), "channel_bandwidth_hz")
         _require_shape(spectral_window_id, (channel_count,), "spectral_window_id")
-        _require_shape(visibilities, (row_count, channel_count, 4), "visibilities")
-        _require_shape(weights, (row_count, channel_count, 4), "weights")
-        _require_shape(flags, (row_count, channel_count, 4), "flags")
+        data_shape = (row_count, channel_count, product_slot_count)
+        _require_shape(visibilities, data_shape, "visibilities")
+        _require_shape(sigma_jy, data_shape, "sigma_jy")
+        _require_shape(flags, data_shape, "flags")
 
         for name, values in (
             ("time_mjd", time_mjd),
@@ -218,20 +381,15 @@ class VisibilityDataset:
             ("tau2", tau2),
             ("channel_frequency_hz", channel_frequency_hz),
             ("channel_bandwidth_hz", channel_bandwidth_hz),
-            ("weights", weights),
         ):
             _require_finite(values, name)
-        unflagged = ~flags
-        if not np.all(np.isfinite(visibilities[unflagged])):
-            raise ValueError("Unflagged visibilities must be finite.")
         if np.any(integration_time_s <= 0.0):
             raise ValueError("integration_time_s must be positive.")
         if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
             raise ValueError("tau1 and tau2 must be non-negative.")
         if np.any(channel_frequency_hz <= 0.0) or np.any(channel_bandwidth_hz <= 0.0):
             raise ValueError("Channel frequencies and bandwidths must be positive.")
-        if np.any(weights < 0.0) or np.any(weights[unflagged] == 0.0):
-            raise ValueError("Unflagged visibility weights must be positive.")
+
         station_count = len(self.stations.names)
         if np.any(antenna1 < 0) or np.any(antenna1 >= station_count):
             raise ValueError("antenna1 contains an out-of-range station index.")
@@ -239,19 +397,47 @@ class VisibilityDataset:
             raise ValueError("antenna2 contains an out-of-range station index.")
         if np.any(antenna1 == antenna2):
             raise ValueError("Visibility rows must use two distinct stations.")
+        if np.any(self.receptors.station_index >= station_count):
+            raise ValueError("ReceptorTable references an out-of-range station index.")
 
-        layouts = tuple(tuple(str(product) for product in layout) for layout in self.correlation_layouts)
-        if not layouts:
-            raise ValueError("At least one correlation layout is required.")
-        if len(set(layouts)) != len(layouts):
-            raise ValueError("Correlation layouts must be unique.")
-        for layout in layouts:
-            if len(layout) != 4 or len(set(layout)) != 4:
-                raise ValueError("Every correlation layout must contain four distinct products.")
-            if any(product not in _VALID_CORRELATION_PRODUCTS for product in layout):
-                raise ValueError("Correlation layouts contain an unsupported product.")
-        if np.any(row_layout_id < 0) or np.any(row_layout_id >= len(layouts)):
-            raise ValueError("row_layout_id contains an out-of-range layout index.")
+        product_count = self.correlation_products.count
+        if np.any(row_product_id < -1) or np.any(row_product_id >= product_count):
+            raise ValueError("row_product_id contains an out-of-range product index.")
+        if product_count and (
+            np.any(self.correlation_products.receptor1_id >= self.receptors.count)
+            or np.any(self.correlation_products.receptor2_id >= self.receptors.count)
+        ):
+            raise ValueError("Correlation products reference an out-of-range receptor index.")
+
+        populated_slots = row_product_id >= 0
+        if row_count and np.any(np.sum(populated_slots, axis=1) == 0):
+            raise ValueError("Every visibility row must contain at least one correlation product.")
+        for row, product_ids in enumerate(row_product_id):
+            product_ids = product_ids[product_ids >= 0]
+            if len(set(product_ids.tolist())) != len(product_ids):
+                raise ValueError("A visibility row cannot repeat a correlation product.")
+            if len(product_ids):
+                product_receptors1 = self.correlation_products.receptor1_id[product_ids]
+                product_receptors2 = self.correlation_products.receptor2_id[product_ids]
+                if not np.all(self.receptors.station_index[product_receptors1] == antenna1[row]):
+                    raise ValueError("Correlation product first receptors must belong to antenna1.")
+                if not np.all(self.receptors.station_index[product_receptors2] == antenna2[row]):
+                    raise ValueError("Correlation product second receptors must belong to antenna2.")
+
+        sample_present = np.broadcast_to(populated_slots[:, np.newaxis, :], data_shape)
+        if np.any(~flags[~sample_present]):
+            raise ValueError("Unused product slots must be flagged.")
+        if not np.all(np.isnan(sigma_jy[~sample_present])):
+            raise ValueError("Unused product slots must have NaN sigma_jy values.")
+        unflagged = sample_present & ~flags
+        unflagged_sigma = sigma_jy[unflagged]
+        if not np.all(np.isfinite(unflagged_sigma)) or np.any(unflagged_sigma <= 0.0):
+            raise ValueError("Unflagged visibility sigma_jy values must be finite and positive.")
+        flagged_sigma = sigma_jy[sample_present & flags]
+        if np.any(np.isinf(flagged_sigma)) or np.any(flagged_sigma <= 0.0):
+            raise ValueError("Flagged visibility sigma_jy values must be positive or NaN.")
+        if not np.all(np.isfinite(visibilities[unflagged])):
+            raise ValueError("Unflagged visibilities must be finite.")
 
         scan_start_mjd, scan_stop_mjd = _validate_scans(
             self.scan_start_mjd,
@@ -271,10 +457,9 @@ class VisibilityDataset:
         object.__setattr__(self, "channel_frequency_hz", channel_frequency_hz)
         object.__setattr__(self, "channel_bandwidth_hz", channel_bandwidth_hz)
         object.__setattr__(self, "spectral_window_id", spectral_window_id)
-        object.__setattr__(self, "correlation_layouts", layouts)
-        object.__setattr__(self, "row_layout_id", row_layout_id)
+        object.__setattr__(self, "row_product_id", row_product_id)
         object.__setattr__(self, "visibilities", visibilities)
-        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "sigma_jy", sigma_jy)
         object.__setattr__(self, "flags", flags)
         object.__setattr__(self, "source", str(self.source))
         object.__setattr__(self, "ra_hours", float(self.ra_hours))
@@ -293,6 +478,85 @@ class VisibilityDataset:
         """Return the number of spectral channels."""
 
         return len(self.channel_frequency_hz)
+
+    @property
+    def product_slot_count(self):
+        """Return the dense in-memory product-axis width."""
+
+        return self.row_product_id.shape[1]
+
+    @property
+    def sample_present(self):
+        """Return a mask for populated, non-padding visibility samples."""
+
+        return np.broadcast_to(
+            self.row_product_id[:, np.newaxis, :] >= 0,
+            self.visibilities.shape,
+        )
+
+    def product_slots(self, product_labels):
+        """Return per-row product slots for an exact labelled product set.
+
+        This is intentionally strict. Boundary adapters that require standard
+        circular or linear data must reject extra, missing, or ambiguous
+        receptor products instead of silently dropping or relabelling them.
+        """
+
+        product_labels = tuple(str(value) for value in product_labels)
+        if not product_labels or len(set(product_labels)) != len(product_labels):
+            raise ValueError("product_labels must contain distinct labels.")
+        product_names = np.asarray(
+            tuple(
+                self.receptors.polarization_label[first]
+                + self.receptors.polarization_label[second]
+                for first, second in zip(
+                    self.correlation_products.receptor1_id,
+                    self.correlation_products.receptor2_id,
+                )
+            ),
+            dtype=object,
+        )
+        output = np.empty((self.row_count, len(product_labels)), dtype=np.intp)
+        expected = set(product_labels)
+        for row, product_ids in enumerate(self.row_product_id):
+            slots = np.flatnonzero(product_ids >= 0)
+            labels = tuple(product_names[product_ids[slots]])
+            if len(labels) != len(product_labels) or set(labels) != expected:
+                raise ValueError(
+                    "Dataset rows do not contain exactly the required correlation products: {0}.".format(
+                        ", ".join(product_labels)
+                    )
+                )
+            for destination, label in enumerate(product_labels):
+                output[row, destination] = slots[labels.index(label)]
+        return output
+
+    def circular_product_slots(self):
+        """Return slots holding RR, LL, RL, and LR for every row."""
+
+        return self._standard_product_slots(CIRCULAR_PRODUCT_LABELS, "CIRCULAR")
+
+    def linear_product_slots(self):
+        """Return slots holding XX, YY, XY, and YX for every row."""
+
+        return self._standard_product_slots(LINEAR_PRODUCT_LABELS, "LINEAR")
+
+    def _standard_product_slots(self, product_labels, expected_basis):
+        slots = self.product_slots(product_labels)
+        for row, row_slots in enumerate(slots):
+            product_ids = self.row_product_id[row, row_slots]
+            receptor_ids = np.concatenate((
+                self.correlation_products.receptor1_id[product_ids],
+                self.correlation_products.receptor2_id[product_ids],
+            ))
+            bases = np.asarray(self.receptors.basis, dtype=object)[receptor_ids]
+            if not np.all(np.char.upper(bases.astype(str)) == expected_basis):
+                raise ValueError(
+                    "Standard {0} product export requires {0} receptor basis metadata.".format(
+                        expected_basis.lower()
+                    )
+                )
+        return slots
 
     def select_rows(self, row_mask):
         """Return a dataset containing the selected visibility rows."""
@@ -321,15 +585,15 @@ class VisibilityDataset:
             uvw_m=self.uvw_m[row_indices],
             tau1=self.tau1[row_indices],
             tau2=self.tau2[row_indices],
-            row_layout_id=self.row_layout_id[row_indices],
+            row_product_id=self.row_product_id[row_indices],
             visibilities=self.visibilities[row_indices],
-            weights=self.weights[row_indices],
+            sigma_jy=self.sigma_jy[row_indices],
             flags=self.flags[row_indices],
         )
 
     @classmethod
     def from_ehtim_obsdata(cls, obs):
-        """Convert a standard ``ehtim.Obsdata`` object to an internal dataset."""
+        """Convert a standard ``ehtim.Obsdata`` object to a native dataset."""
 
         import ehtim as eh
 
@@ -341,11 +605,11 @@ class VisibilityDataset:
         if working.polrep != "circ":
             working = working.switch_polrep("circ")
 
-        sigma = np.stack(
+        sigma_jy = np.stack(
             (working.data["rrsigma"], working.data["llsigma"], working.data["rlsigma"], working.data["lrsigma"]),
             axis=1,
         )
-        if not np.all(np.isfinite(sigma)) or np.any(sigma <= 0.0):
+        if not np.all(np.isfinite(sigma_jy)) or np.any(sigma_jy <= 0.0):
             raise ValueError("ehtim Obsdata sigma values must be finite and positive.")
         scan_start_mjd = None
         scan_stop_mjd = None
@@ -359,32 +623,46 @@ class VisibilityDataset:
         station_index = {
             str(name): index for index, name in enumerate(working.tarr["site"])
         }
+        antenna1 = np.fromiter(
+            (station_index[str(name)] for name in working.data["t1"]),
+            dtype=np.intp,
+        )
+        antenna2 = np.fromiter(
+            (station_index[str(name)] for name in working.data["t2"]),
+            dtype=np.intp,
+        )
+        receptors = ReceptorTable.from_station_labels(
+            len(working.tarr),
+            ("R", "L"),
+            "CIRCULAR",
+        )
+        correlation_products, row_product_id = standard_products_for_rows(
+            receptors,
+            antenna1,
+            antenna2,
+            CIRCULAR_PRODUCT_LABELS,
+        )
         wavelength = SPEED_OF_LIGHT.to_value("m / s") / working.rf
         return cls(
             stations=StationTable.from_ehtim_tarr(working.tarr),
+            receptors=receptors,
+            correlation_products=correlation_products,
             time_mjd=working.mjd + (working.data["time"] / 24.0),
             integration_time_s=working.data["tint"],
-            antenna1=np.fromiter(
-                (station_index[str(name)] for name in working.data["t1"]),
-                dtype=np.intp,
-            ),
-            antenna2=np.fromiter(
-                (station_index[str(name)] for name in working.data["t2"]),
-                dtype=np.intp,
-            ),
+            antenna1=antenna1,
+            antenna2=antenna2,
             uvw_m=np.column_stack((working.data["u"] * wavelength, working.data["v"] * wavelength, np.zeros(len(working.data)))),
             tau1=working.data["tau1"],
             tau2=working.data["tau2"],
             channel_frequency_hz=np.array((working.rf,)),
             channel_bandwidth_hz=np.array((working.bw,)),
             spectral_window_id=np.array((0,), dtype=np.intp),
-            correlation_layouts=(CIRCULAR_CORRELATIONS,),
-            row_layout_id=np.zeros(len(working.data), dtype=np.intp),
+            row_product_id=row_product_id,
             visibilities=np.stack(
                 (working.data["rrvis"], working.data["llvis"], working.data["rlvis"], working.data["lrvis"]),
                 axis=1,
             )[:, np.newaxis, :],
-            weights=(1.0 / np.square(sigma))[:, np.newaxis, :],
+            sigma_jy=sigma_jy[:, np.newaxis, :],
             flags=np.zeros((len(working.data), 1, 4), dtype=bool),
             source=working.source,
             ra_hours=working.ra,
@@ -403,9 +681,9 @@ class VisibilityDataset:
 
         if self.channel_count != 1:
             raise ValueError("ehtim Obsdata output requires exactly one spectral channel.")
-        if any(self.correlation_layouts[index] != CIRCULAR_CORRELATIONS for index in self.row_layout_id):
-            raise ValueError("ehtim Obsdata output requires circular RR, LL, RL, LR correlations.")
-        if np.any(self.flags):
+        circular_slots = self.circular_product_slots()
+        row_index = np.arange(self.row_count)[:, np.newaxis]
+        if np.any(self.flags[row_index, 0, circular_slots]):
             raise ValueError("ehtim Obsdata output cannot represent flagged visibility samples.")
         if not self.row_count:
             raise ValueError("ehtim Obsdata output requires at least one visibility row.")
@@ -424,14 +702,16 @@ class VisibilityDataset:
         wavelength = SPEED_OF_LIGHT.to_value("m / s") / self.channel_frequency_hz[0]
         data["u"] = self.uvw_m[:, 0] / wavelength
         data["v"] = self.uvw_m[:, 1] / wavelength
-        data["rrvis"] = self.visibilities[:, 0, 0]
-        data["llvis"] = self.visibilities[:, 0, 1]
-        data["rlvis"] = self.visibilities[:, 0, 2]
-        data["lrvis"] = self.visibilities[:, 0, 3]
-        data["rrsigma"] = 1.0 / np.sqrt(self.weights[:, 0, 0])
-        data["llsigma"] = 1.0 / np.sqrt(self.weights[:, 0, 1])
-        data["rlsigma"] = 1.0 / np.sqrt(self.weights[:, 0, 2])
-        data["lrsigma"] = 1.0 / np.sqrt(self.weights[:, 0, 3])
+        circular = self.visibilities[row_index, 0, circular_slots]
+        sigma_jy = self.sigma_jy[row_index, 0, circular_slots]
+        data["rrvis"] = circular[:, 0]
+        data["llvis"] = circular[:, 1]
+        data["rlvis"] = circular[:, 2]
+        data["lrvis"] = circular[:, 3]
+        data["rrsigma"] = sigma_jy[:, 0]
+        data["llsigma"] = sigma_jy[:, 1]
+        data["rlsigma"] = sigma_jy[:, 2]
+        data["lrsigma"] = sigma_jy[:, 3]
 
         scantable = None
         if self.scan_start_mjd is not None:
@@ -472,6 +752,21 @@ class VisibilityDataset:
         from ngehtsim.obs.uvfits import write_uvfits
 
         return write_uvfits(self, path, overwrite=overwrite)
+
+    @classmethod
+    def from_ehtfits(cls, path):
+        """Read a lossless native FITS-EHT visibility dataset."""
+
+        from ngehtsim.obs.ehtfits import read_ehtfits
+
+        return read_ehtfits(path)
+
+    def to_ehtfits(self, path, overwrite=False):
+        """Write this dataset as a lossless native FITS-EHT archive."""
+
+        from ngehtsim.obs.ehtfits import write_ehtfits
+
+        return write_ehtfits(self, path, overwrite=overwrite)
 
 
 def _validate_scans(scan_start_mjd, scan_stop_mjd):

--- a/tests/test_ehtfits.py
+++ b/tests/test_ehtfits.py
@@ -1,0 +1,145 @@
+"""Tests for lossless FITS-EHT native visibility interchange."""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from ngehtsim.obs.ehtfits import EhtfitsError, FORMAT_NAME, FORMAT_VERSION, read_ehtfits
+from ngehtsim.obs.visibility_dataset import (
+    CorrelationProductTable,
+    ReceptorTable,
+    StationTable,
+    VisibilityDataset,
+)
+
+
+def _stations():
+    return StationTable(
+        names=("STA1", "STA2", "STA3"),
+        position_itrs_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0))),
+        sefd_r_jy=np.array((100.0, 110.0, 120.0)),
+        sefd_l_jy=np.array((101.0, 111.0, 121.0)),
+        leakage_r=np.array((0.01j, 0.02j, 0.03j)),
+        leakage_l=np.array((0.01, 0.02, 0.03)),
+        feed_rotation_par=np.array((1.0, 0.0, 1.0)),
+        feed_rotation_elev=np.zeros(3),
+        feed_rotation_offset_deg=np.array((0.0, 15.0, -30.0)),
+    )
+
+
+def _mixed_feed_dataset():
+    """Two-by-two and two-by-three rows, with an unknown flagged sigma."""
+
+    receptors = ReceptorTable(
+        station_index=np.array((0, 0, 1, 1, 2, 2, 2)),
+        feed_id=("1", "2", "1", "2", "1", "2", "3"),
+        polarization_label=("R", "L", "X", "Y", "R", "X", "Y"),
+        basis=("CIRCULAR", "CIRCULAR", "LINEAR", "LINEAR", "CIRCULAR", "LINEAR", "LINEAR"),
+    )
+    products = CorrelationProductTable(
+        receptor1_id=np.array((0, 0, 1, 1, 2, 2, 2, 3, 3, 3)),
+        receptor2_id=np.array((2, 3, 2, 3, 4, 5, 6, 4, 5, 6)),
+    )
+    row_product_id = np.array(((0, 1, 2, 3, -1, -1), (4, 5, 6, 7, 8, 9)))
+    visibilities = np.arange(24, dtype=float).reshape(2, 2, 6).astype(complex)
+    visibilities += 1.0j * (100.0 + visibilities)
+    sigma_jy = np.full((2, 2, 6), 0.5)
+    flags = np.zeros((2, 2, 6), dtype=bool)
+    visibilities[0, :, 4:] = np.nan + 1.0j * np.nan
+    sigma_jy[0, :, 4:] = np.nan
+    flags[0, :, 4:] = True
+    visibilities[1, 1, 5] = np.nan + 1.0j * np.nan
+    sigma_jy[1, 1, 5] = np.nan
+    flags[1, 1, 5] = True
+    return VisibilityDataset(
+        stations=_stations(),
+        receptors=receptors,
+        correlation_products=products,
+        time_mjd=np.array((60000.0, 60000.01)),
+        integration_time_s=np.array((10.0, 20.0)),
+        antenna1=np.array((0, 1)),
+        antenna2=np.array((1, 2)),
+        uvw_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))),
+        tau1=np.array((0.1, 0.2)),
+        tau2=np.array((0.3, 0.4)),
+        channel_frequency_hz=np.array((230.0e9, 230.1e9)),
+        channel_bandwidth_hz=np.array((2.0e9, 2.0e9)),
+        spectral_window_id=np.array((0, 0)),
+        row_product_id=row_product_id,
+        visibilities=visibilities,
+        sigma_jy=sigma_jy,
+        flags=flags,
+        source="M87",
+        ra_hours=12.5,
+        dec_degrees=12.4,
+        ampcal=False,
+        phasecal=False,
+        opacitycal=True,
+        dcal=False,
+        frcal=False,
+        scan_start_mjd=np.array((59999.999,)),
+        scan_stop_mjd=np.array((60000.011,)),
+    )
+
+
+def test_fits_eht_round_trip_preserves_mixed_receptor_data(tmp_path):
+    original = _mixed_feed_dataset()
+    path = tmp_path / "mixed.ehtfits"
+
+    original.to_ehtfits(path)
+    restored = VisibilityDataset.from_ehtfits(path)
+
+    assert restored.stations.names == original.stations.names
+    assert np.array_equal(restored.receptors.station_index, original.receptors.station_index)
+    assert restored.receptors.feed_id == original.receptors.feed_id
+    assert restored.receptors.polarization_label == original.receptors.polarization_label
+    assert restored.receptors.basis == original.receptors.basis
+    assert np.array_equal(restored.correlation_products.receptor1_id, original.correlation_products.receptor1_id)
+    assert np.array_equal(restored.correlation_products.receptor2_id, original.correlation_products.receptor2_id)
+    assert np.array_equal(restored.row_product_id, original.row_product_id)
+    assert np.allclose(restored.visibilities, original.visibilities, equal_nan=True)
+    assert np.allclose(restored.sigma_jy, original.sigma_jy, equal_nan=True)
+    assert np.array_equal(restored.flags, original.flags)
+    assert np.allclose(restored.channel_frequency_hz, original.channel_frequency_hz)
+    assert np.allclose(restored.scan_start_mjd, original.scan_start_mjd)
+    assert restored.ampcal is False
+    assert restored.phasecal is False
+    assert restored.opacitycal is True
+    assert restored.dcal is False
+    assert restored.frcal is False
+
+
+def test_fits_eht_uses_explicit_receptor_product_payloads_and_sigmas(tmp_path):
+    path = tmp_path / "mixed.ehtfits"
+    _mixed_feed_dataset().to_ehtfits(path)
+
+    with fits.open(path, memmap=False) as hdul:
+        assert hdul[0].header["EHTFMT"] == FORMAT_NAME
+        assert hdul[0].header["EHTVER"] == FORMAT_VERSION
+        assert [hdu.name for hdu in hdul] == [
+            "PRIMARY",
+            "ARRAY_GEOMETRY",
+            "FREQUENCY",
+            "SOURCE",
+            "EHT_RECEPTORS",
+            "EHT_CORRELATION_PRODUCTS",
+            "EHT_CHANNELS",
+            "EHT_SCANS",
+            "UV_DATA",
+        ]
+        data = hdul["UV_DATA"].data
+        assert "WEIGHT" not in data.names
+        assert hdul["UV_DATA"].columns["SIGMA"].unit == "JY"
+        assert np.array_equal(data["PRODUCT_ID"][0], np.array((1, 2, 3, 4)))
+        assert np.array_equal(data["PRODUCT_ID"][1], np.array((5, 6, 7, 8, 9, 10)))
+        assert data["NPRODUCT"].tolist() == [4, 6]
+        assert len(data["VISIBILITY"][0]) == 16
+        assert len(data["SIGMA"][1]) == 12
+
+
+def test_fits_eht_reader_rejects_non_fits_eht_input(tmp_path):
+    path = tmp_path / "not-ehtfits.fits"
+    fits.PrimaryHDU().writeto(path)
+
+    with pytest.raises(EhtfitsError, match="not a FITS-EHT"):
+        read_ehtfits(path)

--- a/tests/test_fringe_selection.py
+++ b/tests/test_fringe_selection.py
@@ -333,12 +333,16 @@ def test_native_fringegroups_uses_parallel_hand_weights_and_shared_selector():
             np.zeros(selection_rows.row_count, dtype=complex),
             np.zeros(selection_rows.row_count, dtype=complex),
         ))[:, np.newaxis, :],
-        weights=np.column_stack((
-            1.0 / np.square(selection_rows.rr_sigma),
-            1.0 / np.square(selection_rows.ll_sigma),
+        sigma_jy=np.column_stack((
+            selection_rows.rr_sigma,
+            selection_rows.ll_sigma,
             np.ones(selection_rows.row_count),
             np.ones(selection_rows.row_count),
         ))[:, np.newaxis, :],
+        circular_product_slots=lambda: np.tile(
+            np.arange(4, dtype=np.intp),
+            (selection_rows.row_count, 1),
+        ),
     )
 
     class Generator:

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -23,6 +23,7 @@ SETTINGS = {
     "t_rest": 1200.0,
     "fringe_finder": ["naive", 0.0],
     "random_seed": 1,
+    "ttype": "direct",
 }
 
 
@@ -253,8 +254,8 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
         flagsun=False,
     )
 
-    clean_sigma = 1.0 / np.sqrt(clean.dataset.weights)
-    noisy_sigma = 1.0 / np.sqrt(noisy.dataset.weights)
+    clean_sigma = clean.dataset.sigma_jy
+    noisy_sigma = noisy.dataset.sigma_jy
     assert np.allclose(noisy_sigma, clean_sigma)
     assert np.allclose(
         noisy.dataset.visibilities - clean.dataset.visibilities,
@@ -341,11 +342,12 @@ def test_native_circular_corruptions_match_legacy_generator_without_noise(monkey
         "flagday": False,
         "flagsun": False,
     }
-    native_generator = og.obs_generator(settings=SETTINGS)
+    direct_settings = {**SETTINGS, "ttype": "direct"}
+    native_generator = og.obs_generator(settings=direct_settings)
     native_generator.rng = FixedRng()
     native = _native_corrupted_dataset(native_generator, _polarized_image(), **kwargs)
 
-    legacy_generator = og.obs_generator(settings=SETTINGS)
+    legacy_generator = og.obs_generator(settings=direct_settings)
     legacy_generator.rng = FixedRng()
     legacy_template = observation_geometry.ground_visibility_template(
         legacy_generator.arr,
@@ -363,7 +365,7 @@ def test_native_circular_corruptions_match_legacy_generator_without_noise(monkey
     legacy_order = _obsdata_row_order(legacy)
     native_names = np.asarray(unflagged.stations.names)
     native_visibilities = unflagged.visibilities[:, 0, :]
-    native_sigma = 1.0 / np.sqrt(unflagged.weights[:, 0, :])
+    native_sigma = unflagged.sigma_jy[:, 0, :]
     legacy_visibilities = np.column_stack((
         legacy.data["rrvis"],
         legacy.data["llvis"],
@@ -440,7 +442,7 @@ def test_native_circular_corruptions_do_not_require_obsdata_conversion(monkeypat
 
     assert isinstance(corrupted, VisibilityDataset)
     assert corrupted.opacitycal is False
-    assert np.all(np.isfinite(corrupted.weights))
+    assert np.all(np.isfinite(corrupted.sigma_jy))
 
 
 def test_native_circular_noise_uses_reported_sigmas():
@@ -473,8 +475,8 @@ def test_native_circular_noise_uses_reported_sigmas():
         flagsun=False,
     )
 
-    sigma = 1.0 / np.sqrt(noisy.weights)
-    assert np.allclose(noisy.weights, clean.weights)
+    sigma = noisy.sigma_jy
+    assert np.allclose(noisy.sigma_jy, clean.sigma_jy)
     assert np.allclose(noisy.visibilities - clean.visibilities, (1.0 + 1.0j) * sigma)
 
 

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -7,7 +7,7 @@ from ngehtsim.obs.obs_generator import obs_generator
 import ngehtsim.obs.observation_geometry as observation_geometry
 from ngehtsim.obs.obs_generator import make_array
 import ngehtsim.obs.source_models as source_models
-from ngehtsim.obs.visibility_dataset import CIRCULAR_CORRELATIONS, VisibilityDataset
+from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ def test_ground_visibility_template_preserves_legacy_visibility_rows(array_name)
 
     assert isinstance(template, VisibilityDataset)
     assert template.channel_count == 1
-    assert template.correlation_layouts == (CIRCULAR_CORRELATIONS,)
+    assert template.circular_product_slots().shape == (template.row_count, 4)
     assert np.allclose(template.time_mjd, legacy.mjd + (legacy.data["time"] / 24.0))
     geometry = observation_geometry.ground_geometry(array, context)
     assert np.array_equal(template.antenna1, geometry.station1_indices)

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -732,7 +732,7 @@ def test_native_simulation_is_reproducible_with_a_fixed_seed():
     assert np.array_equal(first.dataset.time_mjd, second.dataset.time_mjd)
     assert np.array_equal(first.dataset.flags, second.dataset.flags)
     assert np.allclose(first.dataset.visibilities, second.dataset.visibilities)
-    assert np.allclose(first.dataset.weights, second.dataset.weights)
+    assert np.allclose(first.dataset.sigma_jy, second.dataset.sigma_jy)
 
 
 def test_native_simulation_retains_all_flagged_rows_and_exports_an_empty_obsdata():

--- a/tests/test_uvfits.py
+++ b/tests/test_uvfits.py
@@ -9,11 +9,13 @@ from astropy.io import fits
 
 from ngehtsim.obs.uvfits import UvfitsError, read_uvfits, write_uvfits
 from ngehtsim.obs.visibility_dataset import (
-    CIRCULAR_CORRELATIONS,
-    LINEAR_CIRCULAR_CORRELATIONS,
-    LINEAR_CORRELATIONS,
+    CIRCULAR_PRODUCT_LABELS,
+    CorrelationProductTable,
+    LINEAR_PRODUCT_LABELS,
+    ReceptorTable,
     StationTable,
     VisibilityDataset,
+    standard_products_for_rows,
 )
 
 
@@ -31,30 +33,46 @@ def _stations():
     )
 
 
-def _dataset(layout=CIRCULAR_CORRELATIONS):
+def _dataset(kind="circular"):
+    labels, basis = (
+        (CIRCULAR_PRODUCT_LABELS, "CIRCULAR")
+        if kind == "circular"
+        else (LINEAR_PRODUCT_LABELS, "LINEAR")
+    )
+    antenna1 = np.array((0, 1))
+    antenna2 = np.array((1, 2))
+    receptor_labels = ("R", "L") if kind == "circular" else ("X", "Y")
+    receptors = ReceptorTable.from_station_labels(3, receptor_labels, basis)
+    products, row_product_id = standard_products_for_rows(
+        receptors,
+        antenna1,
+        antenna2,
+        labels,
+    )
     visibilities = np.arange(32, dtype=float).reshape(2, 4, 4)
     visibilities = visibilities + 1.0j * (100.0 + visibilities)
-    weights = np.full((2, 4, 4), 4.0)
+    sigma_jy = np.full((2, 4, 4), 0.5)
     flags = np.zeros((2, 4, 4), dtype=bool)
     flags[1, 3, 2] = True
-    weights[1, 3, 2] = 0.0
+    sigma_jy[1, 3, 2] = np.nan
     visibilities[1, 3, 2] = 0.0
     return VisibilityDataset(
         stations=_stations(),
+        receptors=receptors,
+        correlation_products=products,
         time_mjd=np.array((60000.0, 60000.01)),
         integration_time_s=np.array((10.0, 20.0)),
-        antenna1=np.array((0, 1)),
-        antenna2=np.array((1, 2)),
+        antenna1=antenna1,
+        antenna2=antenna2,
         uvw_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))),
         tau1=np.array((0.1, 0.2)),
         tau2=np.array((0.3, 0.4)),
         channel_frequency_hz=np.array((230.0e9, 230.001e9, 231.0e9, 231.001e9)),
         channel_bandwidth_hz=np.full(4, 1.0e6),
         spectral_window_id=np.array((0, 0, 1, 1)),
-        correlation_layouts=(layout,),
-        row_layout_id=np.zeros(2, dtype=np.intp),
+        row_product_id=row_product_id,
         visibilities=visibilities,
-        weights=weights,
+        sigma_jy=sigma_jy,
         flags=flags,
         source="M87",
         ra_hours=12.5,
@@ -64,25 +82,24 @@ def _dataset(layout=CIRCULAR_CORRELATIONS):
     )
 
 
-@pytest.mark.parametrize("layout", (CIRCULAR_CORRELATIONS, LINEAR_CORRELATIONS))
-def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, layout):
-    original = _dataset(layout)
+@pytest.mark.parametrize("kind", ("circular", "linear"))
+def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, kind):
+    original = _dataset(kind)
     path = tmp_path / "native.uvfits"
 
     original.to_uvfits(path)
     with fits.open(path, memmap=False) as hdul:
         assert hdul[0].header["NAXIS4"] == 2
         assert hdul[0].header["NAXIS5"] == 2
-        assert hdul[0].header["CRVAL3"] == (-1.0 if layout == CIRCULAR_CORRELATIONS else -5.0)
+        assert hdul[0].header["CRVAL3"] == (-1.0 if kind == "circular" else -5.0)
         assert [hdu.name for hdu in hdul] == ["PRIMARY", "AIPS AN", "AIPS FQ", "AIPS NX"]
-        expected_feeds = ("R", "L") if layout == CIRCULAR_CORRELATIONS else ("X", "Y")
+        expected_feeds = ("R", "L") if kind == "circular" else ("X", "Y")
         assert tuple(hdul["AIPS AN"].data["POLTYA"][:1]) == (expected_feeds[0],)
         assert tuple(hdul["AIPS AN"].data["POLTYB"][:1]) == (expected_feeds[1],)
         assert np.allclose(hdul["AIPS FQ"].data["TOTAL BANDWIDTH"][0], [2.0e6, 2.0e6])
 
     restored = VisibilityDataset.from_uvfits(path)
 
-    assert restored.correlation_layouts == (layout,)
     assert np.allclose(restored.time_mjd, original.time_mjd)
     assert np.array_equal(restored.antenna1, original.antenna1)
     assert np.array_equal(restored.antenna2, original.antenna2)
@@ -91,20 +108,22 @@ def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, layout):
     assert np.allclose(restored.channel_bandwidth_hz, original.channel_bandwidth_hz)
     assert np.array_equal(restored.spectral_window_id, original.spectral_window_id)
     assert np.array_equal(restored.flags, original.flags)
-    assert np.allclose(restored.weights, original.weights)
+    assert np.allclose(restored.sigma_jy, original.sigma_jy, equal_nan=True)
     assert np.allclose(restored.visibilities, original.visibilities)
     assert np.allclose(restored.scan_start_mjd, original.scan_start_mjd)
     assert np.allclose(restored.scan_stop_mjd, original.scan_stop_mjd)
+    slots = restored.circular_product_slots() if kind == "circular" else restored.linear_product_slots()
+    assert slots.shape == (2, 4)
 
 
-def test_native_uvfits_reader_loads_the_checked_in_eht_2017_file_without_ehtim():
+def test_native_uvfits_reader_loads_checked_in_eht_2017_file_without_ehtim():
     path = "docs/source/EHT2017_tutorial/SR1_M87_2017_096_lo_hops_netcal_StokesI.uvfits"
 
     dataset = read_uvfits(path)
 
     assert dataset.row_count == 8645
     assert dataset.channel_count == 1
-    assert dataset.correlation_layouts == (CIRCULAR_CORRELATIONS,)
+    assert dataset.circular_product_slots().shape == (8645, 4)
     assert dataset.stations.names == ("AA", "AP", "AZ", "JC", "LM", "PV", "SM", "SR")
 
 
@@ -139,10 +158,22 @@ def test_native_uvfits_module_does_not_import_ehtim():
     assert result.returncode == 0, result.stderr
 
 
-def test_native_uvfits_writer_rejects_per_row_mixed_layouts(tmp_path):
+def test_native_uvfits_writer_rejects_mixed_receptor_products(tmp_path):
     original = _dataset()
+    receptors = ReceptorTable(
+        station_index=np.array((0, 0, 1, 1, 2, 2)),
+        feed_id=("R", "L", "X", "Y", "R", "L"),
+        polarization_label=("R", "L", "X", "Y", "R", "L"),
+        basis=("CIRCULAR", "CIRCULAR", "LINEAR", "LINEAR", "CIRCULAR", "CIRCULAR"),
+    )
+    products = CorrelationProductTable(
+        receptor1_id=np.array((0, 0, 1, 1, 2, 2, 3, 3)),
+        receptor2_id=np.array((2, 3, 2, 3, 4, 5, 4, 5)),
+    )
     mixed = VisibilityDataset(
         stations=original.stations,
+        receptors=receptors,
+        correlation_products=products,
         time_mjd=original.time_mjd,
         integration_time_s=original.integration_time_s,
         antenna1=original.antenna1,
@@ -153,15 +184,14 @@ def test_native_uvfits_writer_rejects_per_row_mixed_layouts(tmp_path):
         channel_frequency_hz=original.channel_frequency_hz,
         channel_bandwidth_hz=original.channel_bandwidth_hz,
         spectral_window_id=original.spectral_window_id,
-        correlation_layouts=(CIRCULAR_CORRELATIONS, LINEAR_CIRCULAR_CORRELATIONS),
-        row_layout_id=np.array((0, 1), dtype=np.intp),
+        row_product_id=np.array(((0, 1, 2, 3), (4, 5, 6, 7))),
         visibilities=original.visibilities,
-        weights=original.weights,
+        sigma_jy=original.sigma_jy,
         flags=original.flags,
         source=original.source,
         ra_hours=original.ra_hours,
         dec_degrees=original.dec_degrees,
     )
 
-    with pytest.raises(UvfitsError, match="per-row mixed"):
+    with pytest.raises(UvfitsError, match="requires exactly"):
         write_uvfits(mixed, tmp_path / "mixed.uvfits")

--- a/tests/test_visibility_dataset.py
+++ b/tests/test_visibility_dataset.py
@@ -1,13 +1,17 @@
-"""Tests for the internal visibility dataset and ehtim compatibility adapters."""
+"""Tests for native visibility data and optional ehtim adapters."""
+
+from dataclasses import replace
 
 import numpy as np
 import pytest
 
 from ngehtsim.obs.visibility_dataset import (
-    CIRCULAR_CORRELATIONS,
-    LINEAR_CIRCULAR_CORRELATIONS,
+    CIRCULAR_PRODUCT_LABELS,
+    CorrelationProductTable,
+    ReceptorTable,
     StationTable,
     VisibilityDataset,
+    standard_products_for_rows,
 )
 
 
@@ -25,23 +29,33 @@ def stations():
     )
 
 
-def dataset(**overrides):
+def circular_dataset(**overrides):
+    antenna1 = np.array((0, 1))
+    antenna2 = np.array((1, 2))
+    receptors = ReceptorTable.from_station_labels(3, ("R", "L"), "CIRCULAR")
+    products, row_product_id = standard_products_for_rows(
+        receptors,
+        antenna1,
+        antenna2,
+        CIRCULAR_PRODUCT_LABELS,
+    )
     values = {
         "stations": stations(),
+        "receptors": receptors,
+        "correlation_products": products,
         "time_mjd": np.array((60000.0, 60000.01)),
         "integration_time_s": np.array((10.0, 10.0)),
-        "antenna1": np.array((0, 1)),
-        "antenna2": np.array((1, 2)),
+        "antenna1": antenna1,
+        "antenna2": antenna2,
         "uvw_m": np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))),
         "tau1": np.array((0.1, 0.2)),
         "tau2": np.array((0.3, 0.4)),
         "channel_frequency_hz": np.array((230.0e9, 231.0e9)),
         "channel_bandwidth_hz": np.array((2.0e9, 2.0e9)),
         "spectral_window_id": np.array((0, 1)),
-        "correlation_layouts": (CIRCULAR_CORRELATIONS, LINEAR_CIRCULAR_CORRELATIONS),
-        "row_layout_id": np.array((0, 1)),
+        "row_product_id": row_product_id,
         "visibilities": np.ones((2, 2, 4), dtype=complex),
-        "weights": np.full((2, 2, 4), 4.0),
+        "sigma_jy": np.full((2, 2, 4), 0.5),
         "flags": np.zeros((2, 2, 4), dtype=bool),
         "source": "M87",
         "ra_hours": 12.5,
@@ -53,55 +67,88 @@ def dataset(**overrides):
     return VisibilityDataset(**values)
 
 
-def test_dataset_supports_mixed_layouts_and_multiple_channels():
-    data = dataset()
+def mixed_feed_dataset():
+    """Return a dataset with a two-by-two and a two-by-three baseline."""
+
+    receptor_table = ReceptorTable(
+        station_index=np.array((0, 0, 1, 1, 2, 2, 2)),
+        feed_id=("1", "2", "1", "2", "1", "2", "3"),
+        polarization_label=("R", "L", "X", "Y", "R", "X", "Y"),
+        basis=("CIRCULAR", "CIRCULAR", "LINEAR", "LINEAR", "CIRCULAR", "LINEAR", "LINEAR"),
+    )
+    products = CorrelationProductTable(
+        receptor1_id=np.array((0, 0, 1, 1, 2, 2, 2, 3, 3, 3)),
+        receptor2_id=np.array((2, 3, 2, 3, 4, 5, 6, 4, 5, 6)),
+    )
+    row_product_id = np.array(((0, 1, 2, 3, -1, -1), (4, 5, 6, 7, 8, 9)))
+    flags = np.zeros((2, 2, 6), dtype=bool)
+    flags[0, :, 4:] = True
+    sigma_jy = np.full((2, 2, 6), 0.5)
+    sigma_jy[0, :, 4:] = np.nan
+    visibilities = np.ones((2, 2, 6), dtype=complex)
+    visibilities[0, :, 4:] = np.nan + 1.0j * np.nan
+    return VisibilityDataset(
+        stations=stations(),
+        receptors=receptor_table,
+        correlation_products=products,
+        time_mjd=np.array((60000.0, 60000.01)),
+        integration_time_s=np.array((10.0, 10.0)),
+        antenna1=np.array((0, 1)),
+        antenna2=np.array((1, 2)),
+        uvw_m=np.array(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0))),
+        tau1=np.array((0.1, 0.2)),
+        tau2=np.array((0.3, 0.4)),
+        channel_frequency_hz=np.array((230.0e9, 231.0e9)),
+        channel_bandwidth_hz=np.array((2.0e9, 2.0e9)),
+        spectral_window_id=np.array((0, 1)),
+        row_product_id=row_product_id,
+        visibilities=visibilities,
+        sigma_jy=sigma_jy,
+        flags=flags,
+        source="M87",
+        ra_hours=12.5,
+        dec_degrees=12.4,
+    )
+
+
+def test_dataset_supports_mixed_receiver_counts_and_multiple_channels():
+    data = mixed_feed_dataset()
 
     assert data.row_count == 2
     assert data.channel_count == 2
-    assert data.correlation_layouts[data.row_layout_id[0]] == CIRCULAR_CORRELATIONS
-    assert data.correlation_layouts[data.row_layout_id[1]] == LINEAR_CIRCULAR_CORRELATIONS
+    assert data.product_slot_count == 6
+    assert np.array_equal(data.row_product_id[0], np.array((0, 1, 2, 3, -1, -1)))
+    assert np.array_equal(data.row_product_id[1], np.array((4, 5, 6, 7, 8, 9)))
+    assert np.all(data.flags[~data.sample_present])
+    assert np.all(np.isnan(data.sigma_jy[~data.sample_present]))
     assert not data.visibilities.flags.writeable
     assert not data.stations.position_itrs_m.flags.writeable
 
 
 def test_dataset_select_rows_preserves_selected_rows_and_metadata():
-    original = dataset()
+    original = mixed_feed_dataset()
 
     selected = original.select_rows(np.array((True, False)))
 
     assert selected.row_count == 1
     assert np.array_equal(selected.time_mjd, original.time_mjd[:1])
     assert np.array_equal(selected.uvw_m, original.uvw_m[:1])
-    assert np.array_equal(selected.visibilities, original.visibilities[:1])
-    assert np.array_equal(selected.weights, original.weights[:1])
+    assert np.array_equal(selected.row_product_id, original.row_product_id[:1])
+    assert np.array_equal(selected.visibilities, original.visibilities[:1], equal_nan=True)
+    assert np.array_equal(selected.sigma_jy, original.sigma_jy[:1], equal_nan=True)
     assert np.array_equal(selected.flags, original.flags[:1])
     assert selected.stations.names == original.stations.names
-    assert np.array_equal(selected.scan_start_mjd, original.scan_start_mjd)
-    assert np.array_equal(selected.scan_stop_mjd, original.scan_stop_mjd)
-    assert not selected.visibilities.flags.writeable
-
-
-@pytest.mark.parametrize(
-    "row_mask",
-    (
-        np.array((1, 0), dtype=np.intp),
-        np.array((True,)),
-        np.array(((True, False),)),
-    ),
-)
-def test_dataset_select_rows_rejects_invalid_masks(row_mask):
-    with pytest.raises(ValueError, match="row_mask"):
-        dataset().select_rows(row_mask)
 
 
 def test_dataset_take_rows_reorders_selected_rows():
-    original = dataset()
+    original = mixed_feed_dataset()
 
     reordered = original.take_rows(np.array((1, 0), dtype=np.intp))
 
     assert np.array_equal(reordered.time_mjd, original.time_mjd[::-1])
     assert np.array_equal(reordered.antenna1, original.antenna1[::-1])
-    assert np.array_equal(reordered.visibilities, original.visibilities[::-1])
+    assert np.array_equal(reordered.row_product_id, original.row_product_id[::-1])
+    assert np.array_equal(reordered.visibilities, original.visibilities[::-1], equal_nan=True)
 
 
 @pytest.mark.parametrize(
@@ -114,7 +161,20 @@ def test_dataset_take_rows_reorders_selected_rows():
 )
 def test_dataset_take_rows_rejects_invalid_indices(row_indices):
     with pytest.raises(ValueError, match="row_indices"):
-        dataset().take_rows(row_indices)
+        circular_dataset().take_rows(row_indices)
+
+
+@pytest.mark.parametrize(
+    "row_mask",
+    (
+        np.array((1, 0), dtype=np.intp),
+        np.array((True,)),
+        np.array(((True, False),)),
+    ),
+)
+def test_dataset_select_rows_rejects_invalid_masks(row_mask):
+    with pytest.raises(ValueError, match="row_mask"):
+        circular_dataset().select_rows(row_mask)
 
 
 @pytest.mark.parametrize(
@@ -122,33 +182,38 @@ def test_dataset_take_rows_rejects_invalid_indices(row_indices):
     [
         ({"visibilities": np.ones((2, 2, 3), dtype=complex)}, "visibilities"),
         ({"antenna2": np.array((1, 3))}, "antenna2"),
-        ({"row_layout_id": np.array((0, 2))}, "row_layout_id"),
-        ({"weights": np.zeros((2, 2, 4))}, "weights"),
+        ({"row_product_id": np.array(((0, 99, 2, 3), (4, 5, 6, 7)))}, "row_product_id"),
+        ({"sigma_jy": np.zeros((2, 2, 4))}, "sigma_jy"),
     ],
 )
 def test_dataset_rejects_invalid_shapes_and_indices(overrides, message):
     with pytest.raises(ValueError, match=message):
-        dataset(**overrides)
+        circular_dataset(**overrides)
 
 
-def test_ehtim_circular_obsdata_round_trip():
-    obs = dataset(
+def test_dataset_rejects_product_connected_to_wrong_station():
+    data = circular_dataset()
+    wrong = np.array(data.row_product_id, copy=True)
+    wrong[0, 0] = data.row_product_id[1, 0]
+    with pytest.raises(ValueError, match="first receptors"):
+        circular_dataset(row_product_id=wrong)
+
+
+def test_ehtim_circular_obsdata_round_trip_uses_sigma_directly():
+    obs = circular_dataset(
         channel_frequency_hz=np.array((230.0e9,)),
         channel_bandwidth_hz=np.array((2.0e9,)),
         spectral_window_id=np.array((0,)),
-        correlation_layouts=(CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.array((0, 0)),
         visibilities=np.array(
             [[[1.0 + 1.0j, 2.0 + 1.0j, 3.0 + 1.0j, 4.0 + 1.0j]],
             [[5.0 + 1.0j, 6.0 + 1.0j, 7.0 + 1.0j, 8.0 + 1.0j]]]
         ),
-        weights=np.full((2, 1, 4), 4.0),
+        sigma_jy=np.full((2, 1, 4), 0.5),
         flags=np.zeros((2, 1, 4), dtype=bool),
     ).to_ehtim_obsdata()
 
     restored = VisibilityDataset.from_ehtim_obsdata(obs)
 
-    assert restored.correlation_layouts == (CIRCULAR_CORRELATIONS,)
     assert np.array_equal(restored.antenna1, np.array((0, 1)))
     assert np.array_equal(restored.antenna2, np.array((1, 2)))
     expected_visibilities = np.column_stack(
@@ -157,57 +222,75 @@ def test_ehtim_circular_obsdata_round_trip():
     expected_sigma = np.column_stack(
         (obs.data["rrsigma"], obs.data["llsigma"], obs.data["rlsigma"], obs.data["lrsigma"])
     )
-    assert np.allclose(restored.visibilities[:, 0], expected_visibilities)
-    assert np.allclose(restored.weights[:, 0], 1.0 / np.square(expected_sigma))
+    slots = restored.circular_product_slots()
+    rows = np.arange(restored.row_count)[:, np.newaxis]
+    assert np.allclose(restored.visibilities[rows, 0, slots], expected_visibilities)
+    assert np.allclose(restored.sigma_jy[rows, 0, slots], expected_sigma)
     assert restored.source == obs.source
     assert restored.ampcal == obs.ampcal
 
 
-def test_ehtim_stokes_obsdata_is_converted_to_circular_correlations():
-    circular_obs = dataset(
+def test_ehtim_stokes_obsdata_is_converted_to_standard_circular_products():
+    circular_obs = circular_dataset(
         channel_frequency_hz=np.array((230.0e9,)),
         channel_bandwidth_hz=np.array((2.0e9,)),
         spectral_window_id=np.array((0,)),
-        correlation_layouts=(CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.array((0, 0)),
         visibilities=np.ones((2, 1, 4), dtype=complex),
-        weights=np.full((2, 1, 4), 4.0),
+        sigma_jy=np.full((2, 1, 4), 0.5),
         flags=np.zeros((2, 1, 4), dtype=bool),
     ).to_ehtim_obsdata()
 
-    restored = VisibilityDataset.from_ehtim_obsdata(
-        circular_obs.switch_polrep("stokes")
-    )
+    restored = VisibilityDataset.from_ehtim_obsdata(circular_obs.switch_polrep("stokes"))
+    slots = restored.circular_product_slots()
+    rows = np.arange(restored.row_count)[:, np.newaxis]
 
-    assert restored.correlation_layouts == (CIRCULAR_CORRELATIONS,)
-    assert np.allclose(restored.visibilities[:, 0], 1.0)
+    assert np.allclose(restored.visibilities[rows, 0, slots], 1.0)
+
+
+def test_ehtim_export_rejects_nonstandard_receptor_basis():
+    original = circular_dataset(
+        channel_frequency_hz=np.array((230.0e9,)),
+        channel_bandwidth_hz=np.array((2.0e9,)),
+        spectral_window_id=np.array((0,)),
+        visibilities=np.ones((2, 1, 4), dtype=complex),
+        sigma_jy=np.ones((2, 1, 4)),
+        flags=np.zeros((2, 1, 4), dtype=bool),
+    )
+    custom_receptors = ReceptorTable(
+        station_index=original.receptors.station_index,
+        feed_id=original.receptors.feed_id,
+        polarization_label=original.receptors.polarization_label,
+        basis=("CUSTOM",) * original.receptors.count,
+    )
+    custom = replace(original, receptors=custom_receptors)
+
+    with pytest.raises(ValueError, match="circular receptor basis"):
+        custom.to_ehtim_obsdata()
 
 
 def test_ehtim_adapter_rejects_unrepresentable_datasets():
     with pytest.raises(ValueError, match="exactly one spectral channel"):
-        dataset().to_ehtim_obsdata()
+        circular_dataset().to_ehtim_obsdata()
 
-    mixed = dataset(
-        channel_frequency_hz=np.array((230.0e9,)),
-        channel_bandwidth_hz=np.array((2.0e9,)),
-        spectral_window_id=np.array((0,)),
-        correlation_layouts=(LINEAR_CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.array((0, 0)),
-        visibilities=np.ones((2, 1, 4), dtype=complex),
-        weights=np.ones((2, 1, 4)),
-        flags=np.zeros((2, 1, 4), dtype=bool),
+    mixed = mixed_feed_dataset()
+    mixed = replace(
+        mixed,
+        channel_frequency_hz=mixed.channel_frequency_hz[:1],
+        channel_bandwidth_hz=mixed.channel_bandwidth_hz[:1],
+        spectral_window_id=mixed.spectral_window_id[:1],
+        visibilities=mixed.visibilities[:, :1],
+        sigma_jy=mixed.sigma_jy[:, :1],
+        flags=mixed.flags[:, :1],
     )
-    with pytest.raises(ValueError, match="circular"):
+    with pytest.raises(ValueError, match="required correlation products"):
         mixed.to_ehtim_obsdata()
 
-    flagged = dataset(
+    flagged = circular_dataset(
         channel_frequency_hz=np.array((230.0e9,)),
         channel_bandwidth_hz=np.array((2.0e9,)),
         spectral_window_id=np.array((0,)),
-        correlation_layouts=(CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.array((0, 0)),
         visibilities=np.ones((2, 1, 4), dtype=complex),
-        weights=np.ones((2, 1, 4)),
+        sigma_jy=np.ones((2, 1, 4)),
         flags=np.ones((2, 1, 4), dtype=bool),
     )
     with pytest.raises(ValueError, match="flagged"):
@@ -215,14 +298,12 @@ def test_ehtim_adapter_rejects_unrepresentable_datasets():
 
 
 def test_ehtim_adapter_preserves_rows_across_mjd_boundaries():
-    original = dataset(
+    original = circular_dataset(
         channel_frequency_hz=np.array((230.0e9,)),
         channel_bandwidth_hz=np.array((2.0e9,)),
         spectral_window_id=np.array((0,)),
-        correlation_layouts=(CIRCULAR_CORRELATIONS,),
-        row_layout_id=np.array((0, 0)),
         visibilities=np.ones((2, 1, 4), dtype=complex),
-        weights=np.ones((2, 1, 4)),
+        sigma_jy=np.ones((2, 1, 4)),
         flags=np.zeros((2, 1, 4), dtype=bool),
         time_mjd=np.array((60000.99, 60001.01)),
     )


### PR DESCRIPTION
Add a receptor- and correlation-product-based native visibility model, direct per-sample sigma storage, FITS-EHT read/write support, and constrained UVFITS boundary adapters.