### PR TITLE
Add native mixed-receptor RIME simulation

### DIFF
--- a/docs/source/native_simulation.rst
+++ b/docs/source/native_simulation.rst
@@ -19,9 +19,11 @@ The native ground-array geometry kernel produces baseline rows, elevation
 selection masks, and a circular visibility template without constructing an
 ``ehtim.Obsdata`` object. Spacecraft stations retain the legacy geometry path.
 The station-term kernel then evaluates weather, SEFD, uptime, gains, leakage,
-and feed-rotation quantities on those rows. Its current corruption application
-is circular and one-channel; mixed-receptor station corruptions are a planned
-native extension rather than an implicit conversion.
+and feed-rotation quantities on those rows. The one-channel corruption kernel
+uses a circular-sky Jones RIME and projects the result into every configured
+station-local receptor path. This supports circular, linear, mixed, single-
+feed, and over-complete feed inventories without converting the archived data
+to an assumed global basis.
 
 .. currentmodule:: ngehtsim.obs.observation_geometry
 
@@ -50,8 +52,10 @@ Fringe and Corruption Primitives
 
 The fringe functions are deterministic detectability and fringe-selection
 primitives. Frequency phase transfer (FPT) is currently a selection proxy; it
-does not alter visibility phases. Circular corruption functions currently
-require a one-channel dataset containing exactly RR, LL, RL, and LR products.
+does not alter visibility phases. Native fringe evidence reconstructs Stokes I
+from any rank-two receptor layout, with a strongest-product fallback when a
+baseline cannot constrain the full coherency. This is independent of whether
+the recorded feeds are circular, linear, or mixed.
 
 .. currentmodule:: ngehtsim.obs.simulation_result
 
@@ -67,8 +71,14 @@ require a one-channel dataset containing exactly RR, LL, RL, and LR products.
 
 .. autofunction:: fpt_fringe_group_mask
 
+.. autofunction:: receptor_fringe_snr
+
 .. currentmodule:: ngehtsim.obs.instrumental_corruptions
 
 .. autofunction:: apply_circular_leakage
 
 .. autofunction:: apply_circular_corruptions
+
+.. autofunction:: apply_receptor_corruptions
+
+.. autofunction:: receptor_rows_for_station_terms

--- a/docs/source/native_visibility.rst
+++ b/docs/source/native_visibility.rst
@@ -47,5 +47,16 @@ for lossless interchange of native mixed-receptor data.
 
 .. autofunction:: standard_products_for_rows
 
+.. autofunction:: receptor_products_for_rows
+
 .. autoclass:: VisibilityDataset
    :members:
+
+.. currentmodule:: ngehtsim.obs.receptor_configuration
+
+.. autoclass:: ReceptorConfiguration
+   :members:
+
+.. autofunction:: resolve_receptor_configuration
+
+.. autofunction:: configuration_for_dataset

--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -37,6 +37,63 @@ wind effects at each observation timestamp. SYMBA's static ``.antennas``
 format cannot represent this time dependence and is not available in native
 weather mode.
 
+Mixed-Receptor Native Simulation
+--------------------------------
+
+The native simulator can generate a different receptor inventory at every
+station. Configure this through constructor arguments, rather than a YAML
+setting, so feed and calibration definitions remain explicit Python data:
+
+.. code-block:: python
+
+   obsgen = obs_generator.obs_generator(
+       settings=settings,
+       station_receptors={
+           "ALMA": ("X", "Y"),
+           "APEX": ("R", "L"),
+           "CUSTOM": ("R", "X", "Y"),
+           "SINGLE": ("Y",),
+       },
+   )
+
+Standard ``R``, ``L``, ``X``, and ``Y`` labels receive their conventional
+Jones rows in a common circular sky basis. Each recorded baseline contains the
+full Cartesian product of the two stations' available voltage streams, so a
+single-feed or three-feed station does not require a special data shape.
+
+For a non-standard calibrated signal path, provide a feed mapping and its
+explicit Jones row, relative SEFD, and fixed gain:
+
+.. code-block:: python
+
+   import numpy as np
+
+   obsgen = obs_generator.obs_generator(
+       settings=settings,
+       station_receptors={"CUSTOM": ({"feed_id": "P"},)},
+       station_signal_paths={
+           "CUSTOM": {
+               "P": {
+                   "jones_vector": (1.0, 0.3j),
+                   "sefd_scale": 1.15,
+                   "gain_scale": 0.98 * np.exp(0.1j),
+               },
+           },
+       },
+   )
+
+Native fringe selection reconstructs Stokes I when the available feed products
+have rank two. A rank-deficient baseline, such as one containing a single-feed
+station, uses its strongest individual product as the fringe-detection proxy.
+This follows the HOPS fringe-group criterion without treating a particular
+polarization basis as privileged. FPT uses the same evidence at target and
+reference frequency; it remains a detectability proxy and does not modify
+visibility phases.
+
+Mixed-receptor datasets can be written to FITS-EHT. UVFITS and
+``ehtim.Obsdata`` export remain intentionally limited to their representable
+uniform-polarization layouts.
+
 Raster Source Transform Backend
 -------------------------------
 

--- a/docs/source/source_models.rst
+++ b/docs/source/source_models.rst
@@ -11,11 +11,11 @@ than ehtim's pyNFFT path. The ``transform_backend`` and ``raster_tolerance``
 settings are described in :doc:`obsgen`; neither adapter mutates the source
 object supplied by the caller.
 
-For native datasets, the current adapter supports one-channel circular RR,
-LL, RL, LR products. Mixed-receptor source sampling requires the forthcoming
-native source-structure model and is rejected rather than assigned an implicit
-polarization conversion. The Image and Movie raster-transform backend is
-described in :doc:`obsgen`.
+For native datasets, the adapters sample one spectral channel into arbitrary
+station/feed products through an explicit Jones measurement equation. The
+source coherency is sampled in a common circular sky basis, then projected into
+the configured R/L, X/Y, mixed, single-feed, or custom receptor paths. The
+Image and Movie raster-transform backend is described in :doc:`obsgen`.
 
 The lower-level functions below are useful when building integrations around
 the native data model. Typical users should call ``obs_generator.make_obs()``.

--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'ehtfits',
     'obs_generator',
     'obs_plotter',
+    'receptor_configuration',
     'simulation_result',
     'uvfits',
     'visibility_dataset',

--- a/ngehtsim/obs/fringe_selection.py
+++ b/ngehtsim/obs/fringe_selection.py
@@ -26,11 +26,14 @@ class FringeRows:
         Ordered station identifiers for each baseline.
     integration_time_s : array_like, shape (row,)
         Positive integration durations in seconds.
-    rr, ll : array_like, shape (row,)
-        Parallel-hand circular visibility samples.
-    rr_sigma, ll_sigma : array_like, shape (row,)
-        Positive one-sigma uncertainties of the real or imaginary component of
-        the corresponding parallel-hand visibility.
+    rr, ll : array_like, shape (row,), optional
+        Legacy parallel-hand circular visibility samples. They remain accepted
+        for the historical Stokes-I convenience path.
+    rr_sigma, ll_sigma : array_like, shape (row,), optional
+        Positive one-sigma uncertainties corresponding to ``rr`` and ``ll``.
+    fringe_snr : array_like, shape (row,), optional
+        Basis-agnostic scalar fringe evidence. When supplied, fringe and FPT
+        selection use this value directly instead of the legacy R/L estimate.
 
     Notes
     -----
@@ -43,10 +46,11 @@ class FringeRows:
     station1: np.ndarray
     station2: np.ndarray
     integration_time_s: np.ndarray
-    rr: np.ndarray
-    ll: np.ndarray
-    rr_sigma: np.ndarray
-    ll_sigma: np.ndarray
+    rr: np.ndarray | None = None
+    ll: np.ndarray | None = None
+    rr_sigma: np.ndarray | None = None
+    ll_sigma: np.ndarray | None = None
+    fringe_snr: np.ndarray | None = None
 
     def __post_init__(self):
         arrays = {
@@ -54,11 +58,17 @@ class FringeRows:
             "station1": self.station1,
             "station2": self.station2,
             "integration_time_s": self.integration_time_s,
-            "rr": self.rr,
-            "ll": self.ll,
-            "rr_sigma": self.rr_sigma,
-            "ll_sigma": self.ll_sigma,
         }
+        legacy_values = (self.rr, self.ll, self.rr_sigma, self.ll_sigma)
+        if any(value is not None for value in legacy_values):
+            if any(value is None for value in legacy_values):
+                raise ValueError("Legacy RR/LL fringe inputs must be supplied together.")
+            arrays.update({
+                "rr": self.rr,
+                "ll": self.ll,
+                "rr_sigma": self.rr_sigma,
+                "ll_sigma": self.ll_sigma,
+            })
         normalized = {}
         length = None
         for name, values in arrays.items():
@@ -75,8 +85,19 @@ class FringeRows:
 
         if np.any(self.integration_time_s <= 0.0):
             raise ValueError("Integration times must be positive.")
-        if np.any(self.rr_sigma <= 0.0) or np.any(self.ll_sigma <= 0.0):
+        if self.rr_sigma is not None and (
+            np.any(self.rr_sigma <= 0.0) or np.any(self.ll_sigma <= 0.0)
+        ):
             raise ValueError("Parallel-hand uncertainties must be positive.")
+        if self.fringe_snr is not None:
+            fringe_snr = np.asarray(self.fringe_snr, dtype=float)
+            if fringe_snr.shape != (length,) or not np.all(np.isfinite(fringe_snr)):
+                raise ValueError("fringe_snr must be finite with one value per row.")
+            if np.any(fringe_snr < 0.0):
+                raise ValueError("fringe_snr must be non-negative.")
+            object.__setattr__(self, "fringe_snr", fringe_snr)
+        elif self.rr is None:
+            raise ValueError("Provide either fringe_snr or complete RR/LL inputs.")
 
     @property
     def row_count(self):
