### PR TITLE
Write complete AIPS AN metadata in UVFITS

### DIFF
--- a/docs/source/uvfits.rst
+++ b/docs/source/uvfits.rst
@@ -19,6 +19,11 @@ cannot losslessly store arbitrary per-baseline mixed-feed layouts.  Such
 datasets remain native ``VisibilityDataset`` objects until an explicit output
 basis conversion is selected.
 
+Native output includes the mandatory AIPS AN table metadata used by standard
+UVFITS readers.  By default its array name is ``NGEHTSIM``; set
+``array_name="EHT2017"`` or another non-empty ASCII name of at most eight
+characters when a specific array identity is useful to downstream software.
+
 For compatibility testing with software that cannot read mixed-feed data,
 ``to_uvfits(..., force_circular_labels=True)`` provides a deliberately unsafe
 escape hatch. It writes a global circular UVFITS axis and labels X as R and Y

--- a/ngehtsim/obs/uvfits.py
+++ b/ngehtsim/obs/uvfits.py
@@ -158,7 +158,13 @@ def read_uvfits(path):
         )
 
 
-def write_uvfits(dataset, path, overwrite=False, force_circular_labels=False):
+def write_uvfits(
+    dataset,
+    path,
+    overwrite=False,
+    force_circular_labels=False,
+    array_name="NGEHTSIM",
+):
     """Write a uniformly circular or linear ``VisibilityDataset`` as UVFITS.
 
     The output uses a standard global STOKES axis, a regular frequency axis,
@@ -179,6 +185,10 @@ def write_uvfits(dataset, path, overwrite=False, force_circular_labels=False):
         and every Y feed as L, without transforming any visibility,
         uncertainty, or flag values.  This exists solely for software that
         cannot ingest mixed-feed data and is disabled by default.
+    array_name : str, optional
+        AIPS array name written as the ``ARRNAM`` keyword in the ``AIPS AN``
+        table. It must be non-empty ASCII text of at most eight characters.
+        The default identifies a generic ngehtsim-generated array.
 
     Raises
     ------
@@ -201,6 +211,7 @@ def write_uvfits(dataset, path, overwrite=False, force_circular_labels=False):
         raise UvfitsError("UVFITS output requires at least one visibility row.")
     if not isinstance(force_circular_labels, bool):
         raise TypeError("force_circular_labels must be a bool.")
+    array_name = _aips_array_name(array_name)
 
     layout, product_slots = _uvfits_layout(
         dataset,
@@ -221,6 +232,8 @@ def write_uvfits(dataset, path, overwrite=False, force_circular_labels=False):
         layout,
         frequency_grid["reference_frequency_hz"],
         len(frequency_grid["channel_indices"]),
+        reference_mjd=float(np.floor(np.min(dataset.time_mjd))),
+        array_name=array_name,
     )
     frequency = _frequency_hdu(frequency_grid)
     hdus = [primary, antenna, frequency]
@@ -673,34 +686,98 @@ def _set_common_header(header, dataset, layout, frequency_grid, reference_mjd):
     header["HISTORY"] = "AIPS SORT ORDER='TB'"
 
 
-def _antenna_hdu(dataset, layout, reference_frequency_hz, if_count):
-    if any(len(name.encode("ascii")) > 8 for name in dataset.stations.names):
-        raise UvfitsError("UVFITS AIPS AN output supports station names up to eight ASCII characters.")
+def _antenna_hdu(
+    dataset,
+    layout,
+    reference_frequency_hz,
+    if_count,
+    *,
+    reference_mjd,
+    array_name,
+):
+    """Build a complete AIPS AN table for the native UVFITS writer.
+
+    Global VLBI station positions are expressed in ITRF relative to a
+    geocentric array origin. The mandatory orbit and polarization-calibration
+    columns have zero repeat counts because ngehtsim does not write those
+    optional per-antenna payloads.
+    """
+
+    try:
+        station_name_lengths = [len(name.encode("ascii")) for name in dataset.stations.names]
+    except UnicodeEncodeError as exc:
+        raise UvfitsError("UVFITS AIPS AN output requires ASCII station names.") from exc
+    if any(length > 8 for length in station_name_lengths):
+        raise UvfitsError(
+            "UVFITS AIPS AN output supports station names up to eight ASCII characters."
+        )
     names = np.asarray(dataset.stations.names, dtype="S8")
     count = len(names)
     first_feed, second_feed = ("R", "L") if layout == CIRCULAR_PRODUCT_LABELS else ("X", "Y")
     columns = fits.ColDefs((
         fits.Column(name="ANNAME", format="8A", array=names),
         fits.Column(name="STABXYZ", format="3D", unit="METERS", array=dataset.stations.position_itrs_m),
+        fits.Column(name="ORBPARM", format="0D", array=np.empty((count, 0), dtype=float)),
         fits.Column(name="NOSTA", format="1J", array=np.arange(1, count + 1)),
         fits.Column(name="MNTSTA", format="1J", array=np.zeros(count, dtype=np.int32)),
         fits.Column(name="STAXOF", format="1E", unit="METERS", array=np.zeros(count)),
         fits.Column(name="POLTYA", format="1A", array=np.full(count, first_feed, dtype="S1")),
         fits.Column(name="POLAA", format="1E", unit="DEGREES", array=np.zeros(count)),
-        fits.Column(name="POLCALA", format="3E", array=np.zeros((count, 3))),
+        fits.Column(name="POLCALA", format="0E", array=np.empty((count, 0), dtype=np.float32)),
         fits.Column(name="POLTYB", format="1A", array=np.full(count, second_feed, dtype="S1")),
         fits.Column(name="POLAB", format="1E", unit="DEGREES", array=np.full(count, 90.0)),
-        fits.Column(name="POLCALB", format="3E", array=np.zeros((count, 3))),
+        fits.Column(name="POLCALB", format="0E", array=np.empty((count, 0), dtype=np.float32)),
         fits.Column(name="SEFD", format="1D", array=dataset.stations.sefd_r_jy),
     ))
     antenna = fits.BinTableHDU.from_columns(columns, name="AIPS AN")
     header = antenna.header
+    reference_date = _aips_reference_date(reference_mjd)
     header["EXTVER"] = 1
+    header["ARRAYX"] = 0.0
+    header["ARRAYY"] = 0.0
+    header["ARRAYZ"] = 0.0
+    header["GSTIA0"] = reference_date.sidereal_time("mean", "greenwich").degree
+    header["DEGPDY"] = 360.98564736629
     header["FREQ"] = reference_frequency_hz
+    header["RDATE"] = reference_date.to_value("iso", subfmt="date")
+    header["POLARX"] = 0.0
+    header["POLARY"] = 0.0
+    header["UT1UTC"] = float(reference_date.delta_ut1_utc)
+    header["DATUTC"] = 0.0
     header["NO_IF"] = if_count
     header["TIMESYS"] = "UTC"
+    header["ARRNAM"] = array_name
+    header["XYZHAND"] = "RIGHT"
+    header["FRAME"] = "ITRF"
+    header["NUMORB"] = 0
+    header["NOPCAL"] = 0
     header["POLTYPE"] = "VLBI"
+    header["FREQID"] = 1
     return antenna
+
+
+def _aips_array_name(array_name):
+    """Validate an AIPS AN ``ARRNAM`` value and return its stripped form."""
+
+    if not isinstance(array_name, str):
+        raise TypeError("array_name must be a str.")
+    array_name = array_name.strip()
+    if not array_name:
+        raise UvfitsError("UVFITS AIPS AN ARRNAM must be non-empty.")
+    try:
+        encoded = array_name.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise UvfitsError("UVFITS AIPS AN ARRNAM must contain only ASCII characters.") from exc
+    if len(encoded) > 8:
+        raise UvfitsError("UVFITS AIPS AN ARRNAM supports at most eight ASCII characters.")
+    return array_name
+
+
+def _aips_reference_date(reference_mjd):
+    """Return the UTC midnight reference date for AIPS AN metadata."""
+
+    timestamp = Time(reference_mjd, format="mjd", scale="utc")
+    return Time(timestamp.to_value("iso", subfmt="date"), format="iso", scale="utc")
 
 
 def _frequency_hdu(frequency_grid):

--- a/ngehtsim/obs/visibility_dataset.py
+++ b/ngehtsim/obs/visibility_dataset.py
@@ -1094,7 +1094,13 @@ class VisibilityDataset:
 
         return read_uvfits(path)
 
-    def to_uvfits(self, path, overwrite=False, force_circular_labels=False):
+    def to_uvfits(
+        self,
+        path,
+        overwrite=False,
+        force_circular_labels=False,
+        array_name="NGEHTSIM",
+    ):
         """Write this dataset through the native UVFITS adapter.
 
         Parameters
