### PR TITLE
Document native refactor interfaces

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          python -m sphinx -b html --keep-going docs/source docs/_build/html
+          python -m sphinx -b html -W --keep-going docs/source docs/_build/html
 
       - name: Configure GitHub Pages
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,8 +7,12 @@ Individual package documentation organized by area.
    :maxdepth: 3
 
    ./obsgen
+   ./source_models
+   ./native_visibility
+   ./native_simulation
    ./ehtfits
    ./uvfits
    ./metrics
    ./weather
    ./calibration
+   ./development

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,9 @@ extensions = [
     "sphinx.ext.napoleon",
 ]
 
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build"]
 html_theme = "sphinx_rtd_theme"

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,37 @@
+Documentation Standards
+=======================
+
+The reference documentation is part of ngehtsim's public interface. A change
+is not complete merely because its tests pass: users must be able to discover
+what the changed interface accepts, produces, and deliberately does not
+support.
+
+Public APIs
+-----------
+
+Public classes, functions, methods, and configuration values must have
+NumPy-style docstrings that state their parameters, return values, raised
+errors, units, array shapes, and representation constraints where applicable.
+For example, an uncertainty description must say whether it applies to the
+complex amplitude or independently to its real and imaginary components.
+
+The following are public for documentation purposes:
+
+* Names presented in user tutorials, API pages, package initializers, or file
+  format specifications.
+* Stable native data structures and their boundary adapters.
+* User-configurable simulation and weather behavior.
+
+Private helpers do not need repetitive narrative. They do need a concise
+docstring or orienting comment when their algorithm, coordinate convention, or
+side effects are not evident from the code.
+
+User Guides and CI
+------------------
+
+Docstrings are necessary but not sufficient. New data models, file formats,
+and breaking changes also require a narrative page with examples and explicit
+limitations. The documentation workflow builds Sphinx with warnings treated as
+errors, so unresolved references and malformed directives block a pull
+request. API and tutorial changes should be reviewed together with their
+implementation and tests.

--- a/docs/source/native_simulation.rst
+++ b/docs/source/native_simulation.rst
@@ -1,0 +1,74 @@
+Native Simulation Results
+=========================
+
+Ground-array simulations retain their full native result until an explicit
+export boundary is requested. This preserves flagged rows and supports data
+that cannot be expressed as ``ehtim.Obsdata``.
+
+``SimulationResult`` couples a ``VisibilityDataset`` with the station terms
+used to generate it. The values in ``station_terms`` are implementation
+products of a particular simulation, rather than a stable on-disk calibration
+format. FITS-EHT currently archives the visibility dataset; an archive format
+for station-term realizations will be introduced only after the public
+station-corruption configuration has been redesigned.
+
+Ground Geometry and Station Terms
+---------------------------------
+
+The native ground-array geometry kernel produces baseline rows, elevation
+selection masks, and a circular visibility template without constructing an
+``ehtim.Obsdata`` object. Spacecraft stations retain the legacy geometry path.
+The station-term kernel then evaluates weather, SEFD, uptime, gains, leakage,
+and feed-rotation quantities on those rows. Its current corruption application
+is circular and one-channel; mixed-receptor station corruptions are a planned
+native extension rather than an implicit conversion.
+
+.. currentmodule:: ngehtsim.obs.observation_geometry
+
+.. autoclass:: GroundGeometry
+   :members:
+
+.. autoclass:: StationGeometry
+   :members:
+
+.. autofunction:: ground_geometry
+
+.. autofunction:: ground_visibility_template
+
+.. autofunction:: visibility_dataset_elevation_mask
+
+.. autofunction:: apply_visibility_dataset_elevation_limits
+
+.. currentmodule:: ngehtsim.obs.station_observation
+
+.. autofunction:: station_metadata_for_dataset
+
+.. autofunction:: station_terms_for_dataset
+
+Fringe and Corruption Primitives
+--------------------------------
+
+The fringe functions are deterministic detectability and fringe-selection
+primitives. Frequency phase transfer (FPT) is currently a selection proxy; it
+does not alter visibility phases. Circular corruption functions currently
+require a one-channel dataset containing exactly RR, LL, RL, and LR products.
+
+.. currentmodule:: ngehtsim.obs.simulation_result
+
+.. autoclass:: SimulationResult
+   :members:
+
+.. currentmodule:: ngehtsim.obs.fringe_selection
+
+.. autoclass:: FringeRows
+   :members:
+
+.. autofunction:: fringe_group_mask
+
+.. autofunction:: fpt_fringe_group_mask
+
+.. currentmodule:: ngehtsim.obs.instrumental_corruptions
+
+.. autofunction:: apply_circular_leakage
+
+.. autofunction:: apply_circular_corruptions

--- a/docs/source/native_visibility.rst
+++ b/docs/source/native_visibility.rst
@@ -1,0 +1,51 @@
+Native Visibility Data
+======================
+
+``VisibilityDataset`` is ngehtsim's native in-memory representation for
+visibility data. It is independent of ``ehtim.Obsdata`` and can represent
+multiple spectral channels, explicitly flagged samples, and arrays whose
+stations have different receptor layouts.
+
+Data Model
+----------
+
+A dataset has baseline-time *rows*, frequency *channels*, and dense in-memory
+*product slots*.  Each populated slot maps through ``row_product_id`` to an
+ordered pair of entries in ``CorrelationProductTable``. Each product entry, in
+turn, identifies one receptor at ``antenna1`` and one receptor at ``antenna2``.
+This representation supports arbitrary station-local receptor inventories:
+for example, circular R/L, linear X/Y, a single Y receptor, or a custom
+three-receptor station can coexist in one dataset.
+
+The data arrays ``visibilities``, ``sigma_jy``, and ``flags`` have shape
+``(row, channel, product_slot)``. ``sigma_jy`` is the one-standard-deviation
+uncertainty, in Jy, of each real or imaginary component of a complex
+visibility. Native datasets deliberately do not store statistical weights.
+
+Unused dense product slots are represented by ``row_product_id == -1``. They
+are always flagged and have ``NaN`` uncertainty; use ``sample_present`` to
+distinguish padding from an actual flagged sample.
+
+Boundary Adapters
+-----------------
+
+``from_ehtim_obsdata()`` and ``to_ehtim_obsdata()`` are deliberately narrow
+boundary adapters. The latter requires one unflagged circular-polarization
+channel because those are the constraints of ``ehtim.Obsdata``. Use FITS-EHT
+for lossless interchange of native mixed-receptor data.
+
+.. currentmodule:: ngehtsim.obs.visibility_dataset
+
+.. autoclass:: StationTable
+   :members:
+
+.. autoclass:: ReceptorTable
+   :members:
+
+.. autoclass:: CorrelationProductTable
+   :members:
+
+.. autofunction:: standard_products_for_rows
+
+.. autoclass:: VisibilityDataset
+   :members:

--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -40,18 +40,19 @@ weather mode.
 Raster Source Transform Backend
 -------------------------------
 
-Rasterized ``ehtim.Image`` and ``ehtim.Movie`` sources use the FINUFFT-backed
-``"nfft"`` transform by default. It is substantially faster than a direct
-Fourier transform for typical high-resolution synthetic datasets. FINUFFT
-requires even image dimensions. Use ``"direct"`` explicitly for an odd-sized
-raster or when an exact direct transform is required:
+Rasterized ``ehtim.Image`` and ``ehtim.Movie`` sources currently delegate
+their Fourier transform to ``ehtim``.  Consequently, ``"nfft"`` selects
+ehtim's pyNFFT-based backend; it is not a FINUFFT backend and requires a
+working pyNFFT installation.  Use ``"direct"`` for a supported, dependency-free
+reference transform:
 
 .. code-block:: python
 
    settings = {"ttype": "direct"}
    obsgen = obs_generator.obs_generator(settings=settings)
 