@@ -91,9 +112,85 @@ class FringeRows:
         being stacked.  It therefore combines their amplitudes and propagates
         their independent thermal uncertainties.
         """
+        if self.rr is None:
+            raise ValueError("Stokes-I SNR is unavailable without legacy RR/LL inputs.")
         amplitude = 0.5 * (np.abs(self.rr) + np.abs(self.ll))
         sigma = 0.5 * np.hypot(self.rr_sigma, self.ll_sigma)
         return amplitude / sigma
+
+    @property
+    def detectability_snr(self):
+        """Return generic fringe evidence or the legacy Stokes-I proxy."""
+
+        return self.stokes_i_snr if self.fringe_snr is None else self.fringe_snr
+
+
+def receptor_fringe_snr(visibilities, sigma_jy, left_rows, right_rows, present):
+    """Estimate basis-agnostic fringe SNR from arbitrary receptor products.
+
+    When the available products constrain the full two-polarization coherency,
+    this solves a weighted linear measurement equation and returns the
+    reconstructed Stokes-I SNR.  For rank-deficient rows, such as a baseline
+    containing a single-feed station, it returns the largest valid individual
+    product SNR.  The latter is the HOPS fringe-group criterion: one reliable
+    polarization-product fringe is sufficient to constrain a station edge.
+
+    Parameters
+    ----------
+    visibilities, sigma_jy : array_like, shape (row, product_slot)
+        Complex product samples and independent one-sigma uncertainties.
+    left_rows, right_rows : array_like, shape (row, product_slot, 2)
+        Effective Jones rows for the first and second receptor of each
+        product, expressed in a common circular sky basis.
+    present : array_like of bool, shape (row, product_slot)
+        True for unflagged real product samples.
+
+    Returns
+    -------
+    numpy.ndarray
+        One non-negative scalar fringe SNR per row.
+    """
+
+    visibilities = np.asarray(visibilities, dtype=complex)
+    sigma_jy = np.asarray(sigma_jy, dtype=float)
+    left_rows = np.asarray(left_rows, dtype=complex)
+    right_rows = np.asarray(right_rows, dtype=complex)
+    present = np.asarray(present, dtype=bool)
+    if visibilities.ndim != 2:
+        raise ValueError("Fringe products must have shape (row, product_slot).")
+    shape = visibilities.shape
+    if any(values.shape != shape for values in (sigma_jy, present)):
+        raise ValueError("Fringe product arrays must have matching shapes.")
+    if left_rows.shape != shape + (2,) or right_rows.shape != shape + (2,):
+        raise ValueError("Receptor rows must have shape (row, product_slot, 2).")
+
+    snr = np.zeros(shape[0], dtype=float)
+    trace = np.array((0.5, 0.0, 0.0, 0.5), dtype=complex)
+    for row in range(shape[0]):
+        usable = present[row] & np.isfinite(sigma_jy[row]) & (sigma_jy[row] > 0.0)
+        if not np.any(usable):
+            continue
+        values = visibilities[row, usable]
+        uncertainties = sigma_jy[row, usable]
+        left = left_rows[row, usable]
+        right = right_rows[row, usable]
+        design = np.column_stack((
+            left[:, 0] * np.conj(right[:, 0]),
+            left[:, 0] * np.conj(right[:, 1]),
+            left[:, 1] * np.conj(right[:, 0]),
+            left[:, 1] * np.conj(right[:, 1]),
+        ))
+        weights = 1.0 / uncertainties**2
+        normal = design.conj().T @ (weights[:, np.newaxis] * design)
+        if np.linalg.matrix_rank(normal) == 4:
+            covariance = np.linalg.inv(normal)
+            estimate = covariance @ (design.conj().T @ (weights * values))
+            sigma_i = np.sqrt(np.real(trace.conj() @ covariance @ trace))
+            if np.isfinite(sigma_i) and sigma_i > 0.0:
+                snr[row] = np.abs(trace @ estimate) / sigma_i
+                continue
+        snr[row] = np.max(np.abs(values) / uncertainties)
+    return snr
 
 
 def fringe_group_mask(rows, snr_threshold, tint_reference_s, available_sites=None):
@@ -124,7 +221,7 @@ def fringe_group_mask(rows, snr_threshold, tint_reference_s, available_sites=Non
     _validate_thresholds(snr_threshold, tint_reference_s)
     available = _availability_mask(rows.station1, rows.station2, available_sites)
     strong = available & (
-        rows.stokes_i_snr
+        rows.detectability_snr
         >= snr_threshold * np.sqrt(rows.integration_time_s / tint_reference_s)
     )
     return connected_component_mask(
@@ -205,13 +302,13 @@ def fpt_fringe_group_mask(target_rows, reference_rows, reference_snr_threshold,
         "reference_row_available",
     )
     target_strong = target_available & (
-        target_rows.stokes_i_snr
+        target_rows.detectability_snr
         >= reference_snr_threshold
         * reference_to_target_ratio
         * np.sqrt(target_rows.integration_time_s / tint_reference_s)
     )
     reference_strong = reference_available & (
-        reference_rows.stokes_i_snr
+        reference_rows.detectability_snr
         >= reference_snr_threshold
         * np.sqrt(reference_rows.integration_time_s / tint_reference_s)
     )

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import ngehtsim.const_def as const
 from ngehtsim.obs.visibility_dataset import StationTable, VisibilityDataset
+from ngehtsim.obs.receptor_configuration import response_rows_for_dataset
 
 
 def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
@@ -129,6 +130,19 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
             "par2", "phi_off1", "phi_off2", "uptime_mask",
         )
     }
+    if addgains:
+        terms.update({
+            name: _term_array(station_terms, name, count)
+            for name in (
+                "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
+                "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
+            )
+        })
+    if addleakage:
+        terms.update({
+            name: _term_array(station_terms, name, count)
+            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
+        })
     expected_t1 = np.asarray(dataset.stations.names)[dataset.antenna1]
     expected_t2 = np.asarray(dataset.stations.names)[dataset.antenna2]
     if not np.array_equal(terms["t1"], expected_t1) or not np.array_equal(terms["t2"], expected_t2):
@@ -240,6 +254,320 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
         dcal=not addleakage,
         frcal=not addFR,
     )
+
+
+def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
+                               receptor_configuration, rng, addnoise=True,
+                               addgains=True, opacitycal=True, addFR=True,
+                               addleakage=False):
+    """Apply a one-channel Jones RIME to arbitrary station-feed products.
+
+    ``sky_coherency`` is sampled in the common circular sky basis and has one
+    ``2 x 2`` matrix per visibility row.  Every stored product is then formed
+    as ``e_p J_1 B J_2^H e_q^H``, where ``e`` is the configured receptor row
+    and ``J`` contains the simulated station gain, leakage, and feed-rotation
+    terms. This formulation supports circular, linear, mixed, single-feed,
+    and over-complete receptor inventories without relabelling products.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        One-channel native visibility layout to populate.
+    sky_coherency : array_like, shape (row, 2, 2)
+        Source coherency matrices in the circular ``(R, L)`` sky basis.
+    station_terms, stations, receptor_configuration, rng
+        Native station-term realization, updated station table, resolved
+        receptor paths, and random generator.
+    addnoise, addgains, opacitycal, addFR, addleakage : bool, optional
+        Enable the corresponding station and thermal-noise effects.
+
+    Returns
+    -------
+    VisibilityDataset
+        Corrupted products with thermal uncertainty and flag state propagated.
+    """
+
+    if not isinstance(dataset, VisibilityDataset):
+        raise TypeError("dataset must be a VisibilityDataset instance.")
+    if not isinstance(stations, StationTable):
+        raise TypeError("stations must be a StationTable instance.")
+    if dataset.channel_count != 1:
+        raise ValueError("Native receptor corruption requires exactly one channel.")
+    sky_coherency = np.asarray(sky_coherency, dtype=complex)
+    if sky_coherency.shape != (dataset.row_count, 2, 2):
+        raise ValueError("sky_coherency must have shape (row, 2, 2).")
+    response, sefd_scale, gain_scale = response_rows_for_dataset(
+        dataset,
+        receptor_configuration,
+    )
+
+    count = dataset.row_count
+    terms = {
+        name: _term_array(station_terms, name, count)
+        for name in (
+            "t1", "t2", "tau1", "tau2", "SEFD1", "SEFD2", "bw1", "bw2",
+            "f_el1", "f_el2", "f_par1", "f_par2", "el1", "el2", "par1",
+            "par2", "phi_off1", "phi_off2", "uptime_mask",
+        )
+    }
+    if addgains:
+        terms.update({
+            name: _term_array(station_terms, name, count)
+            for name in (
+                "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
+                "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
+            )
+        })
+    if addleakage:
+        terms.update({
+            name: _term_array(station_terms, name, count)
+            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
+        })
+    expected_t1 = np.asarray(dataset.stations.names)[dataset.antenna1]
+    expected_t2 = np.asarray(dataset.stations.names)[dataset.antenna2]
+    if not np.array_equal(terms["t1"], expected_t1) or not np.array_equal(terms["t2"], expected_t2):
+        raise ValueError("Station terms do not correspond to the dataset row order.")
+    tau1 = np.asarray(terms["tau1"], dtype=float)
+    tau2 = np.asarray(terms["tau2"], dtype=float)
+    if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
+        raise ValueError("Station opacity terms must be non-negative.")
+
+    jones1, jones2, _, _ = _circular_station_jones(
+        terms,
+        count,
+        addgains=addgains,
+        addFR=addFR,
+        addleakage=addleakage,
+    )
+    output_coherency = jones1 @ sky_coherency @ np.swapaxes(np.conj(jones2), -1, -2)
+    if not opacitycal:
+        output_coherency *= np.sqrt(np.exp(-tau1 - tau2))[:, np.newaxis, np.newaxis]
+    receiver_gain1, receiver_gain2 = _receiver_gain_vectors(terms, count, addgains)
+
+    visibilities = np.array(dataset.visibilities, copy=True)
+    sigma_jy = np.array(dataset.sigma_jy, copy=True)
+    flags = np.array(dataset.flags, copy=True)
+    products = dataset.correlation_products
+    base_sigma = _baseline_sigmas(
+        terms["SEFD1"],
+        terms["SEFD2"],
+        np.minimum(terms["bw1"], terms["bw2"]),
+        dataset.integration_time_s,
+        tau1,
+        tau2,
+        opacitycal,
+    )[:, 0]
+    flagged_sites = set(station_terms["flagsites"])
+    row_available = (
+        ~np.isin(terms["t1"], tuple(flagged_sites))
+        & ~np.isin(terms["t2"], tuple(flagged_sites))
+        & np.asarray(terms["uptime_mask"], dtype=bool)
+    )
+    for row, product_ids in enumerate(dataset.row_product_id):
+        for slot, product_id in enumerate(product_ids):
+            if product_id < 0:
+                continue
+            receptor1 = products.receptor1_id[product_id]
+            receptor2 = products.receptor2_id[product_id]
+            first = gain_scale[receptor1] * response[receptor1]
+            second = gain_scale[receptor2] * response[receptor2]
+            value = first @ output_coherency[row] @ np.conj(second)
+            # Thermal receiver noise is injected after the deterministic feed
+            # rotation and leakage response. Propagate only the amplitude
+            # gains through each mixed feed; this exactly preserves the
+            # legacy R/L uncertainty calculation.
+            gain_magnitude = (
+                _path_gain_magnitude(
+                    response[receptor1], gain_scale[receptor1], receiver_gain1[row]
+                )
+                * _path_gain_magnitude(
+                    response[receptor2], gain_scale[receptor2], receiver_gain2[row]
+                )
+            )
+            sigma = (
+                base_sigma[row]
+                * np.sqrt(sefd_scale[receptor1] * sefd_scale[receptor2])
+                * gain_magnitude
+            )
+            if addnoise:
+                value += sigma * (rng.normal() + 1.0j * rng.normal())
+            visibilities[row, 0, slot] = value
+            sigma_jy[row, 0, slot] = sigma
+            flags[row, 0, slot] |= not row_available[row]
+
+    return replace(
+        dataset,
+        stations=stations,
+        tau1=tau1,
+        tau2=tau2,
+        visibilities=visibilities,
+        sigma_jy=sigma_jy,
+        flags=flags,
+        ampcal=not addgains,
+        phasecal=not addgains,
+        opacitycal=opacitycal,
+        dcal=not addleakage,
+        frcal=not addFR,
+    )
+
+
+def _circular_station_jones(terms, count, *, addgains, addFR, addleakage):
+    """Build per-row circular station Jones matrices from legacy terms."""
+
+    identity = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
+    jones1 = np.array(identity, copy=True)
+    jones2 = np.array(identity, copy=True)
+    gain1 = np.ones(count, dtype=complex)
+    gain2 = np.ones(count, dtype=complex)
+    if addFR:
+        rotation1 = (
+            terms["f_par1"] * terms["par1"]
+            + terms["f_el1"] * terms["el1"]
+            + (np.pi / 180.0) * terms["phi_off1"]
+        )
+        rotation2 = (
+            terms["f_par2"] * terms["par2"]
+            + terms["f_el2"] * terms["el2"]
+            + (np.pi / 180.0) * terms["phi_off2"]
+        )
+        rotation1 = np.array(rotation1, copy=True)
+        rotation2 = np.array(rotation2, copy=True)
+        rotation1[terms["t1"] == "space"] = 0.0
+        rotation2[terms["t2"] == "space"] = 0.0
+        jones1[:, 0, 0] = np.exp(-1.0j * rotation1)
+        jones1[:, 1, 1] = np.exp(1.0j * rotation1)
+        jones2[:, 0, 0] = np.exp(-1.0j * rotation2)
+        jones2[:, 1, 1] = np.exp(1.0j * rotation2)
+    if addleakage:
+        leakage = {
+            name: _term_array(terms, name, count)
+            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
+        }
+        d1 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
+        d2 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
+        d1[:, 0, 1] = leakage["leak1R"]
+        d1[:, 1, 0] = leakage["leak1L"]
+        d2[:, 0, 1] = leakage["leak2R"]
+        d2[:, 1, 0] = leakage["leak2L"]
+        jones1 = d1 @ jones1
+        jones2 = d2 @ jones2
+    if addgains:
+        gain_terms = {
+            name: _term_array(terms, name, count)
+            for name in (
+                "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
+                "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
+            )
+        }
+        gain1r = gain_terms["gainamp1R"] * np.exp(1.0j * gain_terms["gainphase1R"])
+        gain1l = gain_terms["gainamp1L"] * np.exp(1.0j * gain_terms["gainphase1L"])
+        gain2r = gain_terms["gainamp2R"] * np.exp(1.0j * gain_terms["gainphase2R"])
+        gain2l = gain_terms["gainamp2L"] * np.exp(1.0j * gain_terms["gainphase2L"])
+        g1 = np.zeros((count, 2, 2), dtype=complex)
+        g2 = np.zeros((count, 2, 2), dtype=complex)
+        g1[:, 0, 0] = gain1r
+        g1[:, 1, 1] = gain1l
+        g2[:, 0, 0] = gain2r
+        g2[:, 1, 1] = gain2l
+        jones1 = g1 @ jones1
+        jones2 = g2 @ jones2
+        gain1 = np.sqrt(np.abs(gain1r * gain1l))
+        gain2 = np.sqrt(np.abs(gain2r * gain2l))
+    return jones1, jones2, gain1, gain2
+
+
+def _receiver_gain_vectors(terms, count, addgains):
+    """Return circular-basis amplitude gains used for thermal uncertainties."""
+
+    if not addgains:
+        return np.ones((count, 2), dtype=complex), np.ones((count, 2), dtype=complex)
+    gain_names = (
+        "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
+        "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
+    )
+    gain_terms = {name: _term_array(terms, name, count) for name in gain_names}
+    first = np.column_stack((
+        gain_terms["gainamp1R"] * np.exp(1.0j * gain_terms["gainphase1R"]),
+        gain_terms["gainamp1L"] * np.exp(1.0j * gain_terms["gainphase1L"]),
+    ))
+    second = np.column_stack((
+        gain_terms["gainamp2R"] * np.exp(1.0j * gain_terms["gainphase2R"]),
+        gain_terms["gainamp2L"] * np.exp(1.0j * gain_terms["gainphase2L"]),
+    ))
+    return first, second
+
+
+def _path_gain_magnitude(response, fixed_gain, circular_gains):
+    """Return a receptor-path thermal gain relative to its nominal response."""
+
+    response = np.asarray(response, dtype=complex)
+    return np.abs(fixed_gain) * np.linalg.norm(response * circular_gains) / np.linalg.norm(response)
+
+
+def receptor_rows_for_station_terms(dataset, station_terms, receptor_configuration):
+    """Return effective receptor Jones rows for generic fringe selection.
+
+    The rows include the same simulated station gain, leakage, and feed
+    rotation applied by :func:`apply_receptor_corruptions`.  They permit a
+    fringe-evidence estimator to reconstruct Stokes I in a common sky basis
+    rather than treating a particular recorded feed basis as special.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        One-channel native dataset whose product layout is being evaluated.
+    station_terms : mapping
+        Row-aligned native station realization returned by
+        :func:`station_terms_for_dataset`.
+    receptor_configuration : ReceptorConfiguration
+        Resolved station-local receptor paths matching ``dataset.receptors``.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Effective first- and second-station Jones rows, each with shape
+        ``(row, product_slot, 2)`` in the common circular sky basis.
+    """
+
+    if dataset.channel_count != 1:
+        raise ValueError("Native receptor fringe selection requires one channel.")
+    response, _, gain_scale = response_rows_for_dataset(dataset, receptor_configuration)
+    count = dataset.row_count
+    required = (
+        "t1", "t2", "f_el1", "f_el2", "f_par1", "f_par2", "el1", "el2",
+        "par1", "par2", "phi_off1", "phi_off2",
+    )
+    terms = {name: _term_array(station_terms, name, count) for name in required}
+    gain_names = (
+        "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
+        "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
+    )
+    leakage_names = ("leak1R", "leak1L", "leak2R", "leak2L")
+    addgains = all(name in station_terms for name in gain_names)
+    addleakage = all(name in station_terms for name in leakage_names)
+    if addgains:
+        terms.update({name: _term_array(station_terms, name, count) for name in gain_names})
+    if addleakage:
+        terms.update({name: _term_array(station_terms, name, count) for name in leakage_names})
+    jones1, jones2, _, _ = _circular_station_jones(
+        terms,
+        count,
+        addgains=addgains,
+        addFR=not dataset.frcal,
+        addleakage=addleakage,
+    )
+    left = np.zeros((dataset.row_count, dataset.visibilities.shape[2], 2), dtype=complex)
+    right = np.zeros_like(left)
+    products = dataset.correlation_products
+    for row, product_ids in enumerate(dataset.row_product_id):
+        for slot, product_id in enumerate(product_ids):
+            if product_id < 0:
+                continue
+            receptor1 = products.receptor1_id[product_id]
+            receptor2 = products.receptor2_id[product_id]
+            left[row, slot] = gain_scale[receptor1] * (response[receptor1] @ jones1[row])
+            right[row, slot] = gain_scale[receptor2] * (response[receptor2] @ jones2[row])
+    return left, right
 
 
 def _term_array(station_terms, name, count):

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -24,6 +24,11 @@ import ngehtsim.obs.fringe_selection as fringe_selection
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.receptor_configuration import (
+    configuration_for_dataset,
+    resolve_receptor_configuration,
+    response_rows_for_dataset,
+)
 from ngehtsim.obs.simulation_result import SimulationResult
 
 ###################################################
@@ -99,6 +104,10 @@ class obs_generator(object):
                                                                     If None, use the packaged binary weather data.
       weather_cadence (str): ``"daily"`` for the established scalar weather behavior or ``"native"``
                              for linearly interpolated three-hour Zarr weather during observation generation.
+      station_receptors (dict): Optional mapping from station name to an ordered sequence of native
+                                receptor labels or feed specifications. Unspecified stations use ``("R", "L")``.
+      station_signal_paths (dict): Optional nested mapping of calibrated station/feed path properties.
+                                   A path can define ``jones_vector``, ``sefd_scale``, and ``gain_scale``.
     """
 
     # initialize class instantiation