@@ -1108,6 +1114,9 @@ class VisibilityDataset:
             relabelling X as R and Y as L without a basis conversion. This is
             unsafe compatibility output for external software and is disabled
             by default.
+        array_name : str, optional
+            AIPS array name for the mandatory ``ARRNAM`` antenna-table
+            keyword. It must contain at most eight ASCII characters.
 
         Raises
         ------
@@ -1123,6 +1132,7 @@ class VisibilityDataset:
             path,
             overwrite=overwrite,
             force_circular_labels=force_circular_labels,
+            array_name=array_name,
         )
 
     @classmethod

--- a/tests/test_uvfits.py
+++ b/tests/test_uvfits.py
@@ -87,7 +87,7 @@ def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, kind):
     original = _dataset(kind)
     path = tmp_path / "native.uvfits"
 
-    original.to_uvfits(path)
+    original.to_uvfits(path, array_name="SYNTH")
     with fits.open(path, memmap=False) as hdul:
         assert hdul[0].header["NAXIS4"] == 2
         assert hdul[0].header["NAXIS5"] == 2
@@ -96,6 +96,24 @@ def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, kind):
         expected_feeds = ("R", "L") if kind == "circular" else ("X", "Y")
         assert tuple(hdul["AIPS AN"].data["POLTYA"][:1]) == (expected_feeds[0],)
         assert tuple(hdul["AIPS AN"].data["POLTYB"][:1]) == (expected_feeds[1],)
