### PR TITLE
Add native station corruption model

### DIFF
--- a/docs/source/native_simulation.rst
+++ b/docs/source/native_simulation.rst
@@ -18,12 +18,13 @@ Ground Geometry and Station Terms
 The native ground-array geometry kernel produces baseline rows, elevation
 selection masks, and a circular visibility template without constructing an
 ``ehtim.Obsdata`` object. Spacecraft stations retain the legacy geometry path.
-The station-term kernel then evaluates weather, SEFD, uptime, gains, leakage,
-and feed-rotation quantities on those rows. The one-channel corruption kernel
-uses a circular-sky Jones RIME and projects the result into every configured
-station-local receptor path. This supports circular, linear, mixed, single-
-feed, and over-complete feed inventories without converting the archived data
-to an assumed global basis.
+The station-term kernel evaluates weather, SEFD, uptime, and station geometry
+on those rows. ``StationCorruptionModel`` separately declares the realization
+of common station Jones terms and per-path gains. The one-channel corruption
+kernel uses a circular-sky Jones RIME and projects the result into every
+configured station-local receptor path. This supports circular, linear,
+mixed, single-feed, and over-complete feed inventories without converting the
+archived data to an assumed global basis.
 
 .. currentmodule:: ngehtsim.obs.observation_geometry
 
@@ -46,6 +47,17 @@ to an assumed global basis.
 .. autofunction:: station_metadata_for_dataset
 
 .. autofunction:: station_terms_for_dataset
+
+.. currentmodule:: ngehtsim.obs.station_effects
+
+.. autoclass:: GainModel
+   :members:
+
+.. autoclass:: LeakageModel
+   :members:
+
+.. autoclass:: StationCorruptionModel
+   :members:
 
 Fringe and Corruption Primitives
 --------------------------------

--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -90,6 +90,72 @@ polarization basis as privileged. FPT uses the same evidence at target and
 reference frequency; it remains a detectability proxy and does not modify
 visibility phases.
 
+Native Station Corruptions
+--------------------------
+
+The v2 native API uses a single explicit model for thermal noise, flagging,
+station-common Jones terms, and per-receptor-path gains. This replaces the
+v1 ``addnoise``, ``addgains``, ``gainamp``, ``addleakage``, ``leakamp``,
+``addFR``, ``opacitycal``, ``flagwind``, ``flagday``, and ``flagsun`` keyword
+arguments on ``simulate()``, ``make_dataset()``, ``observe()``, and
+``make_obs()``.
+
+For example, this produces a noise-free, fully calibrated native dataset:
+
+.. code-block:: python
+
+   from ngehtsim.obs.station_effects import StationCorruptionModel
+
+   effects = StationCorruptionModel(
+       thermal_noise=False,
+       common_gain=None,
+       feed_rotation=False,
+       flag_wind=False,
+       flag_daylight=False,
+       flag_sun=False,
+   )
+   result = obsgen.make_dataset(model, effects=effects)
+
+Common gains act before the station-local receptor response. ``GainModel``
+objects in ``path_gain_overrides`` instead apply after that response to named
+station/feed voltage paths, and are therefore suitable for mixed feeds:
+
+.. code-block:: python
+
+   from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
+
+   effects = StationCorruptionModel(
+       thermal_noise=True,
+       opacity_calibrated=True,
+       feed_rotation=True,
+       common_gain=GainModel(
+           amplitude_sigma_dex=0.04,
+           phase_distribution="uniform",
+       ),
+       leakage=LeakageModel(component_sigma=0.1),
+       path_gain_overrides={
+           "ALMA": {
+               "X": GainModel(amplitude_sigma_dex=0.02),
+               "Y": GainModel(amplitude_sigma_dex=0.02),
+           },
+       },
+   )
+   result = obsgen.make_dataset(model, effects=effects)
+
+``feed_id`` values refer to the local identifiers configured in
+``station_receptors``, rather than assuming a global polarization basis.
+``StationCorruptionModel()`` retains the native default realization: thermal
+noise, opacity calibration, feed rotation, weather/solar flagging, and a
+station-common 0.04-dex amplitude gain with uniform phase; leakage and
+independent path gains are disabled.
+
+The historical implementation is available only through explicit legacy
+entry points (``observe_legacy()``, ``make_obs_legacy()``, and their legacy
+callers). ``observe(..., backend="legacy")`` and
+``make_obs(..., backend="legacy")`` also accept legacy keywords, but native
+calls reject them so a v1 configuration cannot be accidentally interpreted by
+the v2 RIME.
+
 Mixed-receptor datasets can be written to FITS-EHT. UVFITS and
 ``ehtim.Obsdata`` export remain intentionally limited to their representable
 uniform-polarization layouts.

--- a/examples/example_SYMBA_export/generate_observation.py
+++ b/examples/example_SYMBA_export/generate_observation.py
@@ -3,6 +3,7 @@
 
 import ehtim as eh
 import ngehtsim.obs.obs_generator as og
+from ngehtsim.obs.station_effects import GainModel, StationCorruptionModel
 import os
 
 #######################################################
@@ -34,7 +35,14 @@ settings = {'weather': weather_type}
 obsgen = og.obs_generator(settings)
 
 # generate and save the observation
-obs = obsgen.make_obs(im, addnoise=addnoise, addgains=addgains)
+effects = StationCorruptionModel(
+    thermal_noise=addnoise,
+    common_gain=(
+        GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+        if addgains else None
+    ),
+)
+obs = obsgen.make_obs(im, effects=effects)
 obs.save_uvfits('example_dataset.uvfits')
 
 # export SYMBA-compatible input files

--- a/examples/example_data_generation_flagging/generate_observation.py
+++ b/examples/example_data_generation_flagging/generate_observation.py
@@ -4,6 +4,7 @@
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.obs_plotter as op
 import ngehtsim.metrics as cm
+from ngehtsim.obs.station_effects import StationCorruptionModel
 import matplotlib.pyplot as plt
 
 #######################################################
@@ -28,7 +29,9 @@ obs.save_uvfits('./example_datafile.uvfits')
 obsgen_flagged = og.obs_generator(settings_file=yamlfile)
 
 # generate the observation
-obs_flagged = obsgen_flagged.make_obs(flagday=True)
+obs_flagged = obsgen_flagged.make_obs(
+    effects=StationCorruptionModel(flag_daylight=True),
+)
 
 # save it as a uvfits file
 obs_flagged.save_uvfits('./example_datafile_flagged.uvfits')
@@ -58,7 +61,9 @@ obsgen_flagged2 = og.obs_generator(settings_file=yamlfile,
                                    wind_loading_overrides=wind_loading_overrides)
 
 # generate the observation
-obs_flagged2 = obsgen_flagged2.make_obs(flagday=True,flagwind=True)
+obs_flagged2 = obsgen_flagged2.make_obs(
+    effects=StationCorruptionModel(flag_daylight=True, flag_wind=True),
+)
 
 # save it as a uvfits file
 obs_flagged2.save_uvfits('./example_datafile_flagged2.uvfits')

--- a/examples/example_data_generation_instrumental_corruptions/generate_observation.py
+++ b/examples/example_data_generation_instrumental_corruptions/generate_observation.py
@@ -8,6 +8,7 @@ import ehtim as eh
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.obs_plotter as op
 import ngehtsim.metrics as cm
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 
 #######################################################
 # set up obsgen object
@@ -27,24 +28,45 @@ mod = mod.add_circ_gauss(0.5, 20.*eh.RADPERUAS, x0=20.0*eh.RADPERUAS, y0=0.0, po
 mod = mod.add_circ_gauss(0.5, 30.*eh.RADPERUAS, x0=-20.0*eh.RADPERUAS, y0=20.0*eh.RADPERUAS, pol_frac=0.10, pol_evpa=30.0*eh.DEGREE, cpol_frac=-0.05)
 
 # generate an observation with no noise
-obs_nonoise = obsgen.make_obs(input_model=mod,
-                              addnoise=False,addgains=False,addleakage=False)
+obs_nonoise = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(thermal_noise=False, common_gain=None),
+)
 
 # generate an observation with only thermal noise
-obs_thnoise = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=False,addleakage=False)
+obs_thnoise = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(thermal_noise=True, common_gain=None),
+)
 
 # generate an observation with thermal noise and station gains
-obs_thgains = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=True,addleakage=False)
+obs_thgains = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform"),
+    ),
+)
 
 # generate an observation with thermal noise and leakage
-obs_thleak = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=False,addleakage=True)
+obs_thleak = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=None,
+        leakage=LeakageModel(component_sigma=0.1),
+    ),
+)
 
 # generate an observation with thermal noise, station gains, and leakage
-obs_full = obsgen.make_obs(input_model=mod,
-                           addnoise=True,addgains=True,addleakage=True)
+obs_full = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform"),
+        leakage=LeakageModel(component_sigma=0.1),
+    ),
+)
 
 # save uvfits files
 obs_nonoise.save_uvfits('./datafile_nonoise.uvfits')

--- a/ngehtsim/obs/__init__.py
+++ b/ngehtsim/obs/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     'obs_plotter',
     'receptor_configuration',
     'simulation_result',
+    'station_effects',
     'uvfits',
     'visibility_dataset',
 ]

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -9,6 +9,7 @@ import numpy as np
 import ngehtsim.const_def as const
 from ngehtsim.obs.visibility_dataset import StationTable, VisibilityDataset
 from ngehtsim.obs.receptor_configuration import response_rows_for_dataset