-``"fast"`` is no longer a supported ngehtsim transform backend.
+``"fast"`` is not a supported ngehtsim transform backend. A native FINUFFT
+sampler will replace this delegated raster path in a later v2 refactor step.
 
 .. automodule:: ngehtsim.obs.obs_generator
    :members:

--- a/docs/source/source_models.rst
+++ b/docs/source/source_models.rst
@@ -1,0 +1,33 @@
+Source Models
+=============
+
+ngehtsim accepts ``ehtim.Image``, ``ehtim.Movie``, and ``ehtim.Model`` objects
+as source-structure inputs. The adapter layer samples them onto either an
+``ehtim.Obsdata`` boundary object or a native ``VisibilityDataset``. It is an
+interoperability boundary, not ngehtsim's final source-model representation.
+
+For native datasets, the current adapter supports one-channel circular RR,
+LL, RL, LR products. Mixed-receptor source sampling requires the forthcoming
+native source-structure model and is rejected rather than assigned an implicit
+polarization conversion. The Image and Movie raster-transform backend is
+described in :doc:`obsgen`.
+
+The lower-level functions below are useful when building integrations around
+the native data model. Typical users should call ``obs_generator.make_obs()``.
+
+.. currentmodule:: ngehtsim.obs.source_models
+
+.. autoclass:: EhtimImageAdapter
+   :members:
+
+.. autoclass:: EhtimMovieAdapter
+   :members:
+
+.. autoclass:: EhtimModelAdapter
+   :members:
+
+.. autofunction:: adapter_for
+
+.. autofunction:: observe_source
+
+.. autofunction:: observe_source_dataset

--- a/ngehtsim/obs/ehtfits.py
+++ b/ngehtsim/obs/ehtfits.py
@@ -35,6 +35,26 @@ def write_ehtfits(dataset, path, overwrite=False):
     Visibility payloads use variable-length FITS binary-table arrays. Their
     order is channel-major then product-major, with every product ID resolving
     to an ordered pair of station-local receptors.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Native dataset to serialize. Mixed receptor layouts, flags, channels,
+        and per-component uncertainties are preserved.
+    path : str or pathlib.Path
+        Destination FITS-EHT file, conventionally with a ``.ehtfits`` suffix.
+    overwrite : bool, optional
+        Replace an existing file when ``True``.
+
+    Raises
+    ------
+    EhtfitsError
+        If the dataset contains no visibility rows.
+
+    Notes
+    -----
+    FITS-EHT is a project-owned convention, not a FITS-IDI variant. It writes
+    ``SIGMA`` rather than a statistical weight field.
     """
 
     if not isinstance(dataset, VisibilityDataset):
@@ -58,7 +78,24 @@ def write_ehtfits(dataset, path, overwrite=False):
 
 
 def read_ehtfits(path):
-    """Read a FITS-EHT file into a native :class:`VisibilityDataset`."""
+    """Read a FITS-EHT file into a native :class:`VisibilityDataset`.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        FITS-EHT archive to read.
+
+    Returns
+    -------
+    VisibilityDataset
+        Validated native dataset with its receptor/product mapping restored.
+
+    Raises
+    ------
+    EhtfitsError
+        If the primary header, schema version, required table, or variable
+        length UV payload is invalid or unsupported.
+    """
 
     with fits.open(Path(path), memmap=False) as hdul:
         header = hdul[0].header

--- a/ngehtsim/obs/fringe_selection.py
+++ b/ngehtsim/obs/fringe_selection.py
@@ -15,7 +15,29 @@ import numpy as np
 
 @dataclass(frozen=True)
 class FringeRows:
-    """Visibility rows required for fringe-detection selection."""
+    """Visibility rows required for fringe-detection selection.
+
+    Parameters
+    ----------
+    time : array_like, shape (row,)
+        Timestamp keys. Values are compared exactly, so callers should use a
+        common time representation for all rows passed to one selection call.
+    station1, station2 : array_like, shape (row,)
+        Ordered station identifiers for each baseline.
+    integration_time_s : array_like, shape (row,)
+        Positive integration durations in seconds.
+    rr, ll : array_like, shape (row,)
+        Parallel-hand circular visibility samples.
+    rr_sigma, ll_sigma : array_like, shape (row,)
+        Positive one-sigma uncertainties of the real or imaginary component of
+        the corresponding parallel-hand visibility.
+
+    Notes
+    -----
+    This compact structure intentionally contains only the information needed
+    for the published detectability proxy. It is not a calibrated visibility
+    data model.
+    """
 
     time: np.ndarray
     station1: np.ndarray
@@ -75,7 +97,30 @@ class FringeRows:
 
 
 def fringe_group_mask(rows, snr_threshold, tint_reference_s, available_sites=None):
-    """Return rows in timestamp-local components of strong baselines."""
+    """Return rows in timestamp-local components of strong baselines.
+
+    Parameters
+    ----------
+    rows : FringeRows
+        Target-frequency parallel-hand visibility rows.
+    snr_threshold : float
+        Strong-baseline SNR threshold at ``tint_reference_s``.
+    tint_reference_s : float
+        Positive reference integration time in seconds.
+    available_sites : iterable, optional
+        Restrict both graph edges and selected rows to baselines whose stations
+        are in this set.
+
+    Returns
+    -------
+    numpy.ndarray of bool, shape (row,)
+        Rows whose stations lie in a connected component built from strong
+        baselines at the same timestamp.
+
+    Notes
+    -----
+    This is a detectability/fringe-selection proxy, not fringe fitting.
+    """
     _validate_thresholds(snr_threshold, tint_reference_s)
     available = _availability_mask(rows.station1, rows.station2, available_sites)
     strong = available & (
@@ -106,6 +151,34 @@ def fpt_fringe_group_mask(target_rows, reference_rows, reference_snr_threshold,
     are intentionally independent: the station graph is keyed by timestamp
     and never by row position.  Optional row-availability masks exclude
     station-flagged data before either graph is assembled.
+
+    Parameters
+    ----------
+    target_rows, reference_rows : FringeRows
+        Target- and reference-frequency visibility rows. Their row ordering and
+        counts may differ.
+    reference_snr_threshold : float
+        Strong-baseline threshold at the reference frequency and reference
+        integration time.
+    tint_reference_s : float
+        Positive reference integration time in seconds.
+    reference_to_target_ratio : float
+        Positive multiplier mapping the reference SNR threshold to the target
+        frequency.
+    target_available_sites, reference_available_sites : iterable, optional
+        Site-level availability restrictions for the two datasets.
+    target_row_available, reference_row_available : array_like of bool, optional
+        Additional row-level availability masks.
+
+    Returns
+    -------
+    numpy.ndarray of bool, shape (target_row,)
+        Target rows whose stations are connected by strong target or reference
+        baselines at the same timestamp.
+
+    Notes
+    -----
+    FPT selection does not transfer or correct visibility phases.
     """
     _validate_thresholds(reference_snr_threshold, tint_reference_s)
     if not np.isfinite(reference_to_target_ratio) or reference_to_target_ratio <= 0.0:

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -17,6 +17,19 @@ def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
     The final axis of ``visibilities`` must use the order ``RR, LL, RL, LR``.
     The result is a new array so every output correlation is calculated from
     the same, unmodified input coherency matrix.