@@ -106,7 +115,8 @@ class obs_generator(object):
                  surf_rms_overrides=None, receiver_configuration_overrides=None, bandwidth_overrides=None,
                  T_R_overrides=None, sideband_ratio_overrides=None, lo_freq_overrides=None, hi_freq_overrides=None,
                  ap_eff_overrides=None, wind_loading_overrides=None, custom_receivers=None, station_uptimes=None,
-                 array=None, ephem='ephemeris/space', weather_store=None, weather_cadence='daily'):
+                 array=None, ephem='ephemeris/space', weather_store=None, weather_cadence='daily',
+                 station_receptors=None, station_signal_paths=None):
 
         #############################
         # astropy cache
@@ -129,6 +139,8 @@ class obs_generator(object):
         wind_loading_overrides = {} if wind_loading_overrides is None else wind_loading_overrides
         custom_receivers = {} if custom_receivers is None else custom_receivers
         station_uptimes = {} if station_uptimes is None else station_uptimes
+        station_receptors = {} if station_receptors is None else station_receptors
+        station_signal_paths = {} if station_signal_paths is None else station_signal_paths
         if weather_store is not None and not isinstance(weather_store, ZarrWeatherStore):
             raise TypeError("weather_store must be a ZarrWeatherStore instance or None.")
         if weather_cadence not in ('daily', 'native'):
@@ -154,6 +166,8 @@ class obs_generator(object):
         self.wind_loading_overrides = copy.deepcopy(wind_loading_overrides)
         self.custom_receivers = copy.deepcopy(custom_receivers)
         self.station_uptimes = copy.deepcopy(station_uptimes)
+        self.station_receptors = copy.deepcopy(station_receptors)
+        self.station_signal_paths = copy.deepcopy(station_signal_paths)
         self.array = array
         self.ephem = ephem
         self.weather_store = weather_store
@@ -732,6 +746,8 @@ class obs_generator(object):
             "t_start": self.settings["t_start"],
             "t_stop": self.settings["t_start"] + self.settings["dt"],
             "mjd": self.mjd,
+            "station_receptors": self.station_receptors,
+            "station_signal_paths": self.station_signal_paths,
         }
 
     # build context for source-model adapters
@@ -745,6 +761,8 @@ class obs_generator(object):
             "transform_backend": self.settings["transform_backend"],
             "raster_tolerance": self.settings["raster_tolerance"],
             "verbosity": self.verbosity,
+            "station_receptors": self.station_receptors,
+            "station_signal_paths": self.station_signal_paths,
         }
 
     ###################################################
@@ -838,8 +856,9 @@ class obs_generator(object):
         del p  # Native Fisher-forecast sampling is intentionally not supported.
         input_model = self._resolve_input_model(input_model, "simulate")
         if allow_mixed_basis:
-            raise NotImplementedError(
-                "Mixed-polarization simulation will be added to the native RIME path."
+            raise ValueError(
+                "allow_mixed_basis is obsolete for native simulation; configure "
+                "station_receptors and station_signal_paths instead."
             )
         if "space" in self.sites:
             raise NotImplementedError(
@@ -867,10 +886,16 @@ class obs_generator(object):
         if template.row_count == 0:
             return SimulationResult(template, {})
 
-        sampled, F0 = source_models.observe_source_dataset(
+        receptor_configuration = resolve_receptor_configuration(
+            template.stations.names,
+            self.station_receptors,
+            self.station_signal_paths,
+        )
+        sampled, F0, sky_coherency = source_models.observe_source_dataset(
             input_model,
             template,
             self.source_context(),
+            return_coherency=True,
         )
         station_terms, stations = station_observation.station_terms_for_dataset(
             sampled,
@@ -890,10 +915,12 @@ class obs_generator(object):
             reference_mjd=self.mjd,
             cache=self.station_term_cache,
         )
-        corrupted = instrumental_corruptions.apply_circular_corruptions(
+        corrupted = instrumental_corruptions.apply_receptor_corruptions(
             sampled,
+            sky_coherency,
             station_terms,
             stations,
+            receptor_configuration,
             self.rng,
             addnoise=addnoise,
             addgains=addgains,
@@ -1330,7 +1357,8 @@ class obs_generator(object):
         # return observation object
         return obs
 
-    def _native_selection_mask(self, dataset, input_model=None, simulation_kwargs=None):
+    def _native_selection_mask(self, dataset, station_terms, input_model=None,
+                               simulation_kwargs=None):
         """Return the native row-selection mask for availability and fringe finding."""
 
         mask = ~np.any(dataset.flags & dataset.sample_present, axis=(1, 2))
@@ -1362,15 +1390,18 @@ class obs_generator(object):
 
         snr_algorithm, snr_args = self.settings["fringe_finder"]
         snr_algorithm = snr_algorithm.lower()
+        receptor_configuration = resolve_receptor_configuration(
+            dataset.stations.names,
+            self.station_receptors,
+            self.station_signal_paths,
+        )
+        fringe_rows = _fringe_rows_from_dataset(
+            dataset,
+            station_terms=station_terms,
+            receptor_configuration=receptor_configuration,
+        )
         if snr_algorithm == "naive":
-            circular_slots = dataset.circular_product_slots()
-            rows = np.arange(dataset.row_count)
-            pseudo_i_amplitude = 0.5 * (
-                np.abs(dataset.visibilities[rows, 0, circular_slots[:, 0]])
-                + np.abs(dataset.visibilities[rows, 0, circular_slots[:, 1]])
-            )
-            pseudo_i_sigma = dataset.sigma_jy[rows, 0, circular_slots[:, 0]] / np.sqrt(2.0)
-            mask &= (pseudo_i_amplitude / pseudo_i_sigma) > snr_args
+            mask &= fringe_rows.detectability_snr > snr_args
         elif snr_algorithm == "fringegroups":
             selected_indices = np.flatnonzero(mask)
             selected = dataset.take_rows(selected_indices)
@@ -1379,6 +1410,8 @@ class obs_generator(object):
                 selected,
                 snr_args[0],
                 snr_args[1],
+                station_terms=_take_station_terms(station_terms, selected_indices),
+                receptor_configuration=receptor_configuration,
             )
         elif snr_algorithm == "fpt":
             if input_model is None or simulation_kwargs is None:
@@ -1389,6 +1422,8 @@ class obs_generator(object):
             mask &= self._native_fpt_selection_mask(
                 dataset,
                 input_model,
+                station_terms,
+                receptor_configuration,
                 snr_ref,
                 tint_ref,
                 freq_ref,
@@ -1402,8 +1437,9 @@ class obs_generator(object):
             raise ValueError("Unknown algorithm for fringe_finder.")
         return mask
 
-    def _native_fpt_selection_mask(self, target_dataset, target_model, snr_ref,
-                                   tint_ref, freq_ref, model_ref, simulation_kwargs,
+    def _native_fpt_selection_mask(self, target_dataset, target_model,
+                                   target_station_terms, target_receptor_configuration,
+                                   snr_ref, tint_ref, freq_ref, model_ref, simulation_kwargs,
                                    target_available_sites, target_row_available,
                                    unready_sites):
         """Run the FPT reference simulation without constructing ``ehtim.Obsdata``."""
@@ -1428,8 +1464,20 @@ class obs_generator(object):
             and site not in unready_sites
         ]
         return fringe_selection.fpt_fringe_group_mask(
-            _fringe_rows_from_dataset(target_dataset),
-            _fringe_rows_from_dataset(reference_dataset),
+            _fringe_rows_from_dataset(
+                target_dataset,
+                station_terms=target_station_terms,
+                receptor_configuration=target_receptor_configuration,
+            ),
+            _fringe_rows_from_dataset(
+                reference_dataset,
+                station_terms=reference_result.station_terms,
+                receptor_configuration=resolve_receptor_configuration(
+                    reference_dataset.stations.names,
+                    reference_generator.station_receptors,
+                    reference_generator.station_signal_paths,
+                ),
+            ),
             snr_ref,
             tint_ref,
             freq_ref / (self.freq / 1.0e9),
@@ -1480,6 +1528,7 @@ class obs_generator(object):
 
         mask = self._native_selection_mask(
             result.dataset,
+            result.station_terms,
             input_model=input_model,
             simulation_kwargs=simulation_kwargs,
         )
@@ -2168,14 +2217,97 @@ def fringegroups(obsgen, obs, snr_ref, tint_ref):
     )
 
 
-def _fringe_rows_from_dataset(dataset):
-    """Extract circular parallel-hand fringe-selection inputs from a native dataset."""
+def _take_station_terms(station_terms, row_indices):
+    """Return row-aligned station terms restricted to selected native rows."""
+
+    row_indices = np.asarray(row_indices, dtype=np.intp)
+    count = len(station_terms["t1"])
+    selected = {}
+    for name, values in station_terms.items():
+        values_array = np.asarray(values)
+        if values_array.shape == (count,):
+            selected[name] = values_array[row_indices]
+        else:
+            selected[name] = values
+    return selected
+
+
+def _fringe_rows_from_dataset(dataset, station_terms=None, receptor_configuration=None):
+    """Extract basis-agnostic fringe evidence from a native dataset.
+
+    Supplying station terms and a receptor configuration enables weighted
+    Stokes-I reconstruction in the common sky basis. Fully calibrated mixed
+    datasets can infer their standard R/L/X/Y responses. The circular RR/LL
+    path remains available for narrow compatibility callers that provide
+    neither.
+    """
 
     if dataset.channel_count != 1:
         raise ValueError("Native fringe selection requires exactly one spectral channel.")
-    circular_slots = dataset.circular_product_slots()
-    rows = np.arange(dataset.row_count)
     names = np.asarray(dataset.stations.names)
+    if station_terms is not None or receptor_configuration is not None:
+        if station_terms is None or receptor_configuration is None:
+            raise ValueError(
+                "Native mixed-receptor fringe selection requires station_terms and receptor_configuration."
+            )
+        left, right = instrumental_corruptions.receptor_rows_for_station_terms(
+            dataset,
+            station_terms,
+            receptor_configuration,
+        )
+        present = dataset.sample_present[:, 0] & ~dataset.flags[:, 0]
+        snr = fringe_selection.receptor_fringe_snr(
+            dataset.visibilities[:, 0],
+            dataset.sigma_jy[:, 0],
+            left,
+            right,
+            present,
+        )
+        return fringe_selection.FringeRows(
+            time=dataset.time_mjd,
+            station1=names[dataset.antenna1],
+            station2=names[dataset.antenna2],
+            integration_time_s=dataset.integration_time_s,
+            fringe_snr=snr,
+        )
+
+    try:
+        circular_slots = dataset.circular_product_slots()
+    except ValueError:
+        if not all((dataset.ampcal, dataset.phasecal, dataset.dcal, dataset.frcal)):
+            raise ValueError(
+                "Mixed-receptor fringe selection needs station_terms and "
+                "receptor_configuration when the dataset is uncalibrated."
+            )
+        configuration = configuration_for_dataset(dataset)
+        response, _, gain_scale = response_rows_for_dataset(dataset, configuration)
+        left = np.zeros((dataset.row_count, dataset.product_slot_count, 2), dtype=complex)
+        right = np.zeros_like(left)
+        products = dataset.correlation_products
+        for row, product_ids in enumerate(dataset.row_product_id):
+            for slot, product_id in enumerate(product_ids):
+                if product_id < 0:
+                    continue
+                receptor1 = products.receptor1_id[product_id]
+                receptor2 = products.receptor2_id[product_id]
+                left[row, slot] = gain_scale[receptor1] * response[receptor1]
+                right[row, slot] = gain_scale[receptor2] * response[receptor2]
+        present = dataset.sample_present[:, 0] & ~dataset.flags[:, 0]
+        snr = fringe_selection.receptor_fringe_snr(
+            dataset.visibilities[:, 0],
+            dataset.sigma_jy[:, 0],
+            left,
+            right,
+            present,
+        )
+        return fringe_selection.FringeRows(
+            time=dataset.time_mjd,
+            station1=names[dataset.antenna1],
+            station2=names[dataset.antenna2],
+            integration_time_s=dataset.integration_time_s,
+            fringe_snr=snr,
+        )
+    rows = np.arange(dataset.row_count)
     return fringe_selection.FringeRows(
         time=dataset.time_mjd,
         station1=names[dataset.antenna1],
@@ -2188,13 +2320,18 @@ def _fringe_rows_from_dataset(dataset):
     )
 
 
-def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref):
-    """Apply the fringe-group proxy directly to a native circular dataset."""
+def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref, station_terms=None,
+                         receptor_configuration=None):
+    """Apply the fringe-group proxy directly to a native receptor dataset."""
 
     if dataset.row_count == 0:
         return np.zeros(0, dtype=bool)
 
-    rows = _fringe_rows_from_dataset(dataset)
+    rows = _fringe_rows_from_dataset(
+        dataset,
+        station_terms=station_terms,
+        receptor_configuration=receptor_configuration,
+    )
     available_sites = [site for site in obsgen.sites if obsgen.bands[site] is not None]
     return fringe_selection.fringe_group_mask(
         rows,
@@ -2239,6 +2376,8 @@ def _fpt_reference_generator(obsgen, snr_ref, tint_ref, freq_ref, model_ref,
         wind_loading_overrides=copy.deepcopy(obsgen.wind_loading_overrides),
         custom_receivers=copy.deepcopy(obsgen.custom_receivers),
         station_uptimes=copy.deepcopy(obsgen.station_uptimes),
+        station_receptors=copy.deepcopy(getattr(obsgen, "station_receptors", {})),
+        station_signal_paths=copy.deepcopy(getattr(obsgen, "station_signal_paths", {})),
         array=getattr(obsgen, 'array', None),
         ephem=ephem,
         weather_store=obsgen.weather_store,

--- a/ngehtsim/obs/observation_geometry.py
+++ b/ngehtsim/obs/observation_geometry.py
@@ -10,11 +10,12 @@ import ehtim as eh
 
 from ngehtsim.obs.visibility_dataset import (
     CIRCULAR_PRODUCT_LABELS,
-    ReceptorTable,
     StationTable,
     VisibilityDataset,
+    receptor_products_for_rows,
     standard_products_for_rows,
 )
+from ngehtsim.obs.receptor_configuration import resolve_receptor_configuration
 
 
 GEOMETRY_CACHE_FIELDS = (
@@ -28,6 +29,8 @@ GEOMETRY_CACHE_FIELDS = (
     "t_start",
     "t_stop",
     "mjd",
+    "station_receptors",
+    "station_signal_paths",
 )
 
 
@@ -130,7 +133,7 @@ def _cache_value(value):
 
 
 def geometry_cache_key(context):
-    return tuple((field, _cache_value(context[field])) for field in GEOMETRY_CACHE_FIELDS)
+    return tuple((field, _cache_value(context.get(field))) for field in GEOMETRY_CACHE_FIELDS)
 
 ###################################################
 # empty observation construction
@@ -388,7 +391,7 @@ def ground_visibility_template(array, context, geometry=None):
     """Build a native visibility template for a ground-only array.
 
     The template carries geometry and thermal uncertainties but contains
-    zero-valued circular visibilities. Source sampling occurs separately
+    zero-valued native visibility products. Source sampling occurs separately
     through the source-adapter layer.
 
     Parameters
@@ -404,24 +407,12 @@ def ground_visibility_template(array, context, geometry=None):
     Returns
     -------
     VisibilityDataset
-        One-channel circular template with RR, LL, RL, LR products and thermal
-        ``sigma_jy`` values computed from station SEFDs.
+        One-channel template containing every requested station-feed product
+        and thermal ``sigma_jy`` values computed from station SEFDs.
     """
 
     if geometry is None:
         geometry = ground_geometry(array, context)
-
-    sefd1r = array.tarr["sefdr"][geometry.station1_indices]
-    sefd2r = array.tarr["sefdr"][geometry.station2_indices]
-    sefd1l = array.tarr["sefdl"][geometry.station1_indices]
-    sefd2l = array.tarr["sefdl"][geometry.station2_indices]
-    denominator = 2.0 * float(context["bandwidth_hz"]) * float(context["t_int"])
-    sigma = np.column_stack((
-        np.sqrt(sefd1r * sefd2r / denominator) / 0.88,
-        np.sqrt(sefd1l * sefd2l / denominator) / 0.88,
-        np.sqrt(sefd1r * sefd2l / denominator) / 0.88,
-        np.sqrt(sefd1l * sefd2r / denominator) / 0.88,
-    ))
 
     scan_half_width_s = 0.5 * float(context["t_int"])
     scan_times = np.unique(geometry.time_hours)
@@ -431,17 +422,47 @@ def ground_visibility_template(array, context, geometry=None):
     scan_stop_mjd = reference_mjd + (scan_times / 24.0) + (scan_half_width_s / 86400.0)
 
     stations = StationTable.from_ehtim_tarr(array.tarr)
-    receptors = ReceptorTable.from_station_labels(
-        len(stations.names),
-        ("R", "L"),
-        "CIRCULAR",
+    configuration = resolve_receptor_configuration(
+        stations.names,
+        context.get("station_receptors"),
+        context.get("station_signal_paths"),
     )
-    correlation_products, row_product_id = standard_products_for_rows(
-        receptors,
-        geometry.station1_indices,
-        geometry.station2_indices,
-        CIRCULAR_PRODUCT_LABELS,
+    receptors = configuration.receptors
+    receptor_labels = np.asarray(receptors.polarization_label, dtype=object)
+    standard_circular = all(
+        tuple(receptor_labels[receptors.station_index == index]) == ("R", "L")
+        for index in range(len(stations.names))
     )
+    if standard_circular:
+        correlation_products, row_product_id = standard_products_for_rows(
+            receptors,
+            geometry.station1_indices,
+            geometry.station2_indices,
+            CIRCULAR_PRODUCT_LABELS,
+        )
+    else:
+        correlation_products, row_product_id = receptor_products_for_rows(
+            receptors,
+            geometry.station1_indices,
+            geometry.station2_indices,
+        )
+    slots = row_product_id.shape[1]
+    visibilities = np.zeros((len(time_mjd), 1, slots), dtype=complex)
+    sigma = np.full((len(time_mjd), 1, slots), np.nan, dtype=float)
+    flags = np.ones((len(time_mjd), 1, slots), dtype=bool)
+    denominator = 2.0 * float(context["bandwidth_hz"]) * float(context["t_int"])
+    for row, product_ids in enumerate(row_product_id):
+        for slot, product_id in enumerate(product_ids):
+            if product_id < 0:
+                continue
+            receptor1 = correlation_products.receptor1_id[product_id]
+            receptor2 = correlation_products.receptor2_id[product_id]
+            station1 = receptors.station_index[receptor1]
+            station2 = receptors.station_index[receptor2]
+            sefd1 = array.tarr["sefdr"][station1] * configuration.sefd_scale[receptor1]
+            sefd2 = array.tarr["sefdr"][station2] * configuration.sefd_scale[receptor2]
+            sigma[row, 0, slot] = np.sqrt(sefd1 * sefd2 / denominator) / 0.88
+            flags[row, 0, slot] = False
     return VisibilityDataset(
         stations=stations,
         receptors=receptors,
@@ -457,9 +478,9 @@ def ground_visibility_template(array, context, geometry=None):
         channel_bandwidth_hz=np.array((float(context["bandwidth_hz"]),)),
         spectral_window_id=np.array((0,), dtype=np.intp),
         row_product_id=row_product_id,
-        visibilities=np.zeros((len(time_mjd), 1, 4), dtype=complex),
-        sigma_jy=sigma[:, np.newaxis, :],
-        flags=np.zeros((len(time_mjd), 1, 4), dtype=bool),
+        visibilities=visibilities,
+        sigma_jy=sigma,
+        flags=flags,
         source=str(context["ra"]) + ":" + str(context["dec"]),
         ra_hours=float(context["ra"]),
         dec_degrees=float(context["dec"]),

--- a/ngehtsim/obs/receptor_configuration.py
+++ b/ngehtsim/obs/receptor_configuration.py
@@ -1,0 +1,270 @@
+"""Validated station-receptor configuration for native RIME simulations.
+
+The native simulator represents every recorded voltage stream with a Jones
+row in a common circular sky basis.  Standard ``R``, ``L``, ``X``, and ``Y``
+labels have conventional rows; arbitrary signal paths must provide one
+explicitly.  This keeps the on-disk data model permissive while preventing
+the simulator from inventing physics for an unfamiliar feed label.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ngehtsim.obs.visibility_dataset import ReceptorTable
+
+
+STANDARD_JONES_ROWS = {
+    "R": np.array((1.0, 0.0), dtype=complex),
+    "L": np.array((0.0, 1.0), dtype=complex),
+    "X": np.array((1.0, 1.0), dtype=complex) / np.sqrt(2.0),
+    "Y": np.array((-1.0j, 1.0j), dtype=complex) / np.sqrt(2.0),
+}
+
+
+@dataclass(frozen=True)
+class ReceptorConfiguration:
+    """Resolved station-local signal paths for one native simulation.
+
+    Parameters
+    ----------
+    receptors : ReceptorTable
+        Explicit station/feed inventory carried by the output dataset.
+    response_circular : numpy.ndarray, shape (receptor, 2)
+        Uncorrupted Jones row for each voltage stream in the common circular
+        ``(R, L)`` sky basis.
+    sefd_scale : numpy.ndarray, shape (receptor,)
+        Positive per-receptor multiplier applied to weather-derived station
+        SEFD values when calculating thermal uncertainty.
+    gain_scale : numpy.ndarray, shape (receptor,)
+        Fixed complex per-receptor gain. This is applied in addition to the
+        simulated stochastic station gain when ``addgains=True``.
+
+    Notes
+    -----
+    The response row is deliberately general: it can describe ordinary
+    circular or linear feeds, a single-feed station, an over-complete feed
+    inventory, or a custom calibrated voltage path.
+    """
+
+    receptors: ReceptorTable
+    response_circular: np.ndarray
+    sefd_scale: np.ndarray
+    gain_scale: np.ndarray
+
+    def __post_init__(self):
+        response = np.array(self.response_circular, dtype=complex, copy=True)
+        sefd_scale = np.array(self.sefd_scale, dtype=float, copy=True)
+        gain_scale = np.array(self.gain_scale, dtype=complex, copy=True)
+        count = self.receptors.count
+        if response.shape != (count, 2):
+            raise ValueError("response_circular must have shape (receptor, 2).")
+        if sefd_scale.shape != (count,) or gain_scale.shape != (count,):
+            raise ValueError("Receptor path scales must have one value per receptor.")
+        if not np.all(np.isfinite(response)) or not np.all(np.isfinite(gain_scale)):
+            raise ValueError("Receptor response and gain values must be finite.")
+        if np.any(sefd_scale <= 0.0) or not np.all(np.isfinite(sefd_scale)):
+            raise ValueError("Receptor SEFD scales must be positive and finite.")
+        if np.any(np.linalg.norm(response, axis=1) == 0.0):
+            raise ValueError("Receptor Jones rows must be non-zero.")
+        response.setflags(write=False)
+        sefd_scale.setflags(write=False)
+        gain_scale.setflags(write=False)
+        object.__setattr__(self, "response_circular", response)
+        object.__setattr__(self, "sefd_scale", sefd_scale)
+        object.__setattr__(self, "gain_scale", gain_scale)
+
+
+def resolve_receptor_configuration(station_names, station_receptors=None,
+                                   station_signal_paths=None):
+    """Resolve public station/feed settings into immutable native paths.
+
+    Parameters
+    ----------
+    station_names : iterable of str
+        Ordered native station names.
+    station_receptors : mapping, optional
+        Maps station names to an ordered sequence of standard labels or feed
+        specifications. Omitting a station uses the conventional ``("R", "L")``
+        inventory. A feed specification is a mapping with ``feed_id`` and
+        optional ``polarization_label`` keys.
+    station_signal_paths : mapping, optional
+        Optional nested mapping ``{station: {feed_id: specification}}``. Each
+        specification may set ``jones_vector`` (two complex circular-basis
+        components), ``sefd_scale`` (positive float), and ``gain_scale``
+        (complex). It supplements, rather than replaces, ``station_receptors``.
+
+    Returns
+    -------
+    ReceptorConfiguration
+        Resolved receptors and their physical signal-path properties.
+
+    Raises
+    ------
+    ValueError
+        If a station is unknown, a feed is duplicated, a standard response is
+        unavailable, or a supplied path specification is invalid.
+    """
+
+    names = tuple(str(name) for name in station_names)
+    receptor_map = {} if station_receptors is None else dict(station_receptors)
+    path_map = {} if station_signal_paths is None else dict(station_signal_paths)
+    unknown = (set(receptor_map) | set(path_map)) - set(names)
+    if unknown:
+        raise ValueError("Receptor settings reference unknown stations: {0}.".format(
+            ", ".join(sorted(unknown))
+        ))
+
+    station_index = []
+    feed_ids = []
+    labels = []
+    bases = []
+    responses = []
+    sefd_scales = []
+    gain_scales = []
+    for index, station in enumerate(names):
+        feeds = receptor_map.get(station, ("R", "L"))
+        if isinstance(feeds, str):
+            raise ValueError("Station receptor inventories must be sequences, not strings.")
+        seen = set()
+        for feed in feeds:
+            spec = _feed_specification(feed)
+            feed_id = spec["feed_id"]
+            if feed_id in seen:
+                raise ValueError("Station {0} repeats feed_id {1!r}.".format(station, feed_id))
+            seen.add(feed_id)
+            path_spec = dict(path_map.get(station, {}).get(feed_id, {}))
+            path_spec.update({key: value for key, value in spec.items() if key != "feed_id"})
+            label = str(path_spec.pop("polarization_label", feed_id)).upper()
+            basis = str(path_spec.pop("basis", _basis_for_label(label))).upper()
+            response = _response_for_path(label, path_spec.pop("jones_vector", None))
+            sefd_scale = float(path_spec.pop("sefd_scale", 1.0))
+            gain_scale = complex(path_spec.pop("gain_scale", 1.0 + 0.0j))
+            if path_spec:
+                raise ValueError(
+                    "Unsupported signal-path keys for {0}/{1}: {2}.".format(
+                        station, feed_id, ", ".join(sorted(path_spec))
+                    )
+                )
+            station_index.append(index)
+            feed_ids.append(feed_id)
+            labels.append(label)
+            bases.append(basis)
+            responses.append(response)
+            sefd_scales.append(sefd_scale)
+            gain_scales.append(gain_scale)
+        if not seen:
+            raise ValueError("Station {0} must define at least one receptor.".format(station))
+
+    return ReceptorConfiguration(
+        receptors=ReceptorTable(
+            station_index=np.asarray(station_index, dtype=np.intp),
+            feed_id=tuple(feed_ids),
+            polarization_label=tuple(labels),
+            basis=tuple(bases),
+        ),
+        response_circular=np.asarray(responses, dtype=complex),
+        sefd_scale=np.asarray(sefd_scales, dtype=float),
+        gain_scale=np.asarray(gain_scales, dtype=complex),
+    )
+
+
+def response_rows_for_dataset(dataset, configuration):
+    """Return response rows aligned to a dataset's receptor table.
+
+    A native geometry template and its configuration must describe precisely
+    the same station/feed inventory.  This strict check prevents accidental
+    application of a response to the wrong voltage stream.
+    """
+
+    receptors = dataset.receptors
+    configured = configuration.receptors
+    if (
+        not np.array_equal(receptors.station_index, configured.station_index)
+        or receptors.feed_id != configured.feed_id
+        or receptors.polarization_label != configured.polarization_label
+    ):
+        raise ValueError("Dataset receptors do not match the resolved signal-path configuration.")
+    return configuration.response_circular, configuration.sefd_scale, configuration.gain_scale
+
+
+def configuration_for_dataset(dataset, station_receptors=None, station_signal_paths=None):
+    """Resolve or infer the signal paths needed by an existing dataset.
+
+    Parameters
+    ----------
+    dataset : VisibilityDataset
+        Native dataset whose receptor table defines the required station/feed
+        inventory.
+    station_receptors, station_signal_paths : mapping, optional
+        Public configuration inputs accepted by
+        :func:`resolve_receptor_configuration`. When both are omitted, the
+        existing dataset's standard R/L/X/Y labels are used to infer paths.
+
+    Returns
+    -------
+    ReceptorConfiguration
+        Configuration guaranteed to match ``dataset.receptors``.
+
+    Raises
+    ------
+    ValueError
+        If a custom-label dataset has no explicit Jones-row configuration or
+        supplied settings do not match the dataset receptor inventory.
+    """
+
+    if station_receptors is None and station_signal_paths is None:
+        inferred = {}
+        for station_index, station in enumerate(dataset.stations.names):
+            receptor_indices = np.flatnonzero(dataset.receptors.station_index == station_index)
+            inferred[station] = tuple(
+                {
+                    "feed_id": dataset.receptors.feed_id[index],
+                    "polarization_label": dataset.receptors.polarization_label[index],
+                    "basis": dataset.receptors.basis[index],
+                }
+                for index in receptor_indices
+            )
+        configuration = resolve_receptor_configuration(dataset.stations.names, inferred)
+    else:
+        configuration = resolve_receptor_configuration(
+            dataset.stations.names,
+            station_receptors,
+            station_signal_paths,
+        )
+    response_rows_for_dataset(dataset, configuration)
+    return configuration
+
+
+def _feed_specification(feed):
+    if isinstance(feed, str):
+        return {"feed_id": str(feed)}
+    if not isinstance(feed, dict):
+        raise TypeError("Each station receptor must be a label string or mapping.")
+    if "feed_id" not in feed:
+        raise ValueError("Receptor mappings must define feed_id.")
+    return dict(feed)
+
+
+def _basis_for_label(label):
+    if label in ("R", "L"):
+        return "CIRCULAR"
+    if label in ("X", "Y"):
+        return "LINEAR"
+    return "CUSTOM"
+
+
+def _response_for_path(label, supplied):
+    if supplied is None:
+        try:
+            return np.array(STANDARD_JONES_ROWS[label], copy=True)
+        except KeyError as exc:
+            raise ValueError(
+                "Receptor label {0!r} requires an explicit jones_vector.".format(label)
+            ) from exc
+    response = np.asarray(supplied, dtype=complex)
+    if response.shape != (2,):
+        raise ValueError("jones_vector must contain exactly two circular-basis components.")
+    return np.array(response, copy=True)

--- a/ngehtsim/obs/source_models.py
+++ b/ngehtsim/obs/source_models.py
@@ -9,6 +9,10 @@ from astropy.constants import c as SPEED_OF_LIGHT
 
 from ngehtsim.obs import raster_sampling
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
+from ngehtsim.obs.receptor_configuration import (
+    configuration_for_dataset,
+    response_rows_for_dataset,
+)
 
 try:
     import ngEHTforecast.fisher as fp
@@ -50,17 +54,11 @@ def _sample_raster(image, uv, polrep_obs, context, *, native_path):
     )
 
 
-def _require_native_circular_dataset(dataset):
+def _require_native_single_channel_dataset(dataset):
     if not isinstance(dataset, VisibilityDataset):
         raise TypeError("dataset must be a VisibilityDataset instance.")
     if dataset.channel_count != 1:
         raise ValueError("Native source sampling requires exactly one spectral channel.")
-    try:
-        return dataset.circular_product_slots()
-    except ValueError as exc:
-        raise ValueError(
-            "Native source sampling requires exactly circular RR, LL, RL, LR correlations."
-        ) from exc
 
 
 def _dataset_uv(dataset):
@@ -68,26 +66,50 @@ def _dataset_uv(dataset):
     return dataset.uvw_m[:, :2] / wavelength
 
 
-def _write_circular_samples(visibilities, slots, rows, sampled):
-    """Write RR, LL, RL, LR samples into explicitly mapped product slots."""
+def _circular_coherency(sampled):
+    """Return circular-basis coherency matrices from ehtim sampling output."""
 
-    rows = np.asarray(rows, dtype=np.intp)
-    visibilities[rows, 0, slots[rows, 0]] = sampled[0]
-    if sampled[1] is not None:
-        visibilities[rows, 0, slots[rows, 1]] = sampled[1]
-    if sampled[2] is not None:
-        visibilities[rows, 0, slots[rows, 2]] = sampled[2]
-        visibilities[rows, 0, slots[rows, 3]] = sampled[3]
+    rr, ll, rl, lr = sampled
+    rr = np.asarray(rr, dtype=complex)
+    count = len(rr)
+    coherency = np.zeros((count, 2, 2), dtype=complex)
+    coherency[:, 0, 0] = rr
+    if ll is not None:
+        coherency[:, 1, 1] = ll
+    if rl is not None:
+        coherency[:, 0, 1] = rl
+    if lr is not None:
+        coherency[:, 1, 0] = lr
+    return coherency
 
 
-def _with_circular_samples(dataset, sampled, context):
-    visibilities = np.array(dataset.visibilities, copy=True)
-    _write_circular_samples(
-        visibilities,
-        dataset.circular_product_slots(),
-        np.arange(dataset.row_count),
-        sampled,
+def _receptor_configuration(dataset, context):
+    configuration = configuration_for_dataset(
+        dataset,
+        context.get("station_receptors"),
+        context.get("station_signal_paths"),
     )
+    response, _, _ = response_rows_for_dataset(dataset, configuration)
+    return configuration, response
+
+
+def _write_coherency_samples(visibilities, dataset, coherency, context):
+    """Project circular sky coherency into every row's receptor products."""
+
+    _, response = _receptor_configuration(dataset, context)
+    products = dataset.correlation_products
+    for row, product_ids in enumerate(dataset.row_product_id):
+        for slot, product_id in enumerate(product_ids):
+            if product_id < 0:
+                continue
+            first = response[products.receptor1_id[product_id]]
+            second = response[products.receptor2_id[product_id]]
+            visibilities[row, 0, slot] = first @ coherency[row] @ np.conj(second)
+
+
+def _with_coherency_samples(dataset, coherency, context):
+    visibilities = np.array(dataset.visibilities, copy=True)
+    _write_coherency_samples(visibilities, dataset, coherency, context)
     return replace(
         dataset,
         visibilities=visibilities,
@@ -116,10 +138,10 @@ class EhtimImageAdapter(object):
 
     Notes
     -----
-    :meth:`observe_dataset` samples directly into a native dataset, avoiding
-    an intermediate ``ehtim.Obsdata`` data table. It currently requires one
-    channel with exactly circular RR, LL, RL, LR products.  The public
-    ``transform_backend`` setting controls its Fourier-transform backend.
+    :meth:`observe_dataset` samples directly into a one-channel native
+    receptor layout, avoiding an intermediate ``ehtim.Obsdata`` data table.
+    The public ``transform_backend`` setting controls its Fourier-transform
+    backend.
     """
 
     def __init__(self, input_model):
@@ -186,8 +208,8 @@ class EhtimImageAdapter(object):
         F0 = self.input_model.total_flux()
         return obs, F0
 
-    def observe_dataset(self, dataset, context):
-        """Sample an image onto a native circular single-channel dataset.
+    def observe_dataset(self, dataset, context, return_coherency=False):
+        """Sample an image onto a native single-channel receptor dataset.
 
         Parameters
         ----------
@@ -195,6 +217,10 @@ class EhtimImageAdapter(object):
             Geometry and correlation layout to populate.
         context : mapping
             Normalized observation settings.
+        return_coherency : bool, optional
+            When true, also return the circular sky coherency matrices used to
+            populate the receptor products. This is consumed internally by the
+            native station-corruption RIME.
 
         Returns
         -------
@@ -207,11 +233,11 @@ class EhtimImageAdapter(object):
         Raises
         ------
         ValueError
-            If the dataset is not exactly a one-channel circular layout or the
-            configured native raster transform backend is unsupported.
+            If the dataset is not one channel or the configured native raster
+            transform backend is unsupported.
         """
 
-        _require_native_circular_dataset(dataset)
+        _require_native_single_channel_dataset(dataset)
 
         def sample_dataset():
             sampled = _sample_raster(
@@ -221,14 +247,16 @@ class EhtimImageAdapter(object):
                 context,
                 native_path=True,
             )
-            return _with_circular_samples(
+            coherency = _circular_coherency(sampled)
+            return _with_coherency_samples(
                 dataset,
-                sampled,
+                coherency,
                 context,
-            )
+            ), coherency
 
-        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
-        return sampled_dataset, self.input_model.total_flux()
+        sampled_dataset, coherency = _run_quietly(sample_dataset, context["verbosity"])
+        output = (sampled_dataset, self.input_model.total_flux())
+        return output + (coherency,) if return_coherency else output
 
 
 class EhtimMovieAdapter(object):
@@ -243,8 +271,8 @@ class EhtimMovieAdapter(object):
     Notes
     -----
     The movie's own ``bounds_error`` behavior determines whether observation
-    times outside its nominal range are looped. Native sampling has the same
-    circular single-channel limitation as :class:`EhtimImageAdapter`.
+    times outside its nominal range are looped. Native sampling supports the
+    same one-channel arbitrary-receptor layouts as :class:`EhtimImageAdapter`.
     """
 
     def __init__(self, input_model):
@@ -354,8 +382,8 @@ class EhtimMovieAdapter(object):
         F0 = np.mean(self.input_model.lightcurve)
         return obs, F0
 
-    def observe_dataset(self, dataset, context):
-        """Sample a repeating movie onto a native circular dataset.
+    def observe_dataset(self, dataset, context, return_coherency=False):
+        """Sample a repeating movie onto a native receptor dataset.
 
         Parameters
         ----------
@@ -376,16 +404,16 @@ class EhtimMovieAdapter(object):
         Raises
         ------
         ValueError
-            If the dataset is not exactly a one-channel circular layout or the
-            configured raster transform backend is unsupported.
+            If the dataset is not one channel or the configured raster
+            transform backend is unsupported.
         """
 
-        circular_slots = _require_native_circular_dataset(dataset)
+        _require_native_single_channel_dataset(dataset)
 
         def sample_dataset():
-            visibilities = np.array(dataset.visibilities, copy=True)
             uv = _dataset_uv(dataset)
             observation_times = (dataset.time_mjd - float(context["mjd"])) * 24.0
+            coherency = np.zeros((dataset.row_count, 2, 2), dtype=complex)
 
             for time in np.unique(observation_times):
                 sample_time = time
@@ -403,28 +431,13 @@ class EhtimMovieAdapter(object):
                     context,
                     native_path=True,
                 )
-                _write_circular_samples(
-                    visibilities,
-                    circular_slots,
-                    np.flatnonzero(row_mask),
-                    sampled,
-                )
+                coherency[row_mask] = _circular_coherency(sampled)
 
-            return replace(
-                dataset,
-                visibilities=visibilities,
-                source=context["source"],
-                ra_hours=context["ra"],
-                dec_degrees=context["dec"],
-                ampcal=True,
-                phasecal=True,
-                opacitycal=True,
-                dcal=True,
-                frcal=True,
-            )
+            return _with_coherency_samples(dataset, coherency, context), coherency
 
-        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
-        return sampled_dataset, np.mean(self.input_model.lightcurve)
+        sampled_dataset, coherency = _run_quietly(sample_dataset, context["verbosity"])
+        output = (sampled_dataset, np.mean(self.input_model.lightcurve))
+        return output + (coherency,) if return_coherency else output
 
 
 class EhtimModelAdapter(object):
@@ -438,7 +451,7 @@ class EhtimModelAdapter(object):
     Notes
     -----
     Unlike raster Image and Movie models, this path does not use an NFFT
-    backend. Native sampling still requires a one-channel circular layout.
+    backend. Native sampling supports one-channel arbitrary receptor layouts.
     """
 
     def __init__(self, input_model):
@@ -490,8 +503,8 @@ class EhtimModelAdapter(object):
         F0 = np.abs(self.input_model.sample_uv(0.0, 0.0))
         return obs, F0
 
-    def observe_dataset(self, dataset, context):
-        """Sample an analytic model onto a native circular dataset.
+    def observe_dataset(self, dataset, context, return_coherency=False):
+        """Sample an analytic model onto a native receptor dataset.
 
         Parameters
         ----------
@@ -503,12 +516,12 @@ class EhtimModelAdapter(object):
         Returns
         -------
         VisibilityDataset
-            Dataset with analytic model samples in its circular product slots.
+            Dataset with analytic model samples in its receptor product slots.
         float
             Zero-baseline model amplitude in Jy.
         """
 
-        _require_native_circular_dataset(dataset)
+        _require_native_single_channel_dataset(dataset)
 
         def sample_dataset():
             uv = _dataset_uv(dataset)
@@ -516,14 +529,16 @@ class EhtimModelAdapter(object):
             ll = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="LL")
             rl = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="RL")
             lr = self.input_model.sample_uv(uv[:, 0], uv[:, 1], pol="LR")
-            return _with_circular_samples(
+            coherency = _circular_coherency((rr, ll, rl, lr))
+            return _with_coherency_samples(
                 dataset,
-                (rr, ll, rl, lr),
+                coherency,
                 context,
-            )
+            ), coherency
 
-        sampled_dataset = _run_quietly(sample_dataset, context["verbosity"])
-        return sampled_dataset, np.abs(self.input_model.sample_uv(0.0, 0.0))
+        sampled_dataset, coherency = _run_quietly(sample_dataset, context["verbosity"])
+        output = (sampled_dataset, np.abs(self.input_model.sample_uv(0.0, 0.0)))
+        return output + (coherency,) if return_coherency else output
 
 
 class FisherForecastAdapter(object):
@@ -622,7 +637,7 @@ def observe_source(input_model, obs_empty, context, p=None):
     return adapter_for(input_model).observe(obs_empty, context, p=p)
 
 
-def observe_source_dataset(input_model, dataset, context):
+def observe_source_dataset(input_model, dataset, context, return_coherency=False):
     """Sample a supported source model onto a native visibility dataset.
 
     Parameters
@@ -633,6 +648,9 @@ def observe_source_dataset(input_model, dataset, context):
         Native geometry and correlation layout to populate.
     context : mapping
         Normalized observation settings.
+    return_coherency : bool, optional
+        Return the sampled circular sky coherency as a third value. The public
+        default retains the established two-value return contract.
 
     Returns
     -------
@@ -656,4 +674,4 @@ def observe_source_dataset(input_model, dataset, context):
             "Native VisibilityDataset sampling currently supports ehtim Image, Movie, "
             "and Model inputs only."
         )
-    return adapter.observe_dataset(dataset, context)
+    return adapter.observe_dataset(dataset, context, return_coherency=return_coherency)

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -642,16 +642,17 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
     Returns
     -------
     dict
-        Row-aligned station terms consumed by the circular corruption kernel.
+        Row-aligned station terms consumed by the native receptor RIME.
     StationTable
         Updated immutable station metadata with simulated SEFD and leakage
         values.
 
     Notes
     -----
-    The returned terms are currently specific to circular, one-channel
-    corruption. They are retained in :class:`SimulationResult` as provenance,
-    not yet as a stable archive interchange format.
+    The terms are evaluated in the common circular sky frame and are projected
+    into configured native receptor paths by the one-channel corruption RIME.
+    They are retained in :class:`SimulationResult` as provenance, not yet as a
+    stable archive interchange format.
     """
 
     metadata = station_metadata_for_dataset(

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -407,6 +407,81 @@ def standard_products_for_rows(receptors, antenna1, antenna2, product_labels):
     )
 
 
+def receptor_products_for_rows(receptors, antenna1, antenna2):
+    """Build every station-feed correlation available on each visibility row.
+
+    Unlike :func:`standard_products_for_rows`, this function does not assume a
+    shared two-feed polarization layout.  Each row contains the Cartesian
+    product of the first and second station's receptor inventories.  Dense
+    product slots are padded with ``-1`` for short rows; callers must mark the
+    corresponding data, uncertainty, and flag slots as absent.
+
+    For conventional shared R/L or X/Y inventories, the diagonal products are
+    ordered first followed by the cross products.  This preserves the historic
+    ``RR, LL, RL, LR`` and ``XX, YY, XY, YX`` order respectively.
+
+    Parameters
+    ----------
+    receptors : ReceptorTable
+        Station-local receptor inventory.
+    antenna1, antenna2 : array_like, shape (row,)
+        Ordered station indices for every visibility row.
+
+    Returns
+    -------
+    CorrelationProductTable
+        Unique receptor-pair definitions.
+    numpy.ndarray
+        Product IDs with shape ``(row, max_product_slot)``. Padding is ``-1``.
+    """
+
+    if not isinstance(receptors, ReceptorTable):
+        raise TypeError("receptors must be a ReceptorTable.")
+    antenna1 = _integer_array(antenna1, "antenna1")
+    antenna2 = _integer_array(antenna2, "antenna2")
+    if antenna1.ndim != 1 or antenna2.shape != antenna1.shape:
+        raise ValueError("antenna1 and antenna2 must be matching one-dimensional arrays.")
+
+    per_row_pairs = []
+    maximum = 0
+    labels = np.asarray(receptors.polarization_label, dtype=object)
+    for station1, station2 in zip(antenna1, antenna2):
+        first = np.flatnonzero(receptors.station_index == station1)
+        second = np.flatnonzero(receptors.station_index == station2)
+        if not len(first) or not len(second):
+            raise ValueError("Every visibility station must own at least one receptor.")
+        diagonal = [
+            (left, right)
+            for left in first for right in second
+            if labels[left] == labels[right]
+        ]
+        all_pairs = [(left, right) for left in first for right in second]
+        ordered = diagonal + [pair for pair in all_pairs if pair not in diagonal]
+        per_row_pairs.append(ordered)
+        maximum = max(maximum, len(ordered))
+
+    product_id_by_pair = {}
+    first_receptor = []
+    second_receptor = []
+    row_product_id = np.full((len(antenna1), maximum), -1, dtype=np.intp)
+    for row, pairs in enumerate(per_row_pairs):
+        for slot, pair in enumerate(pairs):
+            product_id = product_id_by_pair.get(pair)
+            if product_id is None:
+                product_id = len(first_receptor)
+                product_id_by_pair[pair] = product_id
+                first_receptor.append(pair[0])
+                second_receptor.append(pair[1])
+            row_product_id[row, slot] = product_id
+    return (
+        CorrelationProductTable(
+            receptor1_id=np.asarray(first_receptor, dtype=np.intp),
+            receptor2_id=np.asarray(second_receptor, dtype=np.intp),
+        ),
+        row_product_id,
+    )
+
+
 @dataclass(frozen=True)
 class VisibilityDataset:
     """Native visibility data with explicit station-receptor correlations.

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -519,11 +519,11 @@ def test_native_circular_corruptions_flag_rows_and_support_selection():
     assert not np.any(selected.flags)
 
 
-def test_mixed_basis_output_is_rejected_until_native_support_exists():
+def test_legacy_mixed_basis_switch_is_obsolete():
     obsgen = og.obs_generator(settings=SETTINGS)
 
-    with pytest.raises(NotImplementedError, match="Mixed-polarization simulation"):
-        obsgen.make_obs(_polarized_model(), allow_mixed_basis=True)
+    with pytest.raises(ValueError, match="allow_mixed_basis is obsolete"):
+        obsgen.simulate(_polarized_model(), allow_mixed_basis=True)
 
 
 def test_station_registry_marks_roen_as_linear():

--- a/tests/test_mixed_receptor_rime.py
+++ b/tests/test_mixed_receptor_rime.py
@@ -1,0 +1,273 @@
+"""Regression tests for native mixed-receptor simulation and fringe evidence."""
+
+from __future__ import annotations
+
+import numpy as np
+import ehtim as eh
+
+import ngehtsim.obs.fringe_selection as fringe_selection
+import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
+import ngehtsim.obs.obs_generator as og
+import ngehtsim.obs.source_models as source_models
+from ngehtsim.obs.receptor_configuration import (
+    STANDARD_JONES_ROWS,
+    resolve_receptor_configuration,
+)
+
+
+SETTINGS = {
+    "source": "M87",
+    "sites": ["ALMA", "APEX", "LMT", "SMT"],
+    "weather": "typical",
+    "t_start": 0.0,
+    "dt": 1.0,
+    "t_int": 600.0,
+    "t_rest": 1200.0,
+    "fringe_finder": ["fringegroups", [0.0, 10.0]],
+    "random_seed": 1,
+    "transform_backend": "direct",
+}
+
+
+MIXED_RECEPTORS = {
+    "ALMA": ("X", "Y"),
+    "APEX": ("R", "L"),
+    "LMT": ("Y",),
+    "SMT": ("R", "X", "Y"),
+}
+
+
+def _polarized_model():
+    model = eh.model.Model()
+    return model.add_circ_gauss(
+        F0=1.0,
+        FWHM=40.0 * eh.RADPERUAS,
+        pol_frac=0.25,
+        pol_evpa=30.0 * eh.DEGREE,
+        cpol_frac=0.10,
+    )
+
+
+def _product_snr(left, right, coherency, sigma=1.0):
+    values = np.array([
+        first @ coherency @ np.conj(second)
+        for first in left for second in right
+    ], dtype=complex)[np.newaxis, :]
+    sigma_jy = np.full(values.shape, sigma, dtype=float)
+    left_rows = np.array([
+        first for first in left for _ in right
+    ], dtype=complex)[np.newaxis, :, :]
+    right_rows = np.array([
+        second for _ in left for second in right
+    ], dtype=complex)[np.newaxis, :, :]
+    return fringe_selection.receptor_fringe_snr(
+        values,
+        sigma_jy,
+        left_rows,
+        right_rows,
+        np.ones(values.shape, dtype=bool),
+    )[0]
+
+
+def test_stokes_i_fringe_evidence_is_invariant_under_feed_basis_conversion():
+    coherency = np.array(
+        [[1.2 + 0.3j, -0.25 + 0.4j], [0.1 - 0.2j, 0.7 - 0.15j]],
+        dtype=complex,
+    )
+    circular = (STANDARD_JONES_ROWS["R"], STANDARD_JONES_ROWS["L"])
+    linear = (STANDARD_JONES_ROWS["X"], STANDARD_JONES_ROWS["Y"])
+
+    circular_snr = _product_snr(circular, circular, coherency)
+    linear_snr = _product_snr(linear, linear, coherency)
+    mixed_snr = _product_snr(linear, circular, coherency)
+
+    assert np.allclose((circular_snr, linear_snr, mixed_snr), circular_snr)
+
+
+def test_rank_deficient_fringe_evidence_uses_strongest_product():
+    coherency = np.array([[1.0 + 0.5j, 0.2j], [0.3, 0.5 - 0.1j]], dtype=complex)
+    left = (STANDARD_JONES_ROWS["Y"],)
+    right = (STANDARD_JONES_ROWS["R"],)
+    expected = np.abs(left[0] @ coherency @ np.conj(right[0])) / 2.0
+
+    assert _product_snr(left, right, coherency, sigma=2.0) == expected
+
+
+def test_standard_circular_rime_matches_the_legacy_circular_kernel():
+    """The generic Jones path retains the established circular calculation."""
+
+    generator = og.obs_generator(settings=SETTINGS)
+    result = generator.simulate(
+        _polarized_model(),
+        addnoise=False,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    sampled, _ = source_models.observe_source_dataset(
+        _polarized_model(),
+        result.dataset,
+        generator.source_context(),
+    )
+    legacy = instrumental_corruptions.apply_circular_corruptions(
+        sampled,
+        result.station_terms,
+        result.dataset.stations,
+        np.random.default_rng(2),
+        addnoise=False,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+    )
+
+    assert np.allclose(result.dataset.visibilities, legacy.visibilities, atol=1.0e-12)
+    assert np.allclose(result.dataset.sigma_jy, legacy.sigma_jy, atol=1.0e-12)
+    assert np.array_equal(result.dataset.flags, legacy.flags)
+
+
+def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
+    generator = og.obs_generator(
+        settings=SETTINGS,
+        station_receptors=MIXED_RECEPTORS,
+    )
+    result = generator.simulate(
+        _polarized_model(),
+        addnoise=False,
+        addgains=True,
+        addFR=True,
+        addleakage=True,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+    dataset = result.dataset
+    configuration = resolve_receptor_configuration(
+        dataset.stations.names,
+        generator.station_receptors,
+        generator.station_signal_paths,
+    )
+    _, _, sky_coherency = source_models.observe_source_dataset(
+        _polarized_model(),
+        dataset,
+        generator.source_context(),
+        return_coherency=True,
+    )
+    left, right = instrumental_corruptions.receptor_rows_for_station_terms(
+        dataset,
+        result.station_terms,
+        configuration,
+    )
+
+    expected = np.zeros_like(dataset.visibilities[:, 0])
+    for row, product_ids in enumerate(dataset.row_product_id):
+        for slot, product_id in enumerate(product_ids):
+            if product_id >= 0:
+                expected[row, slot] = left[row, slot] @ sky_coherency[row] @ np.conj(right[row, slot])
+
+    assert dataset.receptors.polarization_label == ("X", "Y", "R", "L", "Y", "R", "X", "Y")
+    assert np.allclose(dataset.visibilities[:, 0], expected, atol=1.0e-12)
+
+
+def test_mixed_receptor_fringegroups_uses_generic_stokes_i_evidence():
+    generator = og.obs_generator(
+        settings=SETTINGS,
+        station_receptors=MIXED_RECEPTORS,
+    )
+    result = generator.make_dataset(
+        _polarized_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert result.dataset.row_count > 0
+    assert np.any(~result.dataset.flags)
+
+
+def test_direct_mixed_fringegroups_dataset_infers_standard_feed_responses():
+    """The public helper must not require private simulator state for R/L/X/Y."""
+
+    generator = og.obs_generator(
+        settings=SETTINGS,
+        station_receptors=MIXED_RECEPTORS,
+    )
+    result = generator.make_dataset(
+        _polarized_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    direct = og.fringegroups_dataset(generator, result.dataset, 0.0, 10.0)
+    with_terms = og.fringegroups_dataset(
+        generator,
+        result.dataset,
+        0.0,
+        10.0,
+        station_terms=result.station_terms,
+        receptor_configuration=resolve_receptor_configuration(
+            result.dataset.stations.names,
+            generator.station_receptors,
+            generator.station_signal_paths,
+        ),
+    )
+
+    assert np.array_equal(direct, with_terms)
+
+
+def test_direct_uncalibrated_mixed_fringegroups_requires_station_terms():
+    """Unknown Jones terms must not be silently ignored by Stokes-I recovery."""
+
+    generator = og.obs_generator(
+        settings=SETTINGS,
+        station_receptors=MIXED_RECEPTORS,
+    )
+    result = generator.make_dataset(
+        _polarized_model(),
+        addnoise=False,
+        addgains=True,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    with np.testing.assert_raises_regex(
+        ValueError,
+        "Mixed-receptor fringe selection needs station_terms",
+    ):
+        og.fringegroups_dataset(generator, result.dataset, 0.0, 10.0)
+
+
+def test_mixed_receptor_fpt_uses_the_same_generic_fringe_evidence():
+    settings = dict(SETTINGS)
+    settings["fringe_finder"] = ["fpt", [0.0, 10.0, 86.0, None]]
+    generator = og.obs_generator(
+        settings=settings,
+        station_receptors=MIXED_RECEPTORS,
+    )
+    result = generator.make_dataset(
+        _polarized_model(),
+        addnoise=False,
+        addgains=False,
+        addFR=False,
+        addleakage=False,
+        flagwind=False,
+        flagday=False,
+        flagsun=False,
+    )
+
+    assert result.dataset.row_count > 0
+    assert np.any(~result.dataset.flags)

--- a/tests/test_native_api_documentation.py
+++ b/tests/test_native_api_documentation.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import inspect
 
 from ngehtsim.obs.ehtfits import read_ehtfits, write_ehtfits
-from ngehtsim.obs.fringe_selection import FringeRows, fpt_fringe_group_mask, fringe_group_mask
-from ngehtsim.obs.instrumental_corruptions import apply_circular_corruptions, apply_circular_leakage
+from ngehtsim.obs.fringe_selection import FringeRows, fpt_fringe_group_mask, fringe_group_mask, receptor_fringe_snr
+from ngehtsim.obs.instrumental_corruptions import (
+    apply_circular_corruptions,
+    apply_circular_leakage,
+    apply_receptor_corruptions,
+    receptor_rows_for_station_terms,
+)
 from ngehtsim.obs.observation_geometry import (
     GroundGeometry,
     StationGeometry,
@@ -35,6 +40,12 @@ from ngehtsim.obs.visibility_dataset import (
     StationTable,
     VisibilityDataset,
     standard_products_for_rows,
+    receptor_products_for_rows,
+)
+from ngehtsim.obs.receptor_configuration import (
+    ReceptorConfiguration,
+    configuration_for_dataset,
+    resolve_receptor_configuration,
 )
 
 
@@ -43,6 +54,10 @@ DOCUMENTED_NATIVE_API = {
     "ReceptorTable": ReceptorTable,
     "CorrelationProductTable": CorrelationProductTable,
     "standard_products_for_rows": standard_products_for_rows,
+    "receptor_products_for_rows": receptor_products_for_rows,
+    "ReceptorConfiguration": ReceptorConfiguration,
+    "configuration_for_dataset": configuration_for_dataset,
+    "resolve_receptor_configuration": resolve_receptor_configuration,
     "VisibilityDataset": VisibilityDataset,
     "read_ehtfits": read_ehtfits,
     "write_ehtfits": write_ehtfits,
@@ -59,9 +74,12 @@ DOCUMENTED_NATIVE_API = {
     "station_terms_for_dataset": station_terms_for_dataset,
     "apply_circular_leakage": apply_circular_leakage,
     "apply_circular_corruptions": apply_circular_corruptions,
+    "apply_receptor_corruptions": apply_receptor_corruptions,
+    "receptor_rows_for_station_terms": receptor_rows_for_station_terms,
     "FringeRows": FringeRows,
     "fringe_group_mask": fringe_group_mask,
     "fpt_fringe_group_mask": fpt_fringe_group_mask,
+    "receptor_fringe_snr": receptor_fringe_snr,
     "EhtimImageAdapter": EhtimImageAdapter,
     "EhtimMovieAdapter": EhtimMovieAdapter,
     "EhtimModelAdapter": EhtimModelAdapter,


### PR DESCRIPTION
## Summary
- add explicit station receptor inventories and calibrated signal-path configuration
- simulate arbitrary station-feed products through a common circular-basis Jones RIME
- make fringe-group and FPT detectability basis independent through rank-two Stokes-I reconstruction, with strongest-product fallback for rank-deficient baselines
- document the native mixed-receptor interface and add regression coverage, including equivalence with the legacy R/L corruption kernel

## Validation
- MPLBACKEND=Agg PYTHONDONTWRITEBYTECODE=1 python -m pytest -q
  - 305 passed, 101 skipped (external weather-release tests only)
- PYTHONDONTWRITEBYTECODE=1 sphinx-build -W -b html docs/source /private/tmp/ngehtsim-mixed-rime-docs