+from ngehtsim.obs.station_effects import StationCorruptionModel
 
 
 def apply_circular_leakage(visibilities, leakage1_r, leakage1_l, leakage2_r,
@@ -257,9 +258,7 @@ def apply_circular_corruptions(dataset, station_terms, stations, rng, addnoise=T
 
 
 def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
-                               receptor_configuration, rng, addnoise=True,
-                               addgains=True, opacitycal=True, addFR=True,
-                               addleakage=False):
+                               receptor_configuration, effects, rng):
     """Apply a one-channel Jones RIME to arbitrary station-feed products.
 
     ``sky_coherency`` is sampled in the common circular sky basis and has one
@@ -275,11 +274,9 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
         One-channel native visibility layout to populate.
     sky_coherency : array_like, shape (row, 2, 2)
         Source coherency matrices in the circular ``(R, L)`` sky basis.
-    station_terms, stations, receptor_configuration, rng
+    station_terms, stations, receptor_configuration, effects, rng
         Native station-term realization, updated station table, resolved
-        receptor paths, and random generator.
-    addnoise, addgains, opacitycal, addFR, addleakage : bool, optional
-        Enable the corresponding station and thermal-noise effects.
+        receptor paths, station-effect model, and random generator.
 
     Returns
     -------
@@ -291,6 +288,8 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
         raise TypeError("dataset must be a VisibilityDataset instance.")
     if not isinstance(stations, StationTable):
         raise TypeError("stations must be a StationTable instance.")
+    if not isinstance(effects, StationCorruptionModel):
+        raise TypeError("effects must be a StationCorruptionModel instance.")
     if dataset.channel_count != 1:
         raise ValueError("Native receptor corruption requires exactly one channel.")
     sky_coherency = np.asarray(sky_coherency, dtype=complex)
@@ -310,19 +309,6 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
             "par2", "phi_off1", "phi_off2", "uptime_mask",
         )
     }
-    if addgains:
-        terms.update({
-            name: _term_array(station_terms, name, count)
-            for name in (
-                "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
-                "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
-            )
-        })
-    if addleakage:
-        terms.update({
-            name: _term_array(station_terms, name, count)
-            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
-        })
     expected_t1 = np.asarray(dataset.stations.names)[dataset.antenna1]
     expected_t2 = np.asarray(dataset.stations.names)[dataset.antenna2]
     if not np.array_equal(terms["t1"], expected_t1) or not np.array_equal(terms["t2"], expected_t2):
@@ -332,17 +318,11 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
     if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
         raise ValueError("Station opacity terms must be non-negative.")
 
-    jones1, jones2, _, _ = _circular_station_jones(
-        terms,
-        count,
-        addgains=addgains,
-        addFR=addFR,
-        addleakage=addleakage,
-    )
+    jones1, jones2 = _native_station_jones(terms, count, station_terms, effects)
     output_coherency = jones1 @ sky_coherency @ np.swapaxes(np.conj(jones2), -1, -2)
-    if not opacitycal:
+    if not effects.opacity_calibrated:
         output_coherency *= np.sqrt(np.exp(-tau1 - tau2))[:, np.newaxis, np.newaxis]
-    receiver_gain1, receiver_gain2 = _receiver_gain_vectors(terms, count, addgains)
+    path_gains = _path_gain_array(station_terms, count, dataset.receptors.count)
 
     visibilities = np.array(dataset.visibilities, copy=True)
     sigma_jy = np.array(dataset.sigma_jy, copy=True)
@@ -355,7 +335,7 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
         dataset.integration_time_s,
         tau1,
         tau2,
-        opacitycal,
+        effects.opacity_calibrated,
     )[:, 0]
     flagged_sites = set(station_terms["flagsites"])
     row_available = (
@@ -369,27 +349,21 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
                 continue
             receptor1 = products.receptor1_id[product_id]
             receptor2 = products.receptor2_id[product_id]
-            first = gain_scale[receptor1] * response[receptor1]
-            second = gain_scale[receptor2] * response[receptor2]
+            first = path_gains[row, receptor1] * gain_scale[receptor1] * response[receptor1]
+            second = path_gains[row, receptor2] * gain_scale[receptor2] * response[receptor2]
             value = first @ output_coherency[row] @ np.conj(second)
-            # Thermal receiver noise is injected after the deterministic feed
-            # rotation and leakage response. Propagate only the amplitude
-            # gains through each mixed feed; this exactly preserves the
-            # legacy R/L uncertainty calculation.
             gain_magnitude = (
-                _path_gain_magnitude(
-                    response[receptor1], gain_scale[receptor1], receiver_gain1[row]
-                )
-                * _path_gain_magnitude(
-                    response[receptor2], gain_scale[receptor2], receiver_gain2[row]
-                )
+                np.abs(station_terms["common_gain1"][row])
+                * np.abs(path_gains[row, receptor1] * gain_scale[receptor1])
+                * np.abs(station_terms["common_gain2"][row])
+                * np.abs(path_gains[row, receptor2] * gain_scale[receptor2])
             )
             sigma = (
                 base_sigma[row]
                 * np.sqrt(sefd_scale[receptor1] * sefd_scale[receptor2])
                 * gain_magnitude
             )
-            if addnoise:
+            if effects.thermal_noise:
                 value += sigma * (rng.normal() + 1.0j * rng.normal())
             visibilities[row, 0, slot] = value
             sigma_jy[row, 0, slot] = sigma
@@ -403,23 +377,21 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
         visibilities=visibilities,
         sigma_jy=sigma_jy,
         flags=flags,
-        ampcal=not addgains,
-        phasecal=not addgains,
-        opacitycal=opacitycal,
-        dcal=not addleakage,
-        frcal=not addFR,
+        ampcal=effects.common_gain is None and not effects.path_gain_overrides,
+        phasecal=effects.common_gain is None and not effects.path_gain_overrides,
+        opacitycal=effects.opacity_calibrated,
+        dcal=effects.leakage is None,
+        frcal=not effects.feed_rotation,
     )
 
 
-def _circular_station_jones(terms, count, *, addgains, addFR, addleakage):
-    """Build per-row circular station Jones matrices from legacy terms."""
+def _native_station_jones(terms, count, station_terms, effects):
+    """Build native common-frame station Jones matrices from generic terms."""
 
     identity = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
     jones1 = np.array(identity, copy=True)
     jones2 = np.array(identity, copy=True)
-    gain1 = np.ones(count, dtype=complex)
-    gain2 = np.ones(count, dtype=complex)
-    if addFR:
+    if effects.feed_rotation:
         rotation1 = (
             terms["f_par1"] * terms["par1"]
             + terms["f_el1"] * terms["el1"]
@@ -438,73 +410,38 @@ def _circular_station_jones(terms, count, *, addgains, addFR, addleakage):
         jones1[:, 1, 1] = np.exp(1.0j * rotation1)
         jones2[:, 0, 0] = np.exp(-1.0j * rotation2)
         jones2[:, 1, 1] = np.exp(1.0j * rotation2)
-    if addleakage:
-        leakage = {
-            name: _term_array(terms, name, count)
-            for name in ("leak1R", "leak1L", "leak2R", "leak2L")
-        }
-        d1 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
-        d2 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
-        d1[:, 0, 1] = leakage["leak1R"]
-        d1[:, 1, 0] = leakage["leak1L"]
-        d2[:, 0, 1] = leakage["leak2R"]
-        d2[:, 1, 0] = leakage["leak2L"]
-        jones1 = d1 @ jones1
-        jones2 = d2 @ jones2
-    if addgains:
-        gain_terms = {
-            name: _term_array(terms, name, count)
-            for name in (
-                "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
-                "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
-            )
-        }
-        gain1r = gain_terms["gainamp1R"] * np.exp(1.0j * gain_terms["gainphase1R"])
-        gain1l = gain_terms["gainamp1L"] * np.exp(1.0j * gain_terms["gainphase1L"])
-        gain2r = gain_terms["gainamp2R"] * np.exp(1.0j * gain_terms["gainphase2R"])
-        gain2l = gain_terms["gainamp2L"] * np.exp(1.0j * gain_terms["gainphase2L"])
-        g1 = np.zeros((count, 2, 2), dtype=complex)
-        g2 = np.zeros((count, 2, 2), dtype=complex)
-        g1[:, 0, 0] = gain1r
-        g1[:, 1, 1] = gain1l
-        g2[:, 0, 0] = gain2r
-        g2[:, 1, 1] = gain2l
-        jones1 = g1 @ jones1
-        jones2 = g2 @ jones2
-        gain1 = np.sqrt(np.abs(gain1r * gain1l))
-        gain2 = np.sqrt(np.abs(gain2r * gain2l))
-    return jones1, jones2, gain1, gain2
+    jones1 = _matrix_term(station_terms, "leakage_matrix1", count) @ jones1
+    jones2 = _matrix_term(station_terms, "leakage_matrix2", count) @ jones2
+    gain1 = _term_array(station_terms, "common_gain1", count)
+    gain2 = _term_array(station_terms, "common_gain2", count)
+    return gain1[:, np.newaxis, np.newaxis] * jones1, gain2[:, np.newaxis, np.newaxis] * jones2
 
 
-def _receiver_gain_vectors(terms, count, addgains):
-    """Return circular-basis amplitude gains used for thermal uncertainties."""
+def _matrix_term(station_terms, name, count):
+    """Return one validated row-aligned two-by-two station matrix term."""
 
-    if not addgains:
-        return np.ones((count, 2), dtype=complex), np.ones((count, 2), dtype=complex)
-    gain_names = (
-        "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
-        "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
-    )
-    gain_terms = {name: _term_array(terms, name, count) for name in gain_names}
-    first = np.column_stack((
-        gain_terms["gainamp1R"] * np.exp(1.0j * gain_terms["gainphase1R"]),
-        gain_terms["gainamp1L"] * np.exp(1.0j * gain_terms["gainphase1L"]),
-    ))
-    second = np.column_stack((
-        gain_terms["gainamp2R"] * np.exp(1.0j * gain_terms["gainphase2R"]),
-        gain_terms["gainamp2L"] * np.exp(1.0j * gain_terms["gainphase2L"]),
-    ))
-    return first, second
+    try:
+        values = np.asarray(station_terms[name], dtype=complex)
+    except KeyError as exc:
+        raise ValueError("Missing station term: {0}.".format(name)) from exc
+    if values.shape != (count, 2, 2):
+        raise ValueError("Station term {0} must have shape (row, 2, 2).".format(name))
+    return values
 
 
-def _path_gain_magnitude(response, fixed_gain, circular_gains):
-    """Return a receptor-path thermal gain relative to its nominal response."""
+def _path_gain_array(station_terms, count, receptor_count):
+    """Return validated row/receptor gains for all native signal paths."""
 
-    response = np.asarray(response, dtype=complex)
-    return np.abs(fixed_gain) * np.linalg.norm(response * circular_gains) / np.linalg.norm(response)
+    try:
+        values = np.asarray(station_terms["path_gains"], dtype=complex)
+    except KeyError as exc:
+        raise ValueError("Missing station term: path_gains.") from exc
+    if values.shape != (count, receptor_count):
+        raise ValueError("path_gains must have shape (row, receptor).")
+    return values
 
 
-def receptor_rows_for_station_terms(dataset, station_terms, receptor_configuration):
+def receptor_rows_for_station_terms(dataset, station_terms, receptor_configuration, effects):
     """Return effective receptor Jones rows for generic fringe selection.
 
     The rows include the same simulated station gain, leakage, and feed
@@ -521,6 +458,8 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
         :func:`station_terms_for_dataset`.
     receptor_configuration : ReceptorConfiguration
         Resolved station-local receptor paths matching ``dataset.receptors``.
+    effects : StationCorruptionModel
+        Native station-effect configuration that produced the realization.
 
     Returns
     -------
@@ -531,6 +470,8 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
 
     if dataset.channel_count != 1:
         raise ValueError("Native receptor fringe selection requires one channel.")
+    if not isinstance(effects, StationCorruptionModel):
+        raise TypeError("effects must be a StationCorruptionModel instance.")
     response, _, gain_scale = response_rows_for_dataset(dataset, receptor_configuration)
     count = dataset.row_count
     required = (
@@ -538,24 +479,8 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
         "par1", "par2", "phi_off1", "phi_off2",
     )
     terms = {name: _term_array(station_terms, name, count) for name in required}
-    gain_names = (
-        "gainamp1R", "gainamp2R", "gainphase1R", "gainphase2R",
-        "gainamp1L", "gainamp2L", "gainphase1L", "gainphase2L",
-    )
-    leakage_names = ("leak1R", "leak1L", "leak2R", "leak2L")
-    addgains = all(name in station_terms for name in gain_names)
-    addleakage = all(name in station_terms for name in leakage_names)
-    if addgains:
-        terms.update({name: _term_array(station_terms, name, count) for name in gain_names})
-    if addleakage:
-        terms.update({name: _term_array(station_terms, name, count) for name in leakage_names})
-    jones1, jones2, _, _ = _circular_station_jones(
-        terms,
-        count,
-        addgains=addgains,
-        addFR=not dataset.frcal,
-        addleakage=addleakage,
-    )
+    jones1, jones2 = _native_station_jones(terms, count, station_terms, effects)
+    path_gains = _path_gain_array(station_terms, count, dataset.receptors.count)
     left = np.zeros((dataset.row_count, dataset.visibilities.shape[2], 2), dtype=complex)
     right = np.zeros_like(left)
     products = dataset.correlation_products
@@ -565,8 +490,16 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
                 continue
             receptor1 = products.receptor1_id[product_id]
             receptor2 = products.receptor2_id[product_id]
-            left[row, slot] = gain_scale[receptor1] * (response[receptor1] @ jones1[row])
-            right[row, slot] = gain_scale[receptor2] * (response[receptor2] @ jones2[row])
+            left[row, slot] = (
+                path_gains[row, receptor1]
+                * gain_scale[receptor1]
+                * (response[receptor1] @ jones1[row])
+            )
+            right[row, slot] = (
+                path_gains[row, receptor2]
+                * gain_scale[receptor2]
+                * (response[receptor2] @ jones2[row])
+            )
     return left, right
 
 

--- a/ngehtsim/obs/obs_generator.py
+++ b/ngehtsim/obs/obs_generator.py
@@ -30,6 +30,7 @@ from ngehtsim.obs.receptor_configuration import (
     response_rows_for_dataset,
 )
 from ngehtsim.obs.simulation_result import SimulationResult
+from ngehtsim.obs.station_effects import StationCorruptionModel
 
 ###################################################
 # helpers
@@ -840,26 +841,47 @@ class obs_generator(object):
             print("No input model passed to {0}; using the configured model.".format(caller))
         return self.im
 
-    def simulate(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
-                 leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
-                 flagwind=True, flagday=False, flagsun=True,
-                 allow_mixed_basis=False, el_min=const.el_min, el_max=const.el_max,
-                 p=None):
+    def simulate(self, input_model=None, effects=None, el_min=const.el_min,
+                 el_max=const.el_max):
         """Simulate a ground-array observation into a native result object.
 
         This is the primary v2 simulation API. It retains all rows, including
         rows rejected by station-based flagging, in ``result.dataset.flags``.
         ``ehtim`` source classes are accepted as input adapters, but no
         ``ehtim.Obsdata`` is constructed during simulation.
+
+        Parameters
+        ----------
+        input_model : ehtim Image, Movie, or Model, optional
+            Source model to sample. The generator's configured model is used
+            when omitted.
+        effects : StationCorruptionModel, optional
+            Declarative native thermal-noise, calibration, flagging, and
+            station/receptor corruption configuration. The default preserves
+            the native v2 defaults.
+        el_min, el_max : float, optional
+            Inclusive ground-station elevation limits in degrees.
+
+        Returns
+        -------
+        SimulationResult
+            Full native geometry, correlations, flags, and station-term
+            provenance before fringe-selection flags are applied.
+
+        Raises
+        ------
+        NotImplementedError
+            If spacecraft geometry is requested. Use ``observe_legacy`` or
+            ``make_obs_legacy`` for the retained legacy spacecraft route.
+        TypeError
+            If the source has no native adapter or ``effects`` is not a
+            :class:`StationCorruptionModel`.
         """
 
-        del p  # Native Fisher-forecast sampling is intentionally not supported.
         input_model = self._resolve_input_model(input_model, "simulate")
-        if allow_mixed_basis:
-            raise ValueError(
-                "allow_mixed_basis is obsolete for native simulation; configure "
-                "station_receptors and station_signal_paths instead."
-            )
+        effects = StationCorruptionModel() if effects is None else effects
+        if not isinstance(effects, StationCorruptionModel):
+            raise TypeError("effects must be a StationCorruptionModel instance.")
         if "space" in self.sites:
             raise NotImplementedError(
                 "Native spacecraft geometry is not implemented; use observe_legacy() "
@@ -883,14 +905,14 @@ class obs_generator(object):
             el_min=el_min,
             el_max=el_max,
         )