+
+    Parameters
+    ----------
+    visibilities : array_like, shape (..., 4)
+        Circular-basis coherency products ordered RR, LL, RL, LR.
+    leakage1_r, leakage1_l, leakage2_r, leakage2_l : complex or array_like
+        Station 1 and station 2 circular D-terms, broadcast against the
+        leading visibility dimensions.
+
+    Returns
+    -------
+    numpy.ndarray
+        Corrupted visibility products after applying ``D_1 V D_2^H``.
     """
 
     visibilities = np.asarray(visibilities, dtype=complex)
@@ -64,6 +77,34 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
 
     Flagged rows remain in the returned dataset. Use ``select_rows()`` before
     converting an eligible result to ``ehtim.Obsdata``.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        One-channel native dataset with exactly RR, LL, RL, LR products.
+    station_terms : mapping
+        Row-aligned output from ``station_terms_for_dataset()``. Required terms
+        include station names, opacity, SEFD, bandwidth, feed angles, and
+        availability; optional gain and leakage terms are required only when
+        their corresponding switches are enabled.
+    stations : StationTable
+        Station metadata updated by the station-term calculation.
+    rng : numpy.random.Generator
+        Random generator used for thermal noise.
+    addnoise, addgains, opacitycal, addFR, addleakage : bool, optional
+        Enable thermal noise, gain errors, opacity calibration state, feed
+        rotation, and leakage corruption, respectively.
+
+    Returns
+    -------
+    VisibilityDataset
+        New dataset containing corrupted visibilities, propagated ``sigma_jy``
+        values, flags, and calibration-state metadata.
+
+    Notes
+    -----
+    This is currently a circular single-channel kernel. It rejects mixed
+    receptor layouts rather than applying an implicit basis conversion.
     """
 
     if not isinstance(dataset, VisibilityDataset):

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -33,7 +33,20 @@ GEOMETRY_CACHE_FIELDS = (
 
 @dataclass(frozen=True)
 class GroundGeometry:
-    """Ground-station observation rows independent of ``ehtim.Obsdata``."""
+    """Ground-station baseline rows independent of ``ehtim.Obsdata``.
+
+    Parameters
+    ----------
+    time_hours : numpy.ndarray, shape (row,)
+        UTC-hour offsets from the observation's reference MJD.
+    station1_indices, station2_indices : numpy.ndarray, shape (row,)
+        Ordered zero-based station indices for each baseline-time row.
+    uvw_m : numpy.ndarray, shape (row, 3)
+        Projected baseline coordinates in metres.
+    u, v : numpy.ndarray, shape (row,)
+        Projected coordinates in wavelengths at the requested observing
+        frequency. They are retained for the ehtim boundary adapter.
+    """
 
     time_hours: np.ndarray
     station1_indices: np.ndarray
@@ -53,7 +66,21 @@ def _readonly_float_array(values):
 
 @dataclass(frozen=True)
 class StationGeometry:
-    """Per-row ground-station elevation and parallactic angles in radians."""
+    """Per-row ground-station elevation and parallactic angles in radians.
+
+    Parameters
+    ----------
+    elevation1_rad, elevation2_rad : array_like, shape (row,)
+        Elevation of the first and second stations in radians.
+    parallactic_angle1_rad, parallactic_angle2_rad : array_like, shape (row,)
+        Parallactic angles of the first and second stations in radians.
+
+    Notes
+    -----
+    Arrays are copied and stored read-only. The ground-only kernel returns
+    ``None`` instead of this class when a station uses the spacecraft
+    placeholder coordinate convention.
+    """
 
     elevation1_rad: np.ndarray
     elevation2_rad: np.ndarray
@@ -132,6 +159,23 @@ def station_geometry_from_rows(position_itrs_m, time_mjd, antenna1, antenna2,
 
     Returns ``None`` when a row cannot be represented by the ground-only
     geometry kernel, including arrays containing spacecraft placeholders.
+
+    Parameters
+    ----------
+    position_itrs_m : array_like, shape (station, 3)
+        Station ITRS Cartesian coordinates in metres.
+    time_mjd : array_like, shape (row,)
+        UTC MJD timestamps.
+    antenna1, antenna2 : array_like, shape (row,)
+        Ordered zero-based station indices.
+    ra_hours, dec_degrees : float
+        Source right ascension in hours and declination in degrees.
+
+    Returns
+    -------
+    StationGeometry or None
+        Per-row angle arrays, or ``None`` when any station is a spacecraft
+        placeholder unsupported by the native ground-only kernel.
     """
 
     coordinates = np.asarray(position_itrs_m, dtype=float)
@@ -240,7 +284,29 @@ def ground_station_geometry(obs):
 
 
 def ground_geometry(array, context):
-    """Generate ground-array baseline rows without ``ehtim`` geometry helpers."""
+    """Generate ground-array baseline rows without ehtim geometry helpers.
+
+    Parameters
+    ----------
+    array : ehtim.array.Array
+        Ground-only telescope array. Spacecraft placeholder coordinates are
+        rejected and must use the legacy route.
+    context : mapping
+        Normalized observation settings containing ``mjd``, ``ra``, ``dec``,
+        ``rf``, ``t_start``, ``t_stop``, and ``t_rest``.
+
+    Returns
+    -------
+    GroundGeometry
+        Visible baseline-time rows with UVW coordinates in metres and in
+        wavelengths.
+
+    Raises
+    ------
+    ValueError
+        If the array contains a spacecraft placeholder or the requested time
+        range produces no baseline-time rows.
+    """
 
     if _has_space_station(array):
         raise ValueError("Ground geometry does not support spacecraft stations.")
@@ -321,9 +387,25 @@ def ground_geometry(array, context):
 def ground_visibility_template(array, context, geometry=None):
     """Build a native visibility template for a ground-only array.
 
-    The template carries geometry and thermal uncertainties but contains zero-valued
-    circular visibilities. Source sampling remains at the ``ehtim`` adapter
-    boundary until native source adapters are introduced.
+    The template carries geometry and thermal uncertainties but contains
+    zero-valued circular visibilities. Source sampling occurs separately
+    through the source-adapter layer.
+
+    Parameters
+    ----------
+    array : ehtim.array.Array
+        Ground-only telescope array.
+    context : mapping
+        Normalized observation settings including source coordinates, observing
+        frequency, bandwidth, integration time, and reference MJD.
+    geometry : GroundGeometry, optional
+        Precomputed geometry for the same array and context.
+
+    Returns
+    -------
+    VisibilityDataset
+        One-channel circular template with RR, LL, RL, LR products and thermal
+        ``sigma_jy`` values computed from station SEFDs.
     """
 
     if geometry is None:
@@ -392,7 +474,25 @@ def ground_visibility_template(array, context, geometry=None):
 
 
 def visibility_dataset_elevation_mask(dataset, el_min, el_max):
-    """Return the native ground-array elevation-selection mask."""
+    """Return the native ground-array elevation-selection mask.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Ground-only native dataset.
+    el_min, el_max : float
+        Exclusive lower and upper elevation limits in degrees.
+
+    Returns
+    -------
+    numpy.ndarray of bool, shape (row,)
+        Rows for which both stations are strictly inside the elevation range.
+
+    Raises
+    ------
+    ValueError
+        If spacecraft stations require the legacy geometry path.
+    """
 
     if not isinstance(dataset, VisibilityDataset):
         raise TypeError("dataset must be a VisibilityDataset instance.")
@@ -419,7 +519,21 @@ def visibility_dataset_elevation_mask(dataset, el_min, el_max):
 
 
 def apply_visibility_dataset_elevation_limits(dataset, el_min, el_max):
-    """Return a native dataset restricted to the requested elevation range."""
+    """Return a native dataset restricted to the requested elevation range.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Ground-only dataset to filter.
+    el_min, el_max : float
+        Exclusive elevation limits in degrees.
+
+    Returns
+    -------
+    VisibilityDataset
+        New dataset retaining rows selected by
+        :func:`visibility_dataset_elevation_mask`.
+    """
 
     return dataset.select_rows(visibility_dataset_elevation_mask(dataset, el_min, el_max))
 

--- a/ngehtsim/obs/simulation_result.py
+++ b/ngehtsim/obs/simulation_result.py
@@ -18,6 +18,17 @@ class SimulationResult:
     ``dataset`` retains flagged rows. Consumers that need an ehtim-compatible
     view can use :meth:`to_ehtim_obsdata`, which drops those rows at the export
     boundary because ``ehtim.Obsdata`` has no sample-flag representation.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Native simulated visibility data, including rows or individual samples
+        excluded by station availability or fringe selection.
+    station_terms : mapping of str to object
+        Row-aligned station-model products used for this realization, such as
+        opacity, SEFD, gains, leakage, and availability information. Arrays
+        are copied and made read-only; this mapping is simulation provenance,
+        not yet a stable archive schema.
     """
 
     dataset: VisibilityDataset
@@ -38,7 +49,13 @@ class SimulationResult:
 
     @property
     def row_mask(self):
-        """Rows retained after station and fringe-selection flagging."""
+        """Rows retained after station and fringe-selection flagging.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (row,)
+            ``True`` only when no populated sample in that row is flagged.
+        """
 
         return ~np.any(
             self.dataset.flags & self.dataset.sample_present,
@@ -47,7 +64,14 @@ class SimulationResult:
 
     @property
     def unflagged_dataset(self):
-        """Return the visibility rows representable by ``ehtim.Obsdata``."""
+        """Return rows whose populated samples are all unflagged.
+
+        Returns
+        -------
+        VisibilityDataset
+            Native subset suitable for an ehtim export only when its channel
+            and correlation layout also meet ehtim's constraints.
+        """
 
         return self.dataset.select_rows(self.row_mask)
 
@@ -56,6 +80,16 @@ class SimulationResult:
 
         The empty-result case is handled only here to preserve the optional
         ehtim boundary; an empty :class:`VisibilityDataset` remains valid.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Circular single-channel boundary object, possibly with zero rows.
+
+        Raises
+        ------
+        ValueError
+            If the unflagged dataset is not representable by ehtim.
         """
 
         unflagged = self.unflagged_dataset

--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -113,10 +113,45 @@ def _with_circular_samples(dataset, sampled, context):
 
 
 class EhtimImageAdapter(object):
+    """Adapt an ``ehtim.Image`` to ngehtsim observation interfaces.
+
+    Parameters
+    ----------
+    input_model : ehtim.image.Image
+        Raster source model. The current raster Fourier transform is delegated
+        to ehtim; see the Observation utilities documentation for supported
+        transform settings and their dependency constraints.
+
+    Notes
+    -----
+    :meth:`observe_dataset` samples directly into a native dataset, avoiding
+    an intermediate ``ehtim.Obsdata`` data table. It currently requires one
+    channel with exactly circular RR, LL, RL, LR products.
+    """
+
     def __init__(self, input_model):
         self.input_model = input_model
 
     def observe(self, obs_empty, context, p=None):
+        """Sample the image onto an ehtim observation boundary object.
+
+        Parameters
+        ----------
+        obs_empty : ehtim.obsdata.Obsdata
+            Geometry-only observation rows to populate.
+        context : mapping
+            Normalized observation settings, including source coordinates,
+            frequency, transform backend, and verbosity.
+        p : object, optional
+            Unused; retained for the common source-adapter interface.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Noise-free source-sampled observation.
+        float
+            Image total flux density in Jy.
+        """
         _validate_raster_ttype(self.input_model, context)
         _set_ehtim_metadata(self.input_model, context)
 
@@ -164,7 +199,29 @@ class EhtimImageAdapter(object):
         return obs, F0
 
     def observe_dataset(self, dataset, context):
-        """Sample an image onto a native circular single-channel dataset."""
+        """Sample an image onto a native circular single-channel dataset.
+
+        Parameters
+        ----------
+        dataset : VisibilityDataset
+            Geometry and correlation layout to populate.
+        context : mapping
+            Normalized observation settings.
+
+        Returns
+        -------
+        VisibilityDataset
+            Copy of ``dataset`` containing source visibilities and source
+            metadata.
+        float
+            Image total flux density in Jy.
+
+        Raises
+        ------
+        ValueError
+            If the dataset is not exactly a one-channel circular layout or the
+            requested ehtim transform backend is unsupported.
+        """
 
         _require_native_circular_dataset(dataset)
         _validate_raster_ttype(self.input_model, context)
@@ -188,10 +245,34 @@ class EhtimImageAdapter(object):
 
 
 class EhtimMovieAdapter(object):
+    """Adapt a time-varying ``ehtim.Movie`` to ngehtsim interfaces.
+
+    Parameters
+    ----------
+    input_model : ehtim.movie.Movie
+        Raster movie sampled at each distinct observation timestamp.
+
+    Notes
+    -----
+    The movie's own ``bounds_error`` behavior determines whether observation
+    times outside its nominal range are looped. Native sampling has the same
+    circular single-channel limitation as :class:`EhtimImageAdapter`.
+    """
+
     def __init__(self, input_model):
         self.input_model = input_model
 
     def observe(self, obs_empty, context, p=None):
+        """Sample movie frames onto an ehtim observation boundary object.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Noise-free observation with the corresponding movie frame sampled
+            at every timestamp.
+        float
+            Mean movie light-curve flux density in Jy.
+        """
         _validate_raster_ttype(self.input_model, context)
         _set_ehtim_metadata(self.input_model, context)
 
@@ -279,7 +360,23 @@ class EhtimMovieAdapter(object):
         return obs, F0
 
     def observe_dataset(self, dataset, context):
-        """Sample a repeating movie onto a native circular dataset."""
+        """Sample a repeating movie onto a native circular dataset.
+
+        Parameters
+        ----------
+        dataset : VisibilityDataset
+            Geometry and correlation layout to populate.
+        context : mapping
+            Normalized observation settings. Dataset MJD values determine the
+            movie sampling times relative to ``context["mjd"]``.
+
+        Returns
+        -------
+        VisibilityDataset
+            Dataset populated from the applicable frame for every timestamp.
+        float
+            Mean movie light-curve flux density in Jy.
+        """
 
         circular_slots = _require_native_circular_dataset(dataset)
         _validate_raster_ttype(self.input_model, context)
@@ -330,10 +427,32 @@ class EhtimMovieAdapter(object):
 
 
 class EhtimModelAdapter(object):
+    """Adapt an analytic ``ehtim.Model`` to ngehtsim interfaces.
+
+    Parameters
+    ----------
+    input_model : ehtim.model.Model
+        Analytic source model sampled by ehtim's model evaluator.
+
+    Notes
+    -----
+    Unlike raster Image and Movie models, this path does not use an NFFT
+    backend. Native sampling still requires a one-channel circular layout.
+    """
+
     def __init__(self, input_model):
         self.input_model = input_model
 
     def observe(self, obs_empty, context, p=None):
+        """Sample the analytic model onto an ehtim observation boundary object.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Noise-free model-sampled observation.
+        float
+            Zero-baseline model amplitude in Jy.
+        """
         _set_ehtim_metadata(self.input_model, context)
 
         def sample_observation():
@@ -371,7 +490,22 @@ class EhtimModelAdapter(object):
         return obs, F0
 
     def observe_dataset(self, dataset, context):
-        """Sample an analytic model onto a native circular dataset."""
+        """Sample an analytic model onto a native circular dataset.
+
+        Parameters
+        ----------
+        dataset : VisibilityDataset
+            Geometry and correlation layout to populate.
+        context : mapping
+            Normalized observation settings used to label the output source.
+
+        Returns
+        -------
+        VisibilityDataset
+            Dataset with analytic model samples in its circular product slots.
+        float
+            Zero-baseline model amplitude in Jy.
+        """
 
         _require_native_circular_dataset(dataset)
 
@@ -392,6 +526,8 @@ class EhtimModelAdapter(object):
 
 
 class FisherForecastAdapter(object):
+    """Adapt an optional ``ngEHTforecast.FisherForecast`` source model."""
+
     def __init__(self, input_model):
         self.input_model = input_model
 
@@ -429,6 +565,23 @@ class FisherForecastAdapter(object):
 
 
 def adapter_for(input_model):
+    """Return the source adapter appropriate for a supported input object.
+
+    Parameters
+    ----------
+    input_model : ehtim Image, Movie, or Model, or ngEHTforecast FisherForecast
+        Source object accepted by ngehtsim.
+
+    Returns
+    -------
+    EhtimImageAdapter, EhtimMovieAdapter, EhtimModelAdapter, or FisherForecastAdapter
+        Adapter implementing the appropriate observation route.
+
+    Raises
+    ------
+    TypeError
+        If ``input_model`` is not a supported source type.
+    """
     if isinstance(input_model, eh.image.Image):
         return EhtimImageAdapter(input_model)
 
@@ -445,11 +598,56 @@ def adapter_for(input_model):
 
 
 def observe_source(input_model, obs_empty, context, p=None):
+    """Sample a supported source onto an ehtim observation boundary object.
+
+    Parameters
+    ----------
+    input_model : supported source object
+        Source accepted by :func:`adapter_for`.
+    obs_empty : ehtim.obsdata.Obsdata
+        Geometry-only observation rows to populate.
+    context : mapping
+        Normalized observation settings.
+    p : object, optional
+        Parameter vector required by ``ngEHTforecast.FisherForecast`` models.
+
+    Returns
+    -------
+    ehtim.obsdata.Obsdata
+        Noise-free source-sampled observation.
+    float
+        Reference total or zero-baseline flux density in Jy.
+    """
     return adapter_for(input_model).observe(obs_empty, context, p=p)
 
 
 def observe_source_dataset(input_model, dataset, context):
-    """Sample a supported source model onto a native visibility dataset."""
+    """Sample a supported source model onto a native visibility dataset.
+
+    Parameters
+    ----------
+    input_model : ehtim Image, Movie, or Model
+        Source object supporting native sampling.
+    dataset : VisibilityDataset
+        Native geometry and correlation layout to populate.
+    context : mapping
+        Normalized observation settings.
+
+    Returns
+    -------
+    VisibilityDataset
+        Source-sampled native dataset.
+    float
+        Reference total or zero-baseline flux density in Jy.
+
+    Raises
+    ------
+    TypeError
+        If the source type has no native dataset adapter.
+    ValueError
+        If the dataset has a currently unsupported channel or correlation
+        layout.
+    """
 
     adapter = adapter_for(input_model)
     if not hasattr(adapter, "observe_dataset"):

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -237,6 +237,32 @@ def station_metadata(obs, station_context, cache=None):
 
 
 def station_metadata_for_dataset(dataset, station_context, reference_mjd=None, cache=None):
+    """Build or retrieve station metadata aligned to a native dataset.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        One-channel native dataset whose station rows are being simulated.
+    station_context : mapping
+        Resolved weather, receiver, telescope, and source-dependent station
+        inputs produced by the observation generator.
+    reference_mjd : float, optional
+        MJD used to convert native timestamps to the legacy UTC-hour convention.
+        The floor of the earliest dataset timestamp is used when omitted.
+    cache : mutable mapping, optional
+        Cache populated with metadata keyed by geometry and station context.
+
+    Returns
+    -------
+    dict
+        Internal row-aligned geometry and station metadata consumed by
+        :func:`station_terms_for_dataset`.
+
+    Raises
+    ------
+    ValueError
+        If the dataset is multi-channel or cannot supply native station rows.
+    """
     if not isinstance(dataset, VisibilityDataset):
         raise TypeError("dataset must be a VisibilityDataset instance.")
     if dataset.channel_count != 1:
@@ -532,7 +558,22 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
                   addgains=True, addleakage=False, flagwind=True, flagday=False,
                   flagsun=True, allow_mixed_basis=False, solar_angle=None,
                   verbosity=0, windspeed_sefd_modifier=None, cache=None):
-    """Calculate legacy Obsdata station terms through the native row kernel."""
+    """Calculate station terms for the legacy ``ehtim.Obsdata`` route.
+
+    Parameters mirror :func:`station_terms_for_dataset`, except that ``obs``
+    supplies the row geometry and ``array`` is updated in place with the
+    simulated circular SEFD and leakage metadata.
+
+    Returns
+    -------
+    dict
+        Row-aligned station terms for the legacy corruption path.
+
+    Raises
+    ------
+    NotImplementedError
+        If mixed-polarization station terms are requested.
+    """
 
     if allow_mixed_basis:
         raise NotImplementedError(
@@ -568,7 +609,50 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
                               solar_angle=None, verbosity=0,
                               windspeed_sefd_modifier=None, reference_mjd=None,
                               cache=None):
-    """Calculate native station terms and return an updated StationTable."""
+    """Calculate native station terms and return an updated station table.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        One-channel native dataset with ground or legacy-compatible station
+        rows.
+    F0 : float
+        Source total flux density in Jy, used in the current source-temperature
+        contribution to station system temperature.
+    station_context : mapping
+        Resolved weather, receiver, telescope, uptime, and feed-rotation inputs
+        from the observation generator.
+    rng : numpy.random.Generator
+        Random generator used for gain and leakage realizations.
+    gainamp, leakamp : float, optional
+        Gain-amplitude scatter in dex and one-component leakage scatter.
+    addgains, addleakage, flagwind, flagday, flagsun : bool, optional
+        Enable gain/leakage terms and wind, daylight, or solar-avoidance flags.
+    solar_angle : float, optional
+        Source-Sun angular separation in degrees when solar avoidance is used.
+    verbosity : int, optional
+        Emit station-availability messages when positive.
+    windspeed_sefd_modifier : callable, optional
+        Function mapping wind speed and loading parameters to an SEFD factor.
+    reference_mjd : float, optional
+        UTC-hour reference passed to :func:`station_metadata_for_dataset`.
+    cache : mutable mapping, optional
+        Metadata cache reused for unchanged geometry and station context.
+
+    Returns
+    -------
+    dict
+        Row-aligned station terms consumed by the circular corruption kernel.
+    StationTable
+        Updated immutable station metadata with simulated SEFD and leakage
+        values.
+
+    Notes
+    -----
+    The returned terms are currently specific to circular, one-channel
+    corruption. They are retained in :class:`SimulationResult` as provenance,
+    not yet as a stable archive interchange format.
+    """
 
     metadata = station_metadata_for_dataset(
         dataset,

--- a/ngehtsim/obs/uvfits.py
+++ b/ngehtsim/obs/uvfits.py
@@ -49,6 +49,28 @@ def read_uvfits(path):
     Circular and linear datasets with a global STOKES axis are supported.  IF
     and frequency axes are flattened into ``VisibilityDataset``'s channel
     axis, preserving an integer spectral-window ID for each IF.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        AIPS random-groups UVFITS file.
+
+    Returns
+    -------
+    VisibilityDataset
+        Native dataset with one global circular or linear receptor layout.
+
+    Raises
+    ------
+    UvfitsError
+        If the file uses unsupported regular axes, polarization codes, scan
+        metadata, or cannot supply required row metadata.
+
+    Notes
+    -----
+    UVFITS weights are an external-format boundary detail. Positive UVFITS
+    inverse variances are converted to native ``sigma_jy`` values; invalid or
+    flagged values become flagged samples with ``NaN`` uncertainty.
     """
 
     path = Path(path)
@@ -142,6 +164,27 @@ def write_uvfits(dataset, path, overwrite=False):
     The output uses a standard global STOKES axis, a regular frequency axis,
     and optional IF spectral windows.  Rows are time-sorted so an AIPS NX scan
     table can describe native scan metadata correctly.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Dataset with a globally uniform standard circular or linear layout.
+    path : str or pathlib.Path
+        Destination UVFITS file.
+    overwrite : bool, optional
+        Replace an existing file when ``True``.
+
+    Raises
+    ------
+    UvfitsError
+        If the receptor mapping, channel frequencies, or scan metadata cannot
+        be represented by standard UVFITS.
+
+    Notes
+    -----
+    Native ``sigma_jy`` is converted to UVFITS inverse variance only while
+    writing the random-groups payload. Mixed-receptor datasets must use
+    FITS-EHT instead.
     """
 
     if not isinstance(dataset, VisibilityDataset):

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -39,7 +39,33 @@ def _integer_array(values, name):
 
 @dataclass(frozen=True)
 class StationTable:
-    """Station metadata independent of an ``ehtim`` telescope table."""
+    """Station metadata independent of an ``ehtim`` telescope table.
+
+    Parameters
+    ----------
+    names : tuple of str
+        Unique station names. Native visibility rows refer to this table by
+        zero-based integer index.
+    position_itrs_m : array_like, shape (station, 3)
+        ITRS Cartesian station positions in metres.
+    sefd_r_jy, sefd_l_jy : array_like, shape (station,)
+        Circular R and L system-equivalent flux densities in Jy. These fields
+        retain the station calibration metadata used by the current circular
+        corruption kernel.
+    leakage_r, leakage_l : array_like, shape (station,)
+        Complex circular-basis D-terms for the R and L signal paths.
+    feed_rotation_par, feed_rotation_elev : array_like, shape (station,)
+        Coefficients multiplying parallactic and elevation angles in the
+        current circular feed-rotation model.
+    feed_rotation_offset_deg : array_like, shape (station,)
+        Constant feed-rotation offset in degrees.
+
+    Notes
+    -----
+    All arrays are copied, validated, and stored read-only. This table does
+    not define the correlations stored in a dataset; use :class:`ReceptorTable`
+    and :class:`CorrelationProductTable` for that purpose.
+    """
 
     names: tuple[str, ...]
     position_itrs_m: np.ndarray
@@ -96,7 +122,18 @@ class StationTable:
 
     @classmethod
     def from_ehtim_tarr(cls, tarr):
-        """Create a station table from an ``ehtim`` telescope array."""
+        """Create a station table from an ``ehtim`` telescope array.
+
+        Parameters
+        ----------
+        tarr : numpy structured array
+            An ehtim ``DTARR`` telescope table.
+
+        Returns
+        -------
+        StationTable
+            A native copy of the telescope metadata.
+        """
 
         return cls(
             names=tuple(str(name) for name in tarr["site"]),
@@ -111,7 +148,13 @@ class StationTable:
         )
 
     def to_ehtim_tarr(self):
-        """Convert station metadata to an ``ehtim`` telescope array."""
+        """Convert station metadata to an ehtim ``DTARR`` telescope table.
+
+        Returns
+        -------
+        numpy structured array
+            A newly allocated ehtim-compatible telescope table.
+        """
 
         import ehtim as eh
 
@@ -139,6 +182,20 @@ class ReceptorTable:
     ``feed_id`` and ``polarization_label`` fields are descriptive rather than
     inferred calibration instructions, so non-standard receiver arrangements
     remain representable.
+
+    Parameters
+    ----------
+    station_index : array_like, shape (receptor,)
+        Zero-based :class:`StationTable` index owning each receptor.
+    feed_id : tuple of str
+        Station-local feed identifier. ``(station_index, feed_id)`` pairs must
+        be unique.
+    polarization_label : tuple of str
+        Descriptive voltage-product label, such as ``"R"``, ``"L"``, ``"X"``,
+        or ``"Y"``. Labels are not used to infer a basis conversion.
+    basis : tuple of str
+        Basis metadata for each receptor, commonly ``"CIRCULAR"`` or
+        ``"LINEAR"``. Custom strings are preserved for native/FITS-EHT data.
     """
 
     station_index: np.ndarray
@@ -186,6 +243,20 @@ class ReceptorTable:
         This is a convenience constructor for standard all-circular or
         all-linear arrays. More general arrays should construct a table
         directly with station-local ``feed_id`` values.
+
+        Parameters
+        ----------
+        station_count : int
+            Number of stations receiving the same receptor inventory.
+        labels : iterable of str
+            Distinct receptor labels to create at every station.
+        basis : str
+            Basis metadata assigned to every created receptor.
+
+        Returns
+        -------
+        ReceptorTable
+            A standard, identical receptor inventory for each station.
         """
 
         if not isinstance(station_count, (int, np.integer)) or station_count <= 0:
@@ -201,7 +272,25 @@ class ReceptorTable:
         )
 
     def index_for(self, station_index, polarization_label):
-        """Return the unique receptor index for a station and label."""
+        """Return the unique receptor index for a station and label.
+
+        Parameters
+        ----------
+        station_index : int
+            Zero-based station index.
+        polarization_label : str
+            Label to match at that station.
+
+        Returns
+        -------
+        int
+            The zero-based receptor index.
+
+        Raises
+        ------
+        ValueError
+            If the station has no matching receptor or has an ambiguous match.
+        """
 
         matches = np.flatnonzero(
             (self.station_index == station_index)
@@ -219,7 +308,15 @@ class ReceptorTable:
 
 @dataclass(frozen=True)
 class CorrelationProductTable:
-    """Ordered pairs of receptor IDs that define stored correlations."""
+    """Ordered pairs of receptor IDs that define stored correlations.
+
+    Parameters
+    ----------
+    receptor1_id, receptor2_id : array_like, shape (product,)
+        Zero-based :class:`ReceptorTable` indices for the first and second
+        voltage streams. Product order matters: a visibility product is always
+        ``receptor1`` correlated with ``receptor2``.
+    """
 
     receptor1_id: np.ndarray
     receptor2_id: np.ndarray
@@ -251,6 +348,28 @@ def standard_products_for_rows(receptors, antenna1, antenna2, product_labels):
     as ``("RR", "LL", "RL", "LR")``. The returned product table contains
     each unique station/receptor pair once, while ``row_product_id`` maps every
     input row to the relevant ordered product IDs.
+
+    Parameters
+    ----------
+    receptors : ReceptorTable
+        Receptor inventory from which labels are resolved.
+    antenna1, antenna2 : array_like, shape (row,)
+        Zero-based station indices for ordered baseline-time rows.
+    product_labels : iterable of str
+        Ordered two-label products, for example ``("RR", "LL", "RL", "LR")``.
+
+    Returns
+    -------
+    CorrelationProductTable
+        Unique ordered receptor pairs used by the supplied rows.
+    numpy.ndarray
+        Integer array of shape ``(row, product_slot)`` mapping each requested
+        row product to the returned product table.
+
+    Raises
+    ------
+    ValueError
+        If a requested label is unavailable or ambiguous at a row's station.
     """
 
     if not isinstance(receptors, ReceptorTable):
@@ -297,8 +416,55 @@ class VisibilityDataset:
     ordered receptor pair in ``correlation_products``. A value of ``-1`` marks
     padding introduced by the dense in-memory representation; padding is
     always flagged and is never written to a FITS-EHT archive.
-    """
 
+    Parameters
+    ----------
+    stations : StationTable
+        Station metadata.
+    receptors : ReceptorTable
+        Station-local voltage-stream inventory.
+    correlation_products : CorrelationProductTable
+        Ordered receptor pairs referenced by ``row_product_id``.
+    time_mjd : array_like, shape (row,)
+        UTC Modified Julian Date of each baseline-time row.
+    integration_time_s : array_like, shape (row,)
+        Positive integration duration in seconds.
+    antenna1, antenna2 : array_like, shape (row,)
+        Distinct zero-based station indices. The first and second product
+        receptors must belong to these stations, respectively.
+    uvw_m : array_like, shape (row, 3)
+        Baseline coordinates in metres.
+    tau1, tau2 : array_like, shape (row,)
+        Non-negative line-of-sight opacity terms for the two stations.
+    channel_frequency_hz, channel_bandwidth_hz : array_like, shape (channel,)
+        Positive per-channel center frequencies and bandwidths in Hz.
+    spectral_window_id : array_like, shape (channel,)
+        Integer spectral-window identifier for every channel.
+    row_product_id : array_like, shape (row, product_slot)
+        Zero-based correlation-product IDs. ``-1`` denotes dense-array padding.
+    visibilities : array_like, shape (row, channel, product_slot)
+        Complex correlation samples in Jy.
+    sigma_jy : array_like, shape (row, channel, product_slot)
+        One-standard-deviation uncertainty, in Jy, of each real *and*
+        imaginary component. Unflagged populated samples require finite,
+        positive values. Flagged samples may use ``NaN``; padding must do so.
+    flags : array_like, shape (row, channel, product_slot)
+        Boolean sample flags. Padding slots must always be flagged.
+    source : str
+        Source name.
+    ra_hours, dec_degrees : float
+        Source right ascension in hours and declination in degrees.
+    ampcal, phasecal, opacitycal, dcal, frcal : bool, optional
+        Calibration-state metadata retained at export boundaries.
+    scan_start_mjd, scan_stop_mjd : array_like, shape (scan,), optional
+        Matching scan boundaries in MJD. Omit both when scan metadata is not
+        available.
+
+    Notes
+    -----
+    Arrays are copied and made immutable. Native datasets have no ``weights``
+    attribute: applications must use the explicit ``sigma_jy`` uncertainty.
+    """
     stations: StationTable
     receptors: ReceptorTable
     correlation_products: CorrelationProductTable
@@ -487,7 +653,14 @@ class VisibilityDataset:
 
     @property
     def sample_present(self):
-        """Return a mask for populated, non-padding visibility samples."""
+        """Return a mask for populated, non-padding visibility samples.
+
+        Returns
+        -------
+        numpy.ndarray of bool, shape (row, channel, product_slot)
+            ``True`` where ``row_product_id`` identifies a real correlation
+            product, including samples that are flagged.
+        """
 
         return np.broadcast_to(
             self.row_product_id[:, np.newaxis, :] >= 0,
@@ -500,6 +673,21 @@ class VisibilityDataset:
         This is intentionally strict. Boundary adapters that require standard
         circular or linear data must reject extra, missing, or ambiguous
         receptor products instead of silently dropping or relabelling them.
+
+        Parameters
+        ----------
+        product_labels : iterable of str
+            Exact ordered set of two-receptor labels required in every row.
+
+        Returns
+        -------
+        numpy.ndarray of int, shape (row, len(product_labels))
+            Dense product-axis slots in the requested label order.
+
+        Raises
+        ------
+        ValueError
+            If any row has a missing, extra, or ambiguous requested product.
         """
 
         product_labels = tuple(str(value) for value in product_labels)
@@ -532,12 +720,24 @@ class VisibilityDataset:
         return output
 
     def circular_product_slots(self):
-        """Return slots holding RR, LL, RL, and LR for every row."""
+        """Return slots holding RR, LL, RL, and LR for every row.
+
+        Raises
+        ------
+        ValueError
+            If a row is not exactly a standard circular four-product layout.
+        """
 
         return self._standard_product_slots(CIRCULAR_PRODUCT_LABELS, "CIRCULAR")
 
     def linear_product_slots(self):
-        """Return slots holding XX, YY, XY, and YX for every row."""
+        """Return slots holding XX, YY, XY, and YX for every row.
+
+        Raises
+        ------
+        ValueError
+            If a row is not exactly a standard linear four-product layout.
+        """
 
         return self._standard_product_slots(LINEAR_PRODUCT_LABELS, "LINEAR")
 
@@ -559,7 +759,18 @@ class VisibilityDataset:
         return slots
 
     def select_rows(self, row_mask):
-        """Return a dataset containing the selected visibility rows."""
+        """Return a dataset containing the selected visibility rows.
+
+        Parameters
+        ----------
+        row_mask : numpy.ndarray of bool, shape (row,)
+            Rows retained in their existing order.
+
+        Returns
+        -------
+        VisibilityDataset
+            A new immutable dataset with row-aligned arrays filtered.
+        """
 
         row_mask = np.asarray(row_mask)
         if row_mask.dtype != bool or row_mask.shape != (self.row_count,):
@@ -569,7 +780,19 @@ class VisibilityDataset:
         return self.take_rows(np.flatnonzero(row_mask))
 
     def take_rows(self, row_indices):
-        """Return a dataset containing rows selected in the given order."""
+        """Return a dataset containing rows selected in the given order.
+
+        Parameters
+        ----------
+        row_indices : array_like of int, shape (selected_row,)
+            Row indices to retain. Repeated indices are permitted and the
+            supplied order is preserved.
+
+        Returns
+        -------
+        VisibilityDataset
+            A new immutable dataset with row-aligned arrays reordered.
+        """
 
         row_indices = np.asarray(row_indices)
         if row_indices.ndim != 1 or not np.issubdtype(row_indices.dtype, np.integer):
@@ -593,7 +816,29 @@ class VisibilityDataset:
 
     @classmethod
     def from_ehtim_obsdata(cls, obs):
-        """Convert a standard ``ehtim.Obsdata`` object to a native dataset."""
+        """Convert a standard ``ehtim.Obsdata`` object to a native dataset.
+
+        Parameters
+        ----------
+        obs : ehtim.obsdata.Obsdata
+            Input observation. It is copied internally when conversion to UTC
+            time or circular polarization representation is required.
+
+        Returns
+        -------
+        VisibilityDataset
+            One-channel circular native dataset with unflagged samples.
+
+        Raises
+        ------
+        ValueError
+            If ehtim does not provide finite positive uncertainties.
+
+        Notes
+        -----
+        This adapter cannot recover mixed-receptor products because
+        ``ehtim.Obsdata`` cannot represent them.
+        """
 
         import ehtim as eh
 
@@ -677,7 +922,24 @@ class VisibilityDataset:
         )
 
     def to_ehtim_obsdata(self):
-        """Convert a representable circular single-channel dataset to ``ehtim.Obsdata``."""
+        """Convert a representable dataset to ``ehtim.Obsdata``.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            A circular, single-channel, unflagged ehtim boundary object.
+
+        Raises
+        ------
+        ValueError
+            If the dataset is empty, multi-channel, mixed/non-circular, or
+            contains flagged populated samples.
+
+        Notes
+        -----
+        This is an export boundary, not a native storage format. Use
+        :meth:`to_ehtfits` to preserve mixed receptors and flags.
+        """
 
         if self.channel_count != 1:
             raise ValueError("ehtim Obsdata output requires exactly one spectral channel.")
@@ -740,14 +1002,39 @@ class VisibilityDataset:
 
     @classmethod
     def from_uvfits(cls, path):
-        """Read a native multi-channel UVFITS dataset without using ``ehtim``."""
+        """Read a native multi-channel UVFITS dataset without using ehtim.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            UVFITS random-groups file.
+
+        Returns
+        -------
+        VisibilityDataset
+            Dataset with a globally circular or linear product layout.
+        """
 
         from ngehtsim.obs.uvfits import read_uvfits
 
         return read_uvfits(path)
 
     def to_uvfits(self, path, overwrite=False):
-        """Write this dataset through the native UVFITS adapter."""
+        """Write this dataset through the native UVFITS adapter.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Destination UVFITS filename.
+        overwrite : bool, optional
+            Replace an existing file when ``True``.
+
+        Raises
+        ------
+        UvfitsError
+            If the dataset is not representable by UVFITS's global
+            polarization axis or regular-frequency constraints.
+        """
 
         from ngehtsim.obs.uvfits import write_uvfits
 
@@ -755,14 +1042,34 @@ class VisibilityDataset:
 
     @classmethod
     def from_ehtfits(cls, path):
-        """Read a lossless native FITS-EHT visibility dataset."""
+        """Read a lossless native FITS-EHT visibility dataset.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            FITS-EHT archive filename.
+
+        Returns
+        -------
+        VisibilityDataset
+            Dataset preserving native receptor products, flags, and sigmas.
+        """
 
         from ngehtsim.obs.ehtfits import read_ehtfits
 
         return read_ehtfits(path)
 
     def to_ehtfits(self, path, overwrite=False):
-        """Write this dataset as a lossless native FITS-EHT archive."""
+        """Write this dataset as a lossless native FITS-EHT archive.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Destination filename, conventionally using the ``.ehtfits``
+            suffix.
+        overwrite : bool, optional
+            Replace an existing file when ``True``.
+        """
 
         from ngehtsim.obs.ehtfits import write_ehtfits
 

--- a/tests/test_native_api_documentation.py
+++ b/tests/test_native_api_documentation.py
@@ -1,0 +1,82 @@
+"""Regression checks for the documented native public API."""
+
+from __future__ import annotations
+
+import inspect
+
+from ngehtsim.obs.ehtfits import read_ehtfits, write_ehtfits
+from ngehtsim.obs.fringe_selection import FringeRows, fpt_fringe_group_mask, fringe_group_mask
+from ngehtsim.obs.instrumental_corruptions import apply_circular_corruptions, apply_circular_leakage
+from ngehtsim.obs.observation_geometry import (
+    GroundGeometry,
+    StationGeometry,
+    apply_visibility_dataset_elevation_limits,
+    ground_geometry,
+    ground_visibility_template,
+    visibility_dataset_elevation_mask,
+)
+from ngehtsim.obs.simulation_result import SimulationResult
+from ngehtsim.obs.source_models import (
+    EhtimImageAdapter,
+    EhtimModelAdapter,
+    EhtimMovieAdapter,
+    adapter_for,
+    observe_source,
+    observe_source_dataset,
+)
+from ngehtsim.obs.station_observation import (
+    station_metadata_for_dataset,
+    station_terms_for_dataset,
+)
+from ngehtsim.obs.uvfits import read_uvfits, write_uvfits
+from ngehtsim.obs.visibility_dataset import (
+    CorrelationProductTable,
+    ReceptorTable,
+    StationTable,
+    VisibilityDataset,
+    standard_products_for_rows,
+)
+
+
+DOCUMENTED_NATIVE_API = {
+    "StationTable": StationTable,
+    "ReceptorTable": ReceptorTable,
+    "CorrelationProductTable": CorrelationProductTable,
+    "standard_products_for_rows": standard_products_for_rows,
+    "VisibilityDataset": VisibilityDataset,
+    "read_ehtfits": read_ehtfits,
+    "write_ehtfits": write_ehtfits,
+    "read_uvfits": read_uvfits,
+    "write_uvfits": write_uvfits,
+    "SimulationResult": SimulationResult,
+    "GroundGeometry": GroundGeometry,
+    "StationGeometry": StationGeometry,
+    "ground_geometry": ground_geometry,
+    "ground_visibility_template": ground_visibility_template,
+    "visibility_dataset_elevation_mask": visibility_dataset_elevation_mask,
+    "apply_visibility_dataset_elevation_limits": apply_visibility_dataset_elevation_limits,
+    "station_metadata_for_dataset": station_metadata_for_dataset,
+    "station_terms_for_dataset": station_terms_for_dataset,
+    "apply_circular_leakage": apply_circular_leakage,
+    "apply_circular_corruptions": apply_circular_corruptions,
+    "FringeRows": FringeRows,
+    "fringe_group_mask": fringe_group_mask,
+    "fpt_fringe_group_mask": fpt_fringe_group_mask,
+    "EhtimImageAdapter": EhtimImageAdapter,
+    "EhtimMovieAdapter": EhtimMovieAdapter,
+    "EhtimModelAdapter": EhtimModelAdapter,
+    "adapter_for": adapter_for,
+    "observe_source": observe_source,
+    "observe_source_dataset": observe_source_dataset,
+}
+
+
+def test_native_public_api_has_parameter_documentation():
+    """Keep the documented native public surface from silently regressing."""
+
+    missing = []
+    for name, object_ in DOCUMENTED_NATIVE_API.items():
+        docstring = inspect.getdoc(object_) or ""
+        if "Parameters\n----------" not in docstring:
+            missing.append(name)
+    assert not missing, "Missing parameter documentation: {0}".format(", ".join(missing))


### PR DESCRIPTION
Document the native visibility, simulation, source-adapter, geometry, station-term, and I/O APIs; correct the raster-backend documentation; and make Sphinx warnings fail CI.