+        antenna = hdul["AIPS AN"]
+        mandatory = {
+            "EXTNAME", "EXTVER", "ARRAYX", "ARRAYY", "ARRAYZ", "GSTIA0", "DEGPDY",
+            "FREQ", "RDATE", "POLARX", "POLARY", "UT1UTC", "DATUTC", "TIMESYS",
+            "ARRNAM", "XYZHAND", "FRAME", "NUMORB", "NO_IF", "NOPCAL", "POLTYPE",
+            "FREQID",
+        }
+        assert mandatory <= set(antenna.header)
+        assert antenna.header["ARRNAM"] == "SYNTH"
+        assert [antenna.header[name] for name in ("ARRAYX", "ARRAYY", "ARRAYZ")] == [0.0] * 3
+        assert antenna.header["FRAME"] == "ITRF"
+        assert antenna.header["XYZHAND"] == "RIGHT"
+        assert antenna.header["NUMORB"] == 0
+        assert antenna.header["NOPCAL"] == 0
+        assert antenna.header["FREQID"] == 1
+        assert antenna.data["ORBPARM"].shape == (3, 0)
+        assert antenna.data["POLCALA"].shape == (3, 0)
+        assert antenna.data["POLCALB"].shape == (3, 0)
         assert np.allclose(hdul["AIPS FQ"].data["TOTAL BANDWIDTH"][0], [2.0e6, 2.0e6])
 
     restored = VisibilityDataset.from_uvfits(path)
@@ -114,6 +132,25 @@ def test_native_uvfits_round_trip_preserves_multichannel_data(tmp_path, kind):
     assert np.allclose(restored.scan_stop_mjd, original.scan_stop_mjd)
     slots = restored.circular_product_slots() if kind == "circular" else restored.linear_product_slots()
     assert slots.shape == (2, 4)
+
+
+@pytest.mark.parametrize(
+    ("array_name", "exception", "message"),
+    (
+        (None, TypeError, "must be a str"),
+        ("", UvfitsError, "must be non-empty"),
+        ("NINECHARS", UvfitsError, "at most eight ASCII characters"),
+        ("ng" + chr(0x00C9) + "HTsim", UvfitsError, "only ASCII characters"),
+    ),
+)
+def test_native_uvfits_writer_validates_aips_array_name(
+    tmp_path,
+    array_name,
+    exception,
+    message,
+):
+    with pytest.raises(exception, match=message):
+        _dataset().to_uvfits(tmp_path / "native.uvfits", array_name=array_name)
 
 
 def test_native_uvfits_reader_loads_checked_in_eht_2017_file_without_ehtim():


### PR DESCRIPTION
Adds required AIPS AN headers and zero-length standard columns for interoperable native UVFITS output.