-        if template.row_count == 0:
-            return SimulationResult(template, {})
-
         receptor_configuration = resolve_receptor_configuration(
             template.stations.names,
             self.station_receptors,
             self.station_signal_paths,
         )
+        effects.validate_receptors(template.stations.names, template.receptors)
+        if template.row_count == 0:
+            return SimulationResult(template, {})
         sampled, F0, sky_coherency = source_models.observe_source_dataset(
             input_model,
             template,
@@ -902,13 +924,7 @@ class obs_generator(object):
             F0,
             self.station_context((sampled.time_mjd - self.mjd) * 24.0),
             self.rng,
-            gainamp=gainamp,
-            leakamp=leakamp,
-            addgains=addgains,
-            addleakage=addleakage,
-            flagwind=flagwind,
-            flagday=flagday,
-            flagsun=flagsun,
+            effects=effects,
             solar_angle=self.solar_angle,
             verbosity=self.verbosity,
             windspeed_sefd_modifier=windspeed_SEFD_modification,
@@ -921,12 +937,8 @@ class obs_generator(object):
             station_terms,
             stations,
             receptor_configuration,
+            effects,
             self.rng,
-            addnoise=addnoise,
-            addgains=addgains,
-            opacitycal=opacitycal,
-            addFR=addFR,
-            addleakage=addleakage,
         )
         return SimulationResult(corrupted, station_terms)
 
@@ -1357,7 +1369,7 @@ class obs_generator(object):
         # return observation object
         return obs
 
-    def _native_selection_mask(self, dataset, station_terms, input_model=None,
+    def _native_selection_mask(self, dataset, station_terms, effects, input_model=None,
                                simulation_kwargs=None):
         """Return the native row-selection mask for availability and fringe finding."""
 
@@ -1399,6 +1411,7 @@ class obs_generator(object):
             dataset,
             station_terms=station_terms,
             receptor_configuration=receptor_configuration,
+            effects=effects,
         )
         if snr_algorithm == "naive":
             mask &= fringe_rows.detectability_snr > snr_args
@@ -1412,6 +1425,7 @@ class obs_generator(object):
                 snr_args[1],
                 station_terms=_take_station_terms(station_terms, selected_indices),
                 receptor_configuration=receptor_configuration,
+                effects=effects,
             )
         elif snr_algorithm == "fpt":
             if input_model is None or simulation_kwargs is None:
@@ -1424,6 +1438,7 @@ class obs_generator(object):
                 input_model,
                 station_terms,
                 receptor_configuration,
+                effects,
                 snr_ref,
                 tint_ref,
                 freq_ref,
@@ -1438,7 +1453,7 @@ class obs_generator(object):
         return mask
 
     def _native_fpt_selection_mask(self, target_dataset, target_model,
-                                   target_station_terms, target_receptor_configuration,
+                                   target_station_terms, target_receptor_configuration, target_effects,
                                    snr_ref, tint_ref, freq_ref, model_ref, simulation_kwargs,
                                    target_available_sites, target_row_available,
                                    unready_sites):
@@ -1468,6 +1483,7 @@ class obs_generator(object):
                 target_dataset,
                 station_terms=target_station_terms,
                 receptor_configuration=target_receptor_configuration,
+                effects=target_effects,
             ),
             _fringe_rows_from_dataset(
                 reference_dataset,
@@ -1477,6 +1493,7 @@ class obs_generator(object):
                     reference_generator.station_receptors,
                     reference_generator.station_signal_paths,
                 ),
+                effects=simulation_kwargs["effects"],
             ),
             snr_ref,
             tint_ref,
@@ -1490,34 +1507,40 @@ class obs_generator(object):
             ),
         )
 
-    def make_dataset(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
-                     leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
-                     flagwind=True, flagday=False, flagsun=True,
-                     allow_mixed_basis=False, el_min=const.el_min,
-                     el_max=const.el_max, p=None):
+    def make_dataset(self, input_model=None, effects=None, el_min=const.el_min,
+                     el_max=const.el_max):
         """Generate a fully selected native :class:`SimulationResult`.
 
         Station, availability, technical-readiness, and fringe-selection
         failures are represented in ``result.dataset.flags`` rather than by
         deleting rows from the internal data model.
+
+        Parameters
+        ----------
+        input_model : ehtim Image, Movie, or Model, optional
+            Source model to sample. The generator's configured model is used
+            when omitted.
+        effects : StationCorruptionModel, optional
+            Declarative native station-effect configuration. The same model
+            is used for target and reference simulations when FPT selection
+            is configured.
+        el_min, el_max : float, optional
+            Inclusive ground-station elevation limits in degrees.
+
+        Returns
+        -------
+        SimulationResult
+            Native dataset with all rejected samples retained and flagged.
         """
 
         input_model = self._resolve_input_model(input_model, "make_dataset")
+        effects = StationCorruptionModel() if effects is None else effects
+        if not isinstance(effects, StationCorruptionModel):
+            raise TypeError("effects must be a StationCorruptionModel instance.")
         simulation_kwargs = {
-            "addnoise": addnoise,
-            "addgains": addgains,
-            "gainamp": gainamp,
-            "leakamp": leakamp,
-            "opacitycal": opacitycal,
-            "addFR": addFR,
-            "addleakage": addleakage,
-            "flagwind": flagwind,
-            "flagday": flagday,
-            "flagsun": flagsun,
-            "allow_mixed_basis": allow_mixed_basis,
+            "effects": effects,
             "el_min": el_min,
             "el_max": el_max,
-            "p": p,
         }
         result = self.simulate(
             input_model=input_model,
@@ -1529,6 +1552,7 @@ class obs_generator(object):
         mask = self._native_selection_mask(
             result.dataset,
             result.station_terms,
+            effects,
             input_model=input_model,
             simulation_kwargs=simulation_kwargs,
         )
@@ -1543,100 +1567,114 @@ class obs_generator(object):
             )
         return SimulationResult(replace(result.dataset, flags=flags), result.station_terms)
 
-    def observe(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
-                leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
-                flagwind=True, flagday=False, flagsun=True,
-                allow_mixed_basis=False, el_min=const.el_min,
-                el_max=const.el_max, p=None, backend="native"):
+    def observe(self, input_model=None, effects=None, el_min=const.el_min,
+                el_max=const.el_max, backend="native", **legacy_kwargs):
         """Generate a raw ``ehtim.Obsdata`` export from the selected backend.
 
-        ``backend="native"`` is the default and constructs no ``Obsdata``
-        until export. ``backend="legacy"`` explicitly selects the retained
-        legacy implementation for capabilities not yet available natively.
+        ``backend="native"`` is the default and accepts the v2 ``effects``
+        model. ``backend="legacy"`` forwards keyword arguments to the
+        explicitly retained legacy implementation.
+
+        Parameters
+        ----------
+        input_model : supported source object, optional
+            Native inputs are ehtim Image, Movie, and Model objects. The
+            legacy route additionally accepts its historical source adapters.
+        effects : StationCorruptionModel, optional
+            Native station-effect configuration. It cannot be combined with
+            ``backend="legacy"``.
+        el_min, el_max : float, optional
+            Ground-station elevation limits in degrees.
+        backend : {"native", "legacy"}, optional
+            ``"native"`` exports the v2 simulation result. ``"legacy"``
+            calls :meth:`observe_legacy` and accepts only its legacy
+            corruption keywords.
+        **legacy_kwargs
+            Arguments accepted by :meth:`observe_legacy` only when
+            ``backend="legacy"`` is selected.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Selected raw observation in ehtim's representable circular layout.
         """
 
         if backend == "legacy":
+            if effects is not None:
+                raise TypeError(
+                    "effects= is only supported by the native observation backend."
+                )
             input_model = self._resolve_input_model(input_model, "observe_legacy")
             return self.observe_legacy(
                 input_model,
-                addnoise=addnoise,
-                addgains=addgains,
-                gainamp=gainamp,
-                leakamp=leakamp,
-                opacitycal=opacitycal,
-                addFR=addFR,
-                addleakage=addleakage,
-                flagwind=flagwind,
-                flagday=flagday,
-                flagsun=flagsun,
-                allow_mixed_basis=allow_mixed_basis,
                 el_min=el_min,
                 el_max=el_max,
-                p=p,
+                **legacy_kwargs
             )
         if backend != "native":
             raise ValueError("backend must be either 'native' or 'legacy'.")
+        if legacy_kwargs:
+            raise TypeError(
+                "Native observe() accepts effects= rather than legacy corruption "
+                "keywords; use observe_legacy() for the old interface."
+            )
         return self.simulate(
             input_model=input_model,
-            addnoise=addnoise,
-            addgains=addgains,
-            gainamp=gainamp,
-            leakamp=leakamp,
-            opacitycal=opacitycal,
-            addFR=addFR,
-            addleakage=addleakage,
-            flagwind=flagwind,
-            flagday=flagday,
-            flagsun=flagsun,
-            allow_mixed_basis=allow_mixed_basis,
+            effects=effects,
             el_min=el_min,
             el_max=el_max,
-            p=p,
         ).to_ehtim_obsdata()
 
-    def make_obs(self, input_model=None, addnoise=True, addgains=True, gainamp=0.04,
-                 leakamp=0.1, opacitycal=True, addFR=True, addleakage=False,
-                 flagwind=True, flagday=False, flagsun=True,
-                 allow_mixed_basis=False, el_min=const.el_min,
-                 el_max=const.el_max, p=None, backend="native"):
-        """Generate an ``ehtim.Obsdata`` export of a selected observation."""
+    def make_obs(self, input_model=None, effects=None, el_min=const.el_min,
+                 el_max=const.el_max, backend="native", **legacy_kwargs):
+        """Generate an ``ehtim.Obsdata`` export of a selected observation.
+
+        Parameters
+        ----------
+        input_model : supported source object, optional
+            Native inputs are ehtim Image, Movie, and Model objects. The
+            legacy route additionally accepts its historical source adapters.
+        effects : StationCorruptionModel, optional
+            Native station-effect configuration. It cannot be combined with
+            ``backend="legacy"``.
+        el_min, el_max : float, optional
+            Ground-station elevation limits in degrees.
+        backend : {"native", "legacy"}, optional
+            ``"native"`` runs :meth:`make_dataset`; ``"legacy"`` calls
+            :meth:`make_obs_legacy`.
+        **legacy_kwargs
+            Arguments accepted by :meth:`make_obs_legacy` only when
+            ``backend="legacy"`` is selected.
+
+        Returns
+        -------
+        ehtim.obsdata.Obsdata
+            Selected observation in ehtim's representable circular layout.
+        """
 
         if backend == "legacy":
+            if effects is not None:
+                raise TypeError(
+                    "effects= is only supported by the native observation backend."
+                )
             return self.make_obs_legacy(
                 input_model=input_model,
-                addnoise=addnoise,
-                addgains=addgains,
-                gainamp=gainamp,
-                leakamp=leakamp,
-                opacitycal=opacitycal,
-                addFR=addFR,
-                addleakage=addleakage,
-                flagwind=flagwind,
-                flagday=flagday,
-                flagsun=flagsun,
-                allow_mixed_basis=allow_mixed_basis,
                 el_min=el_min,
                 el_max=el_max,
-                p=p,
+                **legacy_kwargs
             )
         if backend != "native":
             raise ValueError("backend must be either 'native' or 'legacy'.")
+        if legacy_kwargs:
+            raise TypeError(
+                "Native make_obs() accepts effects= rather than legacy corruption "
+                "keywords; use make_obs_legacy() for the old interface."
+            )
         return self.make_dataset(
             input_model=input_model,
-            addnoise=addnoise,
-            addgains=addgains,
-            gainamp=gainamp,
-            leakamp=leakamp,
-            opacitycal=opacitycal,
-            addFR=addFR,
-            addleakage=addleakage,
-            flagwind=flagwind,
-            flagday=flagday,
-            flagsun=flagsun,
-            allow_mixed_basis=allow_mixed_basis,
+            effects=effects,
             el_min=el_min,
             el_max=el_max,
-            p=p,
         ).to_ehtim_obsdata()
 
     # generate multifrequency observation, assuming that FPT will be used wherever possible
@@ -2232,10 +2270,11 @@ def _take_station_terms(station_terms, row_indices):
     return selected
 
 
-def _fringe_rows_from_dataset(dataset, station_terms=None, receptor_configuration=None):
+def _fringe_rows_from_dataset(dataset, station_terms=None, receptor_configuration=None,
+                              effects=None):
     """Extract basis-agnostic fringe evidence from a native dataset.
 
-    Supplying station terms and a receptor configuration enables weighted
+    Supplying station terms, a receptor configuration, and effects enables weighted
     Stokes-I reconstruction in the common sky basis. Fully calibrated mixed
     datasets can infer their standard R/L/X/Y responses. The circular RR/LL
     path remains available for narrow compatibility callers that provide
@@ -2245,15 +2284,17 @@ def _fringe_rows_from_dataset(dataset, station_terms=None, receptor_configuratio
     if dataset.channel_count != 1:
         raise ValueError("Native fringe selection requires exactly one spectral channel.")
     names = np.asarray(dataset.stations.names)
-    if station_terms is not None or receptor_configuration is not None:
-        if station_terms is None or receptor_configuration is None:
+    if station_terms is not None or receptor_configuration is not None or effects is not None:
+        if station_terms is None or receptor_configuration is None or effects is None:
             raise ValueError(
-                "Native mixed-receptor fringe selection requires station_terms and receptor_configuration."
+                "Native mixed-receptor fringe selection requires station_terms, "
+                "receptor_configuration, and effects."
             )
         left, right = instrumental_corruptions.receptor_rows_for_station_terms(
             dataset,
             station_terms,
             receptor_configuration,
+            effects,
         )
         present = dataset.sample_present[:, 0] & ~dataset.flags[:, 0]
         snr = fringe_selection.receptor_fringe_snr(
@@ -2321,8 +2362,33 @@ def _fringe_rows_from_dataset(dataset, station_terms=None, receptor_configuratio
 
 
 def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref, station_terms=None,
-                         receptor_configuration=None):
-    """Apply the fringe-group proxy directly to a native receptor dataset."""
+                         receptor_configuration=None, effects=None):
+    """Apply the fringe-group proxy directly to a native receptor dataset.
+
+    Parameters
+    ----------
+    obsgen : obs_generator
+        Generator supplying station availability and frequency metadata.
+    dataset : VisibilityDataset
+        One-channel native visibility data to evaluate.
+    snr_ref : float
+        Strong-baseline signal-to-noise threshold.
+    tint_ref : float
+        Strong-baseline coherence time in seconds.
+    station_terms : mapping, optional
+        Row-aligned native station realization. It must be supplied together
+        with ``receptor_configuration`` and ``effects`` for uncalibrated or
+        mixed-receptor data.
+    receptor_configuration : ReceptorConfiguration, optional
+        Resolved Jones-row configuration matching ``dataset.receptors``.
+    effects : StationCorruptionModel, optional
+        Effect model that produced ``station_terms``.
+
+    Returns
+    -------
+    numpy.ndarray, dtype bool
+        Per-row fringe-group selection mask.
+    """
 
     if dataset.row_count == 0:
         return np.zeros(0, dtype=bool)
@@ -2331,6 +2397,7 @@ def fringegroups_dataset(obsgen, dataset, snr_ref, tint_ref, station_terms=None,
         dataset,
         station_terms=station_terms,
         receptor_configuration=receptor_configuration,
+        effects=effects,
     )
     available_sites = [site for site in obsgen.sites if obsgen.bands[site] is not None]
     return fringe_selection.fringe_group_mask(

--- a/ngehtsim/obs/receptor_configuration.py
+++ b/ngehtsim/obs/receptor_configuration.py
@@ -40,7 +40,8 @@ class ReceptorConfiguration:
         SEFD values when calculating thermal uncertainty.
     gain_scale : numpy.ndarray, shape (receptor,)
         Fixed complex per-receptor gain. This is applied in addition to the
-        simulated stochastic station gain when ``addgains=True``.
+        common station and optional independent path gains declared by
+        :class:`ngehtsim.obs.station_effects.StationCorruptionModel`.
 
     Notes
     -----

--- a/ngehtsim/obs/station_effects.py
+++ b/ngehtsim/obs/station_effects.py
@@ -1,0 +1,227 @@
+"""Declarative station-corruption settings for native simulations.
+
+The native simulator separates effects that act on the common two-component
+sky field from gains attached to individual recorded voltage paths.  This is
+necessary for mixed-receptor arrays: an X/Y, R/L, or custom feed inventory
+cannot be described reliably by historical hand-specific keyword arguments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class GainModel:
+    """Random complex-gain distribution for a station or receptor path.
+
+    Parameters
+    ----------
+    amplitude_sigma_dex : float, optional
+        Standard deviation of the logarithmic gain amplitude in dex. A value
+        of zero leaves amplitudes unchanged.
+    phase_distribution : {"none", "uniform"}, optional
+        ``"uniform"`` draws an independent phase uniformly on ``[-pi, pi)``
+        at every station/time sample. ``"none"`` leaves phases unchanged.
+
+    Notes
+    -----
+    A future time-correlated phase process can extend this compact model
+    without changing the station/receptor distinction in the native RIME.
+    """
+
+    amplitude_sigma_dex: float = 0.0
+    phase_distribution: str = "none"
+
+    def __post_init__(self):
+        if (
+            not np.isfinite(self.amplitude_sigma_dex)
+            or self.amplitude_sigma_dex < 0.0
+        ):
+            raise ValueError("amplitude_sigma_dex must be finite and non-negative.")
+        if self.phase_distribution not in ("none", "uniform"):
+            raise ValueError("phase_distribution must be either 'none' or 'uniform'.")
+
+    def sample(self, rng):
+        """Draw one complex gain from this model.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator
+            Random generator used to produce the realization.
+
+        Returns
+        -------
+        complex
+            Drawn gain multiplier.
+        """
+
+        amplitude = 10.0 ** (self.amplitude_sigma_dex * rng.normal(0.0, 1.0))
+        if self.phase_distribution == "uniform":
+            phase = rng.uniform(-np.pi, np.pi)
+        else:
+            phase = 0.0
+        return amplitude * np.exp(1.0j * phase)
+
+
+@dataclass(frozen=True)
+class LeakageModel:
+    """Station-frame circular leakage distribution.
+
+    Parameters
+    ----------
+    component_sigma : float, optional
+        Standard deviation assigned independently to the real and imaginary
+        parts of each off-diagonal circular-basis leakage term.
+    """
+
+    component_sigma: float = 0.0
+
+    def __post_init__(self):
+        if not np.isfinite(self.component_sigma) or self.component_sigma < 0.0:
+            raise ValueError("component_sigma must be finite and non-negative.")
+
+
+@dataclass(frozen=True)
+class StationCorruptionModel:
+    """Complete native station-effect configuration for one simulation.
+
+    Parameters
+    ----------
+    thermal_noise : bool, optional
+        Add independent complex thermal noise using each product's propagated
+        ``sigma_jy`` uncertainty.
+    opacity_calibrated : bool, optional
+        When true, retain the established opacity-calibrated visibility and
+        uncertainty convention. When false, attenuate the signal instead.
+    feed_rotation : bool, optional
+        Apply mount and feed-angle rotation in the common circular sky frame.
+    common_gain : GainModel or None, optional
+        Station-wide gain drawn once per station/time sample and applied to
+        every local receptor path. ``None`` disables common gains.
+    leakage : LeakageModel or None, optional
+        Station-frame circular leakage realization. ``None`` disables leakage.
+    path_gain_overrides : mapping, optional
+        Nested mapping ``{station: {feed_id: GainModel}}``. Each configured
+        gain is applied after the station-frame Jones response to the named
+        local voltage path. It supplements ``common_gain``.
+    flag_wind, flag_daylight, flag_sun : bool, optional
+        Enable weather, daytime, and solar-avoidance availability masks.
+
+    Notes
+    -----
+    ``StationCorruptionModel()`` preserves the historical native defaults:
+    thermal noise, opacity calibration, feed rotation, and a station-common
+    0.04-dex gain with uniformly random phase; leakage remains disabled.
+    """
+
+    thermal_noise: bool = True
+    opacity_calibrated: bool = True
+    feed_rotation: bool = True
+    common_gain: GainModel | None = field(
+        default_factory=lambda: GainModel(
+            amplitude_sigma_dex=0.04,
+            phase_distribution="uniform",
+        )
+    )
+    leakage: LeakageModel | None = None
+    path_gain_overrides: Mapping[str, Mapping[str, GainModel]] = field(
+        default_factory=dict
+    )
+    flag_wind: bool = True
+    flag_daylight: bool = False
+    flag_sun: bool = True
+
+    def __post_init__(self):
+        for name in (
+            "thermal_noise",
+            "opacity_calibrated",
+            "feed_rotation",
+            "flag_wind",
+            "flag_daylight",
+            "flag_sun",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError("{0} must be a bool.".format(name))
+        if self.common_gain is not None and not isinstance(self.common_gain, GainModel):
+            raise TypeError("common_gain must be a GainModel or None.")
+        if self.leakage is not None and not isinstance(self.leakage, LeakageModel):
+            raise TypeError("leakage must be a LeakageModel or None.")
+        if not isinstance(self.path_gain_overrides, Mapping):
+            raise TypeError("path_gain_overrides must be a mapping.")
+        normalized = {}
+        for station, paths in self.path_gain_overrides.items():
+            if not isinstance(paths, Mapping):
+                raise TypeError("Each path_gain_overrides station value must be a mapping.")
+            normalized_paths = {}
+            for feed_id, model in paths.items():
+                if not isinstance(model, GainModel):
+                    raise TypeError("Each path gain override must be a GainModel.")
+                normalized_paths[str(feed_id)] = model
+            normalized[str(station)] = MappingProxyType(normalized_paths)
+        object.__setattr__(
+            self,
+            "path_gain_overrides",
+            MappingProxyType(normalized),
+        )
+
+    def validate_receptors(self, station_names, receptors):
+        """Validate path overrides against a resolved native receptor table.
+
+        Parameters
+        ----------
+        station_names : iterable of str
+            Ordered native station names.
+        receptors : ReceptorTable
+            Resolved station/feed inventory for the native dataset.
+
+        Raises
+        ------
+        ValueError
+            If an override references an unknown station or feed.
+        """
+
+        names = tuple(str(name) for name in station_names)
+        unknown_stations = set(self.path_gain_overrides) - set(names)
+        if unknown_stations:
+            raise ValueError(
+                "Path gain overrides reference unknown stations: {0}.".format(
+                    ", ".join(sorted(unknown_stations))
+                )
+            )
+        for station, paths in self.path_gain_overrides.items():
+            station_index = names.index(station)
+            valid_feeds = {
+                receptors.feed_id[index]
+                for index in np.flatnonzero(receptors.station_index == station_index)
+            }
+            unknown_feeds = set(paths) - valid_feeds
+            if unknown_feeds:
+                raise ValueError(
+                    "Path gain overrides reference unknown feeds for {0}: {1}.".format(
+                        station,
+                        ", ".join(sorted(unknown_feeds)),
+                    )
+                )
+
+    def path_gain_model(self, station, feed_id):
+        """Return the optional independent gain model for one voltage path.
+
+        Parameters
+        ----------
+        station : str
+            Station name.
+        feed_id : str
+            Local feed identifier.
+
+        Returns
+        -------
+        GainModel or None
+            Override model, or ``None`` when the path has no independent gain.
+        """
+
+        return self.path_gain_overrides.get(str(station), {}).get(str(feed_id))

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -9,6 +9,7 @@ from astropy.coordinates import EarthLocation, AltAz, get_sun
 
 import ngehtsim.const_def as const
 import ngehtsim.obs.observation_geometry as observation_geometry
+from ngehtsim.obs.station_effects import StationCorruptionModel
 from ngehtsim.obs.visibility_dataset import StationTable, VisibilityDataset
 
 ###################################################
@@ -603,9 +604,7 @@ def station_terms(obs, F0, station_context, array, rng, gainamp=0.04, leakamp=0.
     return terms
 
 
-def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
-                              leakamp=0.1, addgains=True, addleakage=False,
-                              flagwind=True, flagday=False, flagsun=True,
+def station_terms_for_dataset(dataset, F0, station_context, rng, effects,
                               solar_angle=None, verbosity=0,
                               windspeed_sefd_modifier=None, reference_mjd=None,
                               cache=None):
@@ -623,11 +622,10 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
         Resolved weather, receiver, telescope, uptime, and feed-rotation inputs
         from the observation generator.
     rng : numpy.random.Generator
-        Random generator used for gain and leakage realizations.
-    gainamp, leakamp : float, optional
-        Gain-amplitude scatter in dex and one-component leakage scatter.
-    addgains, addleakage, flagwind, flagday, flagsun : bool, optional
-        Enable gain/leakage terms and wind, daylight, or solar-avoidance flags.
+        Random generator used for station-effect realizations.
+    effects : StationCorruptionModel
+        Complete native noise, calibration, corruption, and availability
+        configuration.
     solar_angle : float, optional
         Source-Sun angular separation in degrees when solar avoidance is used.
     verbosity : int, optional
@@ -642,7 +640,9 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
     Returns
     -------
     dict
-        Row-aligned station terms consumed by the native receptor RIME.
+        Row-aligned common-Jones, path-gain, weather, and availability terms
+        consumed by the native receptor RIME. Native terms deliberately do not
+        expose hand-specific R/L field names.
     StationTable
         Updated immutable station metadata with simulated SEFD and leakage
         values.
@@ -655,27 +655,101 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, gainamp=0.04,
     stable archive interchange format.
     """
 
+    if not isinstance(effects, StationCorruptionModel):
+        raise TypeError("effects must be a StationCorruptionModel instance.")
+    effects.validate_receptors(dataset.stations.names, dataset.receptors)
     metadata = station_metadata_for_dataset(
         dataset,
         station_context,
         reference_mjd=reference_mjd,
         cache=cache,
     )
-    return _station_terms_from_rows(
+    # Reuse the established weather and availability calculation. Its legacy
+    # hand-specific gain outputs are disabled here and never escape the native
+    # API; generic common/path gains are realized below.
+    legacy_terms, stations = _station_terms_from_rows(
         metadata["_rows"],
         metadata,
         F0,
         station_context,
         dataset.stations,
         rng,
-        gainamp=gainamp,
-        leakamp=leakamp,
-        addgains=addgains,
-        addleakage=addleakage,
-        flagwind=flagwind,
-        flagday=flagday,
-        flagsun=flagsun,
+        addgains=False,
+        leakamp=(0.0 if effects.leakage is None else effects.leakage.component_sigma),
+        addleakage=effects.leakage is not None,
+        flagwind=effects.flag_wind,
+        flagday=effects.flag_daylight,
+        flagsun=effects.flag_sun,
         solar_angle=solar_angle,
         verbosity=verbosity,
         windspeed_sefd_modifier=windspeed_sefd_modifier,
     )
+    terms = dict(legacy_terms)
+    count = dataset.row_count
+    terms["common_gain1"], terms["common_gain2"] = _sample_common_gains(
+        metadata["_rows"],
+        metadata["sites_obs"],
+        effects.common_gain,
+        rng,
+    )
+    terms["leakage_matrix1"], terms["leakage_matrix2"] = _native_leakage_matrices(
+        terms,
+        count,
+        effects.leakage is not None,
+    )
+    terms["path_gains"] = _sample_path_gains(
+        dataset,
+        metadata["_rows"].times,
+        effects,
+        rng,
+    )
+    for name in ("leak1R", "leak2R", "leak1L", "leak2L"):
+        terms.pop(name, None)
+    return terms, stations
+
+
+def _sample_common_gains(rows, sites, gain_model, rng):
+    """Return one row-end complex gain for each station/time sample."""
+
+    count = len(rows.times)
+    gain1 = np.ones(count, dtype=complex)
+    gain2 = np.ones(count, dtype=complex)
+    if gain_model is None:
+        return gain1, gain2
+    for site in sites:
+        for time in np.unique(rows.times):
+            value = gain_model.sample(rng)
+            gain1[(rows.t1 == site) & (rows.times == time)] = value
+            gain2[(rows.t2 == site) & (rows.times == time)] = value
+    return gain1, gain2
+
+
+def _native_leakage_matrices(terms, count, enabled):
+    """Convert transient legacy D-term draws into generic Jones matrices."""
+
+    matrix1 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
+    matrix2 = np.array(matrix1, copy=True)
+    if enabled:
+        matrix1[:, 0, 1] = terms["leak1R"]
+        matrix1[:, 1, 0] = terms["leak1L"]
+        matrix2[:, 0, 1] = terms["leak2R"]
+        matrix2[:, 1, 0] = terms["leak2L"]
+    return matrix1, matrix2
+
+
+def _sample_path_gains(dataset, times, effects, rng):
+    """Return independent receptor-path gains aligned to native rows."""
+
+    count = dataset.row_count
+    gains = np.ones((count, dataset.receptors.count), dtype=complex)
+    names = dataset.stations.names
+    for receptor, (station_index, feed_id) in enumerate(zip(
+        dataset.receptors.station_index,
+        dataset.receptors.feed_id,
+    )):
+        model = effects.path_gain_model(names[station_index], feed_id)
+        if model is None:
+            continue
+        for time in np.unique(times):
+            gains[times == time, receptor] = model.sample(rng)
+    return gains

--- a/tests/test_SYMBA_export.py
+++ b/tests/test_SYMBA_export.py
@@ -3,6 +3,7 @@
 
 import ehtim as eh
 import ngehtsim.obs.obs_generator as og
+from ngehtsim.obs.station_effects import GainModel, StationCorruptionModel
 import os
 
 #######################################################
@@ -34,7 +35,14 @@ settings = {'weather': weather_type}
 obsgen = og.obs_generator(settings)
 
 # generate and save the observation
-obs = obsgen.make_obs(im, addnoise=addnoise, addgains=addgains)
+effects = StationCorruptionModel(
+    thermal_noise=addnoise,
+    common_gain=(
+        GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+        if addgains else None
+    ),
+)
+obs = obsgen.make_obs(im, effects=effects)
 obs.save_uvfits('./tests/example_dataset.uvfits')
 
 # export SYMBA-compatible input files

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,6 +6,7 @@ import ehtim as eh
 import yaml
 import os
 import ngehtsim.obs.obs_generator as og
+from ngehtsim.obs.station_effects import StationCorruptionModel
 import ngehtsim.const_def as const
 
 #######################################################
@@ -14,13 +15,14 @@ import ngehtsim.const_def as const
 # input settings file
 yamlfile = './tests/settings.yaml'
 
-# initialize the observation generator
-obsgen = og.obs_generator(settings_file=yamlfile)
-
 # load settings file
 loader = yaml.SafeLoader
 with open(yamlfile, 'r') as fi:
     settings = yaml.load(fi, Loader=loader)
+settings["transform_backend"] = "direct"
+
+# The basic smoke test must not require the optional FINUFFT runtime.
+obsgen = og.obs_generator(settings=settings)
 
 # load input model
 infile = settings['model_file']
@@ -35,8 +37,15 @@ obs = obsgen.make_obs()
 
 
 def with_vs_without(obsgen):
-    obs1 = obsgen.make_obs(addnoise=False, addgains=False)
-    obs2 = obsgen.make_obs(input_model, addnoise=False, addgains=False)
+    effects = StationCorruptionModel(
+        thermal_noise=False,
+        common_gain=None,
+        flag_wind=False,
+        flag_daylight=False,
+        flag_sun=False,
+    )
+    obs1 = obsgen.make_obs(effects=effects)
+    obs2 = obsgen.make_obs(input_model, effects=effects)
     return obs1, obs2
 
 

--- a/tests/test_core_safety.py
+++ b/tests/test_core_safety.py
@@ -7,6 +7,7 @@ import ehtim as eh
 import ngehtsim.calibration.calibration as nc
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.source_models as source_models
+from ngehtsim.obs.station_effects import StationCorruptionModel
 
 #######################################################
 # helpers
@@ -29,15 +30,15 @@ def _compact_model():
 
 
 def _observe_without_corruptions(obsgen, input_model, **kwargs):
-    observe_kwargs = dict(
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+    effects = StationCorruptionModel(
+        thermal_noise=False,
+        common_gain=None,
+        feed_rotation=False,
+        flag_wind=False,
+        flag_daylight=False,
+        flag_sun=False,
     )
-    observe_kwargs.update(kwargs)
-    return obsgen.observe(input_model, **observe_kwargs)
+    return obsgen.observe(input_model, effects=effects, **kwargs)
 
 #######################################################
 # tests

--- a/tests/test_generate_observation_flagging.py
+++ b/tests/test_generate_observation_flagging.py
@@ -4,6 +4,7 @@
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.obs_plotter as op
 import ngehtsim.metrics as cm
+from ngehtsim.obs.station_effects import StationCorruptionModel
 import matplotlib.pyplot as plt
 
 #######################################################
@@ -28,7 +29,9 @@ obs.save_uvfits('./tests/data_generation_flagging/example_datafile.uvfits')
 obsgen_flagged = og.obs_generator(settings_file=yamlfile)
 
 # generate the observation
-obs_flagged = obsgen_flagged.make_obs(flagday=True)
+obs_flagged = obsgen_flagged.make_obs(
+    effects=StationCorruptionModel(flag_daylight=True),
+)
 
 # save it as a uvfits file
 obs_flagged.save_uvfits('./tests/data_generation_flagging/example_datafile_flagged.uvfits')
@@ -58,7 +61,9 @@ obsgen_flagged2 = og.obs_generator(settings_file=yamlfile,
                                    wind_loading_overrides=wind_loading_overrides)
 
 # generate the observation
-obs_flagged2 = obsgen_flagged2.make_obs(flagday=True)
+obs_flagged2 = obsgen_flagged2.make_obs(
+    effects=StationCorruptionModel(flag_daylight=True),
+)
 
 # save it as a uvfits file
 obs_flagged2.save_uvfits('./tests/data_generation_flagging/example_datafile_flagged2.uvfits')

--- a/tests/test_generate_observation_instrumental_corruptions.py
+++ b/tests/test_generate_observation_instrumental_corruptions.py
@@ -8,6 +8,7 @@ import ehtim as eh
 import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.obs_plotter as op
 import ngehtsim.metrics as cm
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 
 #######################################################
 # set up obsgen object
@@ -27,24 +28,45 @@ mod = mod.add_circ_gauss(0.5, 20.*eh.RADPERUAS, x0=20.0*eh.RADPERUAS, y0=0.0, po
 mod = mod.add_circ_gauss(0.5, 30.*eh.RADPERUAS, x0=-20.0*eh.RADPERUAS, y0=20.0*eh.RADPERUAS, pol_frac=0.10, pol_evpa=30.0*eh.DEGREE, cpol_frac=-0.05)
 
 # generate an observation with no noise
-obs_nonoise = obsgen.make_obs(input_model=mod,
-                              addnoise=False,addgains=False,addleakage=False)
+obs_nonoise = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(thermal_noise=False, common_gain=None),
+)
 
 # generate an observation with only thermal noise
-obs_thnoise = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=False,addleakage=False)
+obs_thnoise = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(thermal_noise=True, common_gain=None),
+)
 
 # generate an observation with thermal noise and station gains
-obs_thgains = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=True,addleakage=False)
+obs_thgains = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform"),
+    ),
+)
 
 # generate an observation with thermal noise and leakage
-obs_thleak = obsgen.make_obs(input_model=mod,
-                              addnoise=True,addgains=False,addleakage=True)
+obs_thleak = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=None,
+        leakage=LeakageModel(component_sigma=0.1),
+    ),
+)
 
 # generate an observation with thermal noise, station gains, and leakage
-obs_full = obsgen.make_obs(input_model=mod,
-                           addnoise=True,addgains=True,addleakage=True)
+obs_full = obsgen.make_obs(
+    input_model=mod,
+    effects=StationCorruptionModel(
+        thermal_noise=True,
+        common_gain=GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform"),
+        leakage=LeakageModel(component_sigma=0.1),
+    ),
+)
 
 # save uvfits files
 obs_nonoise.save_uvfits('./tests/data_generation_instrumental_corruptions/datafile_nonoise.uvfits')

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -6,10 +6,9 @@ import ehtim as eh
 
 import ngehtsim.const_def as const
 import ngehtsim.obs.instrumental_corruptions as instrumental_corruptions
-import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.obs_generator as og
-import ngehtsim.obs.source_models as source_models
-import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.receptor_configuration import resolve_receptor_configuration
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 
@@ -44,6 +43,26 @@ class FixedRng:
         return np.zeros(size, dtype=int)
 
 
+def _effects(*, thermal_noise=False, common_gain=False, opacity_calibrated=True,
+             feed_rotation=False, leakage=False, flag_wind=False,
+             flag_daylight=False, flag_sun=False):
+    """Build native station effects without legacy simulation keywords."""
+
+    return StationCorruptionModel(
+        thermal_noise=thermal_noise,
+        opacity_calibrated=opacity_calibrated,
+        feed_rotation=feed_rotation,
+        common_gain=(
+            GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+            if common_gain else None
+        ),
+        leakage=LeakageModel(component_sigma=0.1) if leakage else None,
+        flag_wind=flag_wind,
+        flag_daylight=flag_daylight,
+        flag_sun=flag_sun,
+    )
+
+
 def _polarized_model():
     model = eh.model.Model()
     return model.add_circ_gauss(
@@ -59,53 +78,11 @@ def _polarized_image():
     return _polarized_model().make_image(160.0 * eh.RADPERUAS, 64)
 
 
-def _elevation_limited(dataset):
-    geometry = observation_geometry.station_geometry_from_rows(
-        dataset.stations.position_itrs_m,
-        dataset.time_mjd,
-        dataset.antenna1,
-        dataset.antenna2,
-        dataset.ra_hours,
-        dataset.dec_degrees,
-    )
-    mask = (
-        (np.rad2deg(geometry.elevation1_rad) > const.el_min)
-        & (np.rad2deg(geometry.elevation1_rad) < const.el_max)
-        & (np.rad2deg(geometry.elevation2_rad) > const.el_min)
-        & (np.rad2deg(geometry.elevation2_rad) < const.el_max)
-    )
-    return dataset.select_rows(mask)
-
-
-def _coherency_matrices(obs):
-    matrices = np.empty((len(obs.data), 2, 2), dtype=complex)
-    matrices[:, 0, 0] = obs.data["rrvis"]
-    matrices[:, 0, 1] = obs.data["rlvis"]
-    matrices[:, 1, 0] = obs.data["lrvis"]
-    matrices[:, 1, 1] = obs.data["llvis"]
-    return matrices
-
-
-def _native_row_order(dataset):
-    names = np.asarray(dataset.stations.names)
-    return np.lexsort((
-        names[dataset.antenna2],
-        names[dataset.antenna1],
-        dataset.time_mjd,
-    ))
-
-
-def _obsdata_row_order(obs):
-    return np.lexsort((obs.data["t2"], obs.data["t1"], obs.data["time"]))
-
-
-def _station_jones(gain_r, gain_l, leakage_r, leakage_l, feed_rotation):
-    jones = np.empty((len(feed_rotation), 2, 2), dtype=complex)
-    jones[:, 0, 0] = gain_r * np.exp(-1.0j * feed_rotation)
-    jones[:, 0, 1] = gain_r * leakage_r * np.exp(1.0j * feed_rotation)
-    jones[:, 1, 0] = gain_l * leakage_l * np.exp(-1.0j * feed_rotation)
-    jones[:, 1, 1] = gain_l * np.exp(1.0j * feed_rotation)
-    return jones
+def _station_jones(common_gain, leakage, feed_rotation):
+    jones = np.zeros((len(feed_rotation), 2, 2), dtype=complex)
+    jones[:, 0, 0] = np.exp(-1.0j * feed_rotation)
+    jones[:, 1, 1] = np.exp(1.0j * feed_rotation)
+    return common_gain[:, np.newaxis, np.newaxis] * leakage @ jones
 
 
 def test_circular_leakage_matches_jones_matrix():
@@ -156,76 +133,66 @@ def test_circular_leakage_matches_jones_matrix():
 
 
 def test_circular_generator_matches_composed_station_jones_matrices():
-    clean_generator = og.obs_generator(settings=SETTINGS)
-    clean = clean_generator.make_dataset(
+    generator = og.obs_generator(settings=SETTINGS, weight=1)
+    effects = _effects(common_gain=True, feed_rotation=True, leakage=True)
+    simulated = generator.simulate(
         _polarized_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=effects,
     )
-    corrupted_generator = og.obs_generator(settings=SETTINGS, weight=1)
-    corrupted_result = corrupted_generator.make_dataset(
-        _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+    dataset = simulated.dataset
+    terms = simulated.station_terms
+    sky_coherency = np.empty((dataset.row_count, 2, 2), dtype=complex)
+    row_index = np.arange(dataset.row_count, dtype=float)
+    sky_coherency[:, 0, 0] = 1.0 + (0.01 * row_index) + 0.1j
+    sky_coherency[:, 0, 1] = -0.2 + 0.3j
+    sky_coherency[:, 1, 0] = 0.15 - 0.25j
+    sky_coherency[:, 1, 1] = 0.8 - (0.02 * row_index) - 0.05j
+    corrupted = instrumental_corruptions.apply_receptor_corruptions(
+        dataset,
+        sky_coherency,
+        terms,
+        dataset.stations,
+        resolve_receptor_configuration(
+            dataset.stations.names,
+            generator.station_receptors,
+            generator.station_signal_paths,
+        ),
+        effects,
+        generator.rng,
     )
-    terms = corrupted_result.station_terms
-    row_mask = corrupted_result.row_mask
-
-    assert np.array_equal(clean.row_mask, row_mask)
 
     jones1 = _station_jones(
-        terms["gainamp1R"][row_mask] * np.exp(1.0j * terms["gainphase1R"][row_mask]),
-        terms["gainamp1L"][row_mask] * np.exp(1.0j * terms["gainphase1L"][row_mask]),
-        terms["leak1R"][row_mask],
-        terms["leak1L"][row_mask],
-        (terms["f_par1"][row_mask] * terms["par1"][row_mask])
-        + (terms["f_el1"][row_mask] * terms["el1"][row_mask])
-        + ((np.pi / 180.0) * terms["phi_off1"][row_mask]),
+        terms["common_gain1"],
+        terms["leakage_matrix1"],
+        (terms["f_par1"] * terms["par1"])
+        + (terms["f_el1"] * terms["el1"])
+        + ((np.pi / 180.0) * terms["phi_off1"]),
     )
     jones2 = _station_jones(
-        terms["gainamp2R"][row_mask] * np.exp(1.0j * terms["gainphase2R"][row_mask]),
-        terms["gainamp2L"][row_mask] * np.exp(1.0j * terms["gainphase2L"][row_mask]),
-        terms["leak2R"][row_mask],
-        terms["leak2L"][row_mask],
-        (terms["f_par2"][row_mask] * terms["par2"][row_mask])
-        + (terms["f_el2"][row_mask] * terms["el2"][row_mask])
-        + ((np.pi / 180.0) * terms["phi_off2"][row_mask]),
+        terms["common_gain2"],
+        terms["leakage_matrix2"],
+        (terms["f_par2"] * terms["par2"])
+        + (terms["f_el2"] * terms["el2"])
+        + ((np.pi / 180.0) * terms["phi_off2"]),
     )
-    clean_visibility = clean.dataset.visibilities[row_mask, 0]
-    clean_coherency = np.empty((len(clean_visibility), 2, 2), dtype=complex)
-    clean_coherency[:, 0, 0] = clean_visibility[:, 0]
-    clean_coherency[:, 0, 1] = clean_visibility[:, 2]
-    clean_coherency[:, 1, 0] = clean_visibility[:, 3]
-    clean_coherency[:, 1, 1] = clean_visibility[:, 1]
-    expected = jones1 @ clean_coherency @ np.swapaxes(np.conj(jones2), -1, -2)
+    expected = (
+        jones1
+        @ sky_coherency
+        @ np.swapaxes(np.conj(jones2), -1, -2)
+    )
 
-    corrupted_visibility = corrupted_result.dataset.visibilities[row_mask, 0]
+    corrupted_visibility = corrupted.visibilities[:, 0]
     corrupted_coherency = np.empty_like(expected)
     corrupted_coherency[:, 0, 0] = corrupted_visibility[:, 0]
     corrupted_coherency[:, 0, 1] = corrupted_visibility[:, 2]
     corrupted_coherency[:, 1, 0] = corrupted_visibility[:, 3]
     corrupted_coherency[:, 1, 1] = corrupted_visibility[:, 1]
     assert np.allclose(corrupted_coherency, expected, atol=1.0e-12)
-    assert clean.dataset.ampcal is True
-    assert clean.dataset.phasecal is True
-    assert clean.dataset.opacitycal is True
-    assert clean.dataset.dcal is True
-    assert clean.dataset.frcal is True
-    assert corrupted_result.dataset.ampcal is False
-    assert corrupted_result.dataset.phasecal is False
-    assert corrupted_result.dataset.opacitycal is True
-    assert corrupted_result.dataset.dcal is False
-    assert corrupted_result.dataset.frcal is False
+    assert corrupted.ampcal is False
+    assert corrupted.phasecal is False
+    assert corrupted.opacitycal is True
+    assert corrupted.dcal is False
+    assert corrupted.frcal is False
 
 
 def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
@@ -233,25 +200,13 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
     clean_generator.rng = FixedRng()
     clean = clean_generator.simulate(
         _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(common_gain=True),
     )
     noisy_generator = og.obs_generator(settings=SETTINGS)
     noisy_generator.rng = FixedRng()
     noisy = noisy_generator.simulate(
         _polarized_model(),
-        addnoise=True,
-        addgains=True,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(thermal_noise=True, common_gain=True),
     )
 
     clean_sigma = clean.dataset.sigma_jy
@@ -266,14 +221,7 @@ def test_thermal_noise_uses_reported_gain_corrupted_sigmas():
 def test_generator_marks_uncalibrated_opacity_in_output_metadata():
     obs = og.obs_generator(settings=SETTINGS).make_obs(
         _polarized_model(),
-        addnoise=False,
-        addgains=False,
-        opacitycal=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(opacity_calibrated=False),
     )
 
     assert obs.ampcal is True
@@ -283,247 +231,34 @@ def test_generator_marks_uncalibrated_opacity_in_output_metadata():
     assert obs.frcal is True
 
 
-def _native_dataset_and_terms(generator, image, **kwargs):
-    template = observation_geometry.ground_visibility_template(
-        generator.arr,
-        generator.geometry_context(),
-    )
-    sampled, F0 = source_models.observe_source_dataset(
-        image,
-        template,
-        generator.source_context(),
-    )
-    sampled = _elevation_limited(sampled)
-    station_keys = (
-        "gainamp",
-        "leakamp",
-        "addgains",
-        "addleakage",
-        "flagwind",
-        "flagday",
-        "flagsun",
-    )
-    station_terms, stations = station_observation.station_terms_for_dataset(
-        sampled,
-        F0,
-        generator.station_context((sampled.time_mjd - generator.mjd) * 24.0),
-        generator.rng,
-        solar_angle=generator.solar_angle,
-        windspeed_sefd_modifier=og.windspeed_SEFD_modification,
-        reference_mjd=generator.mjd,
-        cache=generator.station_term_cache,
-        **{key: kwargs[key] for key in station_keys if key in kwargs},
-    )
-    return sampled, station_terms, stations
-
-
-def _native_corrupted_dataset(generator, image, **kwargs):
-    sampled, station_terms, stations = _native_dataset_and_terms(generator, image, **kwargs)
-    corruption_keys = ("addnoise", "addgains", "opacitycal", "addFR", "addleakage")
-    return instrumental_corruptions.apply_circular_corruptions(
-        sampled,
-        station_terms,
-        stations,
-        generator.rng,
-        **{key: kwargs[key] for key in corruption_keys if key in kwargs},
-    )
-
-
-def test_native_circular_corruptions_match_legacy_generator_without_noise(monkeypatch):
-    kwargs = {
-        "addnoise": False,
-        "addgains": True,
-        "gainamp": 0.04,
-        "leakamp": 0.1,
-        "opacitycal": True,
-        "addFR": True,
-        "addleakage": True,
-        "flagwind": False,
-        "flagday": False,
-        "flagsun": False,
-    }
-    direct_settings = {**SETTINGS, "transform_backend": "direct"}
-    native_generator = og.obs_generator(settings=direct_settings)
-    native_generator.rng = FixedRng()
-    native = _native_corrupted_dataset(native_generator, _polarized_image(), **kwargs)
-
-    legacy_generator = og.obs_generator(settings=direct_settings)
-    legacy_generator.rng = FixedRng()
-    legacy_template = observation_geometry.ground_visibility_template(
-        legacy_generator.arr,
-        legacy_generator.geometry_context(),
-    )
-    legacy_empty = _elevation_limited(legacy_template).to_ehtim_obsdata()
-
-    def fixed_template(*args, **ignored_kwargs):
-        return legacy_empty, "native-test-template", {}, legacy_empty.copy()
-
-    monkeypatch.setattr(observation_geometry, "observation_template", fixed_template)
-    legacy = legacy_generator.observe_legacy(_polarized_image(), **kwargs)
-    unflagged = native.select_rows(~np.any(native.flags[:, 0, :], axis=1))
-    native_order = _native_row_order(unflagged)
-    legacy_order = _obsdata_row_order(legacy)
-    native_names = np.asarray(unflagged.stations.names)
-    native_visibilities = unflagged.visibilities[:, 0, :]
-    native_sigma = unflagged.sigma_jy[:, 0, :]
-    legacy_visibilities = np.column_stack((
-        legacy.data["rrvis"],
-        legacy.data["llvis"],
-        legacy.data["rlvis"],
-        legacy.data["lrvis"],
-    ))
-    legacy_sigma = np.column_stack((
-        legacy.data["rrsigma"],
-        legacy.data["llsigma"],
-        legacy.data["rlsigma"],
-        legacy.data["lrsigma"],
-    ))
-
-    assert np.array_equal(
-        native_names[unflagged.antenna1][native_order],
-        legacy.data["t1"][legacy_order],
-    )
-    assert np.array_equal(
-        native_names[unflagged.antenna2][native_order],
-        legacy.data["t2"][legacy_order],
-    )
-    assert np.allclose(
-        (unflagged.time_mjd[native_order] - legacy.mjd) * 24.0,
-        legacy.data["time"][legacy_order],
-        atol=1.0e-12,
-    )
-    assert np.allclose(
-        unflagged.integration_time_s[native_order],
-        legacy.data["tint"][legacy_order],
-        atol=1.0e-12,
-    )
-    assert np.allclose(unflagged.tau1[native_order], legacy.data["tau1"][legacy_order], atol=1.0e-12)
-    assert np.allclose(unflagged.tau2[native_order], legacy.data["tau2"][legacy_order], atol=1.0e-12)
-    assert np.allclose(native_visibilities[native_order], legacy_visibilities[legacy_order], atol=1.0e-12)
-    assert np.allclose(native_sigma[native_order], legacy_sigma[legacy_order], atol=1.0e-12)
-    assert unflagged.ampcal is legacy.ampcal is False
-    assert unflagged.phasecal is legacy.phasecal is False
-    assert unflagged.opacitycal is legacy.opacitycal is True
-    assert unflagged.dcal is legacy.dcal is False
-    assert unflagged.frcal is legacy.frcal is False
-
-
-def test_native_circular_corruptions_do_not_require_obsdata_conversion(monkeypatch):
-    generator = og.obs_generator(settings=SETTINGS)
-    sampled, station_terms, stations = _native_dataset_and_terms(
-        generator,
-        _polarized_image(),
-        addgains=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
-
+def test_native_receptor_corruptions_do_not_require_obsdata_conversion(monkeypatch):
     def unexpected_obsdata_conversion(*args, **kwargs):
         raise AssertionError("Native corruptions must not construct an Obsdata object.")
 
-    monkeypatch.setattr(
-        VisibilityDataset,
-        "to_ehtim_obsdata",
-        unexpected_obsdata_conversion,
-    )
-    corrupted = instrumental_corruptions.apply_circular_corruptions(
-        sampled,
-        station_terms,
-        stations,
-        generator.rng,
-        addnoise=False,
-        addgains=False,
-        opacitycal=False,
-        addFR=False,
-        addleakage=False,
-    )
-
-    assert isinstance(corrupted, VisibilityDataset)
-    assert corrupted.opacitycal is False
-    assert np.all(np.isfinite(corrupted.sigma_jy))
-
-
-def test_native_circular_noise_uses_reported_sigmas():
-    clean_generator = og.obs_generator(settings=SETTINGS)
-    clean_generator.rng = FixedRng()
-    clean = _native_corrupted_dataset(
-        clean_generator,
+    monkeypatch.setattr(VisibilityDataset, "to_ehtim_obsdata", unexpected_obsdata_conversion)
+    result = og.obs_generator(settings=SETTINGS).simulate(
         _polarized_image(),
-        addnoise=False,
-        addgains=True,
-        gainamp=0.04,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
-    noisy_generator = og.obs_generator(settings=SETTINGS)
-    noisy_generator.rng = FixedRng()
-    noisy = _native_corrupted_dataset(
-        noisy_generator,
-        _polarized_image(),
-        addnoise=True,
-        addgains=True,
-        gainamp=0.04,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(opacity_calibrated=False),
     )
 
-    sigma = noisy.sigma_jy
-    assert np.allclose(noisy.sigma_jy, clean.sigma_jy)
-    assert np.allclose(noisy.visibilities - clean.visibilities, (1.0 + 1.0j) * sigma)
+    assert isinstance(result.dataset, VisibilityDataset)
+    assert result.dataset.opacitycal is False
+    assert np.all(np.isfinite(result.dataset.sigma_jy))
 
 
-def test_native_circular_corruptions_flag_rows_and_support_selection():
-    generator = og.obs_generator(settings=SETTINGS)
-    sampled, station_terms, stations = _native_dataset_and_terms(
-        generator,
-        _polarized_image(),
-        addgains=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-    )
-    station_terms = dict(station_terms)
-    station_terms["uptime_mask"] = np.ones(sampled.row_count, dtype=bool)
-    station_terms["uptime_mask"][:2] = False
-    station_terms["flagsites"] = [station_terms["t1"][2]]
-
-    corrupted = instrumental_corruptions.apply_circular_corruptions(
-        sampled,
-        station_terms,
-        stations,
-        generator.rng,
-        addnoise=False,
-        addgains=False,
-        opacitycal=True,
-        addFR=False,
-        addleakage=False,
-    )
-
-    expected_flagged = (
-        ~station_terms["uptime_mask"]
-        | (station_terms["t1"] == station_terms["flagsites"][0])
-        | (station_terms["t2"] == station_terms["flagsites"][0])
-    )
-    assert np.array_equal(np.all(corrupted.flags[:, 0, :], axis=1), expected_flagged)
-    selected = corrupted.select_rows(~expected_flagged)
-    assert selected.row_count == np.count_nonzero(~expected_flagged)
-    assert not np.any(selected.flags)
-
-
-def test_legacy_mixed_basis_switch_is_obsolete():
+def test_native_effects_reject_legacy_corruption_keywords():
     obsgen = og.obs_generator(settings=SETTINGS)
 
-    with pytest.raises(ValueError, match="allow_mixed_basis is obsolete"):
-        obsgen.simulate(_polarized_model(), allow_mixed_basis=True)
+    with pytest.raises(TypeError, match="unexpected keyword argument 'addnoise'"):
+        obsgen.simulate(_polarized_model(), addnoise=False)
+    with pytest.raises(TypeError, match=r"Native observe\(\) accepts effects"):
+        obsgen.observe(_polarized_model(), addnoise=False)
+    with pytest.raises(TypeError, match="only supported by the native"):
+        obsgen.make_obs(
+            _polarized_model(),
+            effects=_effects(),
+            backend="legacy",
+        )
 
 
 def test_station_registry_marks_roen_as_linear():

--- a/tests/test_mixed_receptor_rime.py
+++ b/tests/test_mixed_receptor_rime.py
@@ -13,6 +13,7 @@ from ngehtsim.obs.receptor_configuration import (
     STANDARD_JONES_ROWS,
     resolve_receptor_configuration,
 )
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 
 
 SETTINGS = {
@@ -35,6 +36,24 @@ MIXED_RECEPTORS = {
     "LMT": ("Y",),
     "SMT": ("R", "X", "Y"),
 }
+
+
+def _effects(*, thermal_noise=False, common_gain=False, feed_rotation=False,
+             leakage=False, flag_wind=False, flag_daylight=False, flag_sun=False):
+    """Build the compact native effect configurations used in this module."""
+
+    return StationCorruptionModel(
+        thermal_noise=thermal_noise,
+        common_gain=(
+            GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+            if common_gain else None
+        ),
+        feed_rotation=feed_rotation,
+        leakage=LeakageModel(component_sigma=0.1) if leakage else None,
+        flag_wind=flag_wind,
+        flag_daylight=flag_daylight,
+        flag_sun=flag_sun,
+    )
 
 
 def _polarized_model():
@@ -93,39 +112,16 @@ def test_rank_deficient_fringe_evidence_uses_strongest_product():
     assert _product_snr(left, right, coherency, sigma=2.0) == expected
 
 
-def test_standard_circular_rime_matches_the_legacy_circular_kernel():
-    """The generic Jones path retains the established circular calculation."""
+def test_standard_circular_rime_uses_generic_station_terms():
+    """Native circular output no longer exposes hand-specific state fields."""
 
     generator = og.obs_generator(settings=SETTINGS)
     result = generator.simulate(
         _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(common_gain=True, feed_rotation=True, leakage=True),
     )
-    sampled, _ = source_models.observe_source_dataset(
-        _polarized_model(),
-        result.dataset,
-        generator.source_context(),
-    )
-    legacy = instrumental_corruptions.apply_circular_corruptions(
-        sampled,
-        result.station_terms,
-        result.dataset.stations,
-        np.random.default_rng(2),
-        addnoise=False,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-    )
-
-    assert np.allclose(result.dataset.visibilities, legacy.visibilities, atol=1.0e-12)
-    assert np.allclose(result.dataset.sigma_jy, legacy.sigma_jy, atol=1.0e-12)
-    assert np.array_equal(result.dataset.flags, legacy.flags)
+    assert {"common_gain1", "common_gain2", "leakage_matrix1", "leakage_matrix2", "path_gains"} <= set(result.station_terms)
+    assert not any(name.startswith(("gainamp", "gainphase", "leak1", "leak2")) for name in result.station_terms)
 
 
 def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
@@ -133,15 +129,26 @@ def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
         settings=SETTINGS,
         station_receptors=MIXED_RECEPTORS,
     )
+    effects = StationCorruptionModel(
+        thermal_noise=False,
+        common_gain=GainModel(
+            amplitude_sigma_dex=0.04,
+            phase_distribution="uniform",
+        ),
+        feed_rotation=True,
+        leakage=LeakageModel(component_sigma=0.1),
+        path_gain_overrides={
+            "ALMA": {
+                "X": GainModel(amplitude_sigma_dex=0.02),
+            },
+        },
+        flag_wind=False,
+        flag_daylight=False,
+        flag_sun=False,
+    )
     result = generator.simulate(
         _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=effects,
     )
     dataset = result.dataset
     configuration = resolve_receptor_configuration(
@@ -159,6 +166,7 @@ def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
         dataset,
         result.station_terms,
         configuration,
+        effects,
     )
 
     expected = np.zeros_like(dataset.visibilities[:, 0])
@@ -169,6 +177,15 @@ def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
 
     assert dataset.receptors.polarization_label == ("X", "Y", "R", "L", "Y", "R", "X", "Y")
     assert np.allclose(dataset.visibilities[:, 0], expected, atol=1.0e-12)
+    alma_x = next(
+        index
+        for index, (station, feed_id) in enumerate(zip(
+            dataset.receptors.station_index,
+            dataset.receptors.feed_id,
+        ))
+        if dataset.stations.names[station] == "ALMA" and feed_id == "X"
+    )
+    assert not np.allclose(result.station_terms["path_gains"][:, alma_x], 1.0)
 
 
 def test_mixed_receptor_fringegroups_uses_generic_stokes_i_evidence():
@@ -178,13 +195,7 @@ def test_mixed_receptor_fringegroups_uses_generic_stokes_i_evidence():
     )
     result = generator.make_dataset(
         _polarized_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert result.dataset.row_count > 0
@@ -200,13 +211,7 @@ def test_direct_mixed_fringegroups_dataset_infers_standard_feed_responses():
     )
     result = generator.make_dataset(
         _polarized_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     direct = og.fringegroups_dataset(generator, result.dataset, 0.0, 10.0)
@@ -221,6 +226,7 @@ def test_direct_mixed_fringegroups_dataset_infers_standard_feed_responses():
             generator.station_receptors,
             generator.station_signal_paths,
         ),
+        effects=_effects(),
     )
 
     assert np.array_equal(direct, with_terms)
@@ -235,13 +241,7 @@ def test_direct_uncalibrated_mixed_fringegroups_requires_station_terms():
     )
     result = generator.make_dataset(
         _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(common_gain=True),
     )
 
     with np.testing.assert_raises_regex(
@@ -260,13 +260,7 @@ def test_mixed_receptor_fpt_uses_the_same_generic_fringe_evidence():
     )
     result = generator.make_dataset(
         _polarized_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert result.dataset.row_count > 0

--- a/tests/test_native_api_documentation.py
+++ b/tests/test_native_api_documentation.py
@@ -33,6 +33,11 @@ from ngehtsim.obs.station_observation import (
     station_metadata_for_dataset,
     station_terms_for_dataset,
 )
+from ngehtsim.obs.station_effects import (
+    GainModel,
+    LeakageModel,
+    StationCorruptionModel,
+)
 from ngehtsim.obs.uvfits import read_uvfits, write_uvfits
 from ngehtsim.obs.visibility_dataset import (
     CorrelationProductTable,
@@ -72,6 +77,9 @@ DOCUMENTED_NATIVE_API = {
     "apply_visibility_dataset_elevation_limits": apply_visibility_dataset_elevation_limits,
     "station_metadata_for_dataset": station_metadata_for_dataset,
     "station_terms_for_dataset": station_terms_for_dataset,
+    "GainModel": GainModel,
+    "LeakageModel": LeakageModel,
+    "StationCorruptionModel": StationCorruptionModel,
     "apply_circular_leakage": apply_circular_leakage,
     "apply_circular_corruptions": apply_circular_corruptions,
     "apply_receptor_corruptions": apply_receptor_corruptions,

--- a/tests/test_observation_geometry.py
+++ b/tests/test_observation_geometry.py
@@ -7,6 +7,7 @@ from ngehtsim.obs.obs_generator import obs_generator
 import ngehtsim.obs.observation_geometry as observation_geometry
 from ngehtsim.obs.obs_generator import make_array
 import ngehtsim.obs.source_models as source_models
+from ngehtsim.obs.station_effects import StationCorruptionModel
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 
@@ -195,11 +196,13 @@ def test_obs_generator_outputs_scan_averaging_ready_data():
 
     obs = obsgen.make_obs(
         model,
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=StationCorruptionModel(
+            thermal_noise=False,
+            common_gain=None,
+            flag_wind=False,
+            flag_daylight=False,
+            flag_sun=False,
+        ),
     )
     scan_averaged = obs.avg_coherent(0.0, scan_avg=True)
 

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -9,6 +9,7 @@ import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.raster_sampling as raster_sampling
 import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
 from ngehtsim.const_def import default_settings
 
@@ -25,6 +26,24 @@ COMPACT_OBS_SETTINGS = {
     "t_rest": 1200.0,
     "random_seed": 1,
 }
+
+
+def _effects(*, thermal_noise=False, common_gain=False, feed_rotation=False,
+             leakage=False, flag_wind=False, flag_daylight=False, flag_sun=False):
+    """Build native station effects without retired keyword arguments."""
+
+    return StationCorruptionModel(
+        thermal_noise=thermal_noise,
+        common_gain=(
+            GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+            if common_gain else None
+        ),
+        feed_rotation=feed_rotation,
+        leakage=LeakageModel(component_sigma=0.1) if leakage else None,
+        flag_wind=flag_wind,
+        flag_daylight=flag_daylight,
+        flag_sun=flag_sun,
+    )
 
 
 def _compact_model():
@@ -100,11 +119,7 @@ def _position_angle_image():
 def _observe_without_corruptions(obsgen, input_model):
     return obsgen.observe(
         input_model,
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
 
@@ -666,13 +681,7 @@ def test_obs_generator_routes_supported_sources_through_native_path(monkeypatch,
     monkeypatch.setattr(station_observation, "station_terms", unexpected_legacy_path)
     obs = obsgen.observe(
         source_factory(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert len(obs.data) > 0
@@ -697,11 +706,7 @@ def test_native_simulate_does_not_construct_obsdata(monkeypatch, source_factory)
     )
     result = og.obs_generator(settings=COMPACT_OBS_SETTINGS).simulate(
         source_factory(),
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert isinstance(result.dataset, VisibilityDataset)
@@ -733,13 +738,7 @@ def test_native_fpt_selection_stays_native_and_uses_one_readiness_draw(monkeypat
     original = (source.ra, source.dec, source.mjd, source.source, source.rf)
     result = og.obs_generator(settings=settings).make_dataset(
         source,
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     names = np.asarray(result.dataset.stations.names)
@@ -759,13 +758,7 @@ def test_native_fpt_make_obs_exports_only_after_selection():
 
     obs = og.obs_generator(settings=settings).make_obs(
         _compact_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert len(obs.data) > 0
@@ -777,13 +770,7 @@ def test_native_simulation_keeps_terms_in_the_result_not_the_generator():
     generator = og.obs_generator(settings=settings, weight=1)
     result = generator.make_dataset(
         _polarized_model(),
-        addnoise=False,
-        addgains=True,
-        addFR=True,
-        addleakage=True,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(common_gain=True, feed_rotation=True, leakage=True),
     )
 
     for name in (
@@ -795,21 +782,13 @@ def test_native_simulation_keeps_terms_in_the_result_not_the_generator():
         "Tb2",
         "SEFD1",
         "SEFD2",
-        "gainamp1R",
-        "gainamp2R",
-        "gainamp1L",
-        "gainamp2L",
-        "gainphase1R",
-        "gainphase2R",
-        "gainphase1L",
-        "gainphase2L",
-        "leak1R",
-        "leak2R",
-        "leak1L",
-        "leak2L",
+        "common_gain1",
+        "common_gain2",
+        "leakage_matrix1",
+        "leakage_matrix2",
     ):
         assert name in result.station_terms
-        assert len(result.station_terms[name]) == result.dataset.row_count
+        assert result.station_terms[name].shape[0] == result.dataset.row_count
     assert not result.station_terms["tau1"].flags.writeable
     assert not hasattr(generator, "timestamps")
     assert not hasattr(generator, "SEFD1")
@@ -819,12 +798,14 @@ def test_native_simulation_is_reproducible_with_a_fixed_seed():
     settings = dict(COMPACT_OBS_SETTINGS)
     settings["fringe_finder"] = ["naive", 0.0]
     first = og.obs_generator(settings=settings).make_dataset(
-        _polarized_model(), addnoise=True, addgains=True, addFR=True,
-        addleakage=True, flagwind=False, flagday=False, flagsun=False,
+        _polarized_model(), effects=_effects(
+            thermal_noise=True, common_gain=True, feed_rotation=True, leakage=True,
+        ),
     )
     second = og.obs_generator(settings=settings).make_dataset(
-        _polarized_model(), addnoise=True, addgains=True, addFR=True,
-        addleakage=True, flagwind=False, flagday=False, flagsun=False,
+        _polarized_model(), effects=_effects(
+            thermal_noise=True, common_gain=True, feed_rotation=True, leakage=True,
+        ),
     )
 
     assert np.array_equal(first.dataset.time_mjd, second.dataset.time_mjd)
@@ -847,13 +828,7 @@ def test_native_simulation_retains_all_flagged_rows_and_exports_an_empty_obsdata
 
     result = obsgen.simulate(
         _compact_model(),
-        addnoise=False,
-        addgains=False,
-        addFR=False,
-        addleakage=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert result.dataset.row_count > 0
@@ -881,11 +856,7 @@ def test_native_source_adapters_do_not_mutate_input_metadata(source_factory):
 
     og.obs_generator(settings=COMPACT_OBS_SETTINGS).simulate(
         source,
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
 
     assert (source.ra, source.dec, source.mjd, source.source, source.rf) == original
@@ -899,11 +870,7 @@ def test_make_obs_exports_updated_station_terms_without_mutating_configuration()
 
     result = generator.make_dataset(
         _compact_model(),
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
+        effects=_effects(),
     )
     obs = result.to_ehtim_obsdata()
 

--- a/tests/test_station_effects.py
+++ b/tests/test_station_effects.py
@@ -1,0 +1,72 @@
+"""Unit tests for declarative native station-effect configuration."""
+
+import numpy as np
+import pytest
+
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
+from ngehtsim.obs.visibility_dataset import ReceptorTable
+
+
+class FixedRng:
+    """Provide reproducible draws for compact effect-model tests."""
+
+    def normal(self, loc=0.0, scale=1.0, size=None):
+        return 1.0 if size is None else np.ones(size, dtype=float)
+
+    def uniform(self, low=0.0, high=1.0, size=None):
+        return 0.0 if size is None else np.zeros(size, dtype=float)
+
+
+def _receptors():
+    return ReceptorTable(
+        station_index=np.array((0, 0, 1), dtype=int),
+        feed_id=("X", "Y", "R"),
+        polarization_label=("X", "Y", "R"),
+        basis=("LINEAR", "LINEAR", "CIRCULAR"),
+    )
+
+
+def test_gain_model_draws_declared_amplitude_and_phase_distribution():
+    gain = GainModel(amplitude_sigma_dex=0.5, phase_distribution="uniform")
+
+    assert gain.sample(FixedRng()) == pytest.approx(10.0 ** 0.5)
+
+
+def test_station_corruption_model_normalizes_immutable_path_overrides():
+    effects = StationCorruptionModel(
+        path_gain_overrides={"ALMA": {"X": GainModel(0.02)}},
+    )
+
+    assert effects.path_gain_model("ALMA", "X") == GainModel(0.02)
+    assert effects.path_gain_model("ALMA", "Y") is None
+    with pytest.raises(TypeError):
+        effects.path_gain_overrides["ALMA"] = {}
+
+
+def test_station_corruption_model_rejects_invalid_configuration():
+    with pytest.raises(ValueError, match="non-negative"):
+        GainModel(amplitude_sigma_dex=-0.01)
+    with pytest.raises(ValueError, match="phase_distribution"):
+        GainModel(phase_distribution="gaussian")
+    with pytest.raises(ValueError, match="non-negative"):
+        LeakageModel(component_sigma=-0.01)
+    with pytest.raises(TypeError, match="path_gain_overrides"):
+        StationCorruptionModel(path_gain_overrides=("ALMA",))
+    with pytest.raises(TypeError, match="GainModel"):
+        StationCorruptionModel(path_gain_overrides={"ALMA": {"X": 0.02}})
+
+
+def test_station_corruption_model_validates_station_local_feed_ids():
+    effects = StationCorruptionModel(
+        path_gain_overrides={"ALMA": {"X": GainModel(0.02)}},
+    )
+    effects.validate_receptors(("ALMA", "APEX"), _receptors())
+
+    with pytest.raises(ValueError, match="unknown stations"):
+        StationCorruptionModel(
+            path_gain_overrides={"LMT": {"X": GainModel(0.02)}},
+        ).validate_receptors(("ALMA", "APEX"), _receptors())
+    with pytest.raises(ValueError, match="unknown feeds"):
+        StationCorruptionModel(
+            path_gain_overrides={"ALMA": {"R": GainModel(0.02)}},
+        ).validate_receptors(("ALMA", "APEX"), _receptors())

--- a/tests/test_station_observation.py
+++ b/tests/test_station_observation.py
@@ -10,6 +10,7 @@ import ngehtsim.obs.obs_generator as og
 import ngehtsim.obs.observation_geometry as observation_geometry
 import ngehtsim.obs.source_models as source_models
 import ngehtsim.obs.station_observation as station_observation
+from ngehtsim.obs.station_effects import GainModel, LeakageModel, StationCorruptionModel
 from ngehtsim.obs.visibility_dataset import VisibilityDataset
 
 #######################################################
@@ -25,6 +26,24 @@ COMPACT_OBS_SETTINGS = {
     "t_rest": 1200.0,
     "random_seed": 1,
 }
+
+
+def _effects(*, thermal_noise=False, common_gain=False, feed_rotation=False,
+             leakage=False, flag_wind=False, flag_daylight=False, flag_sun=False):
+    """Build native effects without invoking retired keyword arguments."""
+
+    return StationCorruptionModel(
+        thermal_noise=thermal_noise,
+        common_gain=(
+            GainModel(amplitude_sigma_dex=0.04, phase_distribution="uniform")
+            if common_gain else None
+        ),
+        feed_rotation=feed_rotation,
+        leakage=LeakageModel(component_sigma=0.1) if leakage else None,
+        flag_wind=flag_wind,
+        flag_daylight=flag_daylight,
+        flag_sun=flag_sun,
+    )
 
 
 def _compact_model():
@@ -134,12 +153,7 @@ def test_native_station_geometry_preserves_generated_observations(monkeypatch):
     native_generator = og.obs_generator(settings=settings)
     native_obs = native_generator.make_obs(
         _compact_model(),
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-        addFR=True,
+        effects=_effects(feed_rotation=True),
     )
 
     monkeypatch.setattr(
@@ -150,12 +164,7 @@ def test_native_station_geometry_preserves_generated_observations(monkeypatch):
     fallback_generator = og.obs_generator(settings=settings)
     fallback_obs = fallback_generator.make_obs(
         _compact_model(),
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagday=False,
-        flagsun=False,
-        addFR=True,
+        effects=_effects(feed_rotation=True),
     )
 
     assert np.array_equal(native_obs.data["t1"], fallback_obs.data["t1"])
@@ -348,17 +357,15 @@ def test_station_terms_populates_gain_and_leakage_arrays_when_enabled():
     assert np.iscomplexobj(terms["leak2R"])
 
 
-def test_native_station_terms_match_obsdata_terms_and_station_table():
+def test_native_station_terms_preserve_weather_and_use_generic_corruption_fields():
     obsgen = og.obs_generator(settings=COMPACT_OBS_SETTINGS)
     obs, F0 = _source_observation(obsgen)
     context = _time_varying_weather_context(obsgen, obs)
     context["tau"]["ALMA"] = np.linspace(0.1, 0.2, len(obs.data))
     context["windspeed"]["ALMA"] = np.linspace(1.0, 8.0, len(obs.data))
     kwargs = {
-        "gainamp": 0.04,
-        "leakamp": 0.1,
-        "addgains": True,
-        "addleakage": True,
+        "addgains": False,
+        "addleakage": False,
         "flagwind": True,
         "flagday": False,
         "flagsun": False,
@@ -380,8 +387,10 @@ def test_native_station_terms_match_obsdata_terms_and_station_table():
         F0,
         context,
         np.random.default_rng(17),
+        effects=_effects(common_gain=True, leakage=True, flag_wind=True),
         reference_mjd=obs.mjd,
-        **kwargs,
+        solar_angle=obsgen.solar_angle,
+        windspeed_sefd_modifier=og.windspeed_SEFD_modification,
     )
 
     assert np.array_equal(native["t1"], legacy["t1"])
@@ -409,25 +418,13 @@ def test_native_station_terms_match_obsdata_terms_and_station_table():
         "f_par2",
         "phi_off1",
         "phi_off2",
-        "gainamp1R",
-        "gainamp2R",
-        "gainphase1R",
-        "gainphase2R",
-        "gainamp1L",
-        "gainamp2L",
-        "gainphase1L",
-        "gainphase2L",
-        "leak1R",
-        "leak2R",
-        "leak1L",
-        "leak2L",
     ):
         assert np.allclose(native[field], legacy[field], atol=1.0e-10)
     assert np.array_equal(native["uptime_mask"], legacy["uptime_mask"])
     assert np.allclose(native_stations.sefd_r_jy, legacy_array.tarr["sefdr"])
     assert np.allclose(native_stations.sefd_l_jy, legacy_array.tarr["sefdl"])
-    assert np.allclose(native_stations.leakage_r, legacy_array.tarr["dr"])
-    assert np.allclose(native_stations.leakage_l, legacy_array.tarr["dl"])
+    assert {"common_gain1", "common_gain2", "leakage_matrix1", "leakage_matrix2", "path_gains"} <= set(native)
+    assert not any(name.startswith(("gainamp", "gainphase", "leak1", "leak2")) for name in native)
 
 
 def test_native_station_metadata_uses_cache_without_obsdata_conversion():

--- a/tests/test_weather_zarr_release.py
+++ b/tests/test_weather_zarr_release.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import ngehtsim.obs.obs_generator as obs_generator_module
+from ngehtsim.obs.station_effects import StationCorruptionModel
 import ngehtsim.weather.weather as weather
 from ngehtsim.weather.zarr_store import SUPPORTED_SCHEMA_VERSIONS, ZarrWeatherStore
 
@@ -138,10 +139,12 @@ def test_obs_generator_uses_native_weather_for_observation_terms(external_store)
 
     obs = obsgen.make_obs(
         model,
-        addnoise=False,
-        addgains=False,
-        flagwind=False,
-        flagsun=False,
+        effects=StationCorruptionModel(
+            thermal_noise=False,
+            common_gain=None,
+            flag_wind=False,
+            flag_sun=False,
+        ),
     )
 
     assert len(obs.data) > 0


### PR DESCRIPTION
Introduces declarative v2 station effects, independent mixed-feed path gains, explicit native/legacy boundaries, and corresponding documentation and regression coverage.