### PR TITLE
Apply native leakage in station feed frames

### DIFF
--- a/docs/source/native_simulation.rst
+++ b/docs/source/native_simulation.rst
@@ -20,11 +20,12 @@ selection masks, and a circular visibility template without constructing an
 ``ehtim.Obsdata`` object. Spacecraft stations retain the legacy geometry path.
 The station-term kernel evaluates weather, SEFD, uptime, and station geometry
 on those rows. ``StationCorruptionModel`` separately declares a station-common
-gain ``G`` and optional two-feed gain ratios ``R = G_A / G_B``. The one-channel
-corruption kernel uses a circular-sky Jones RIME and projects the result into
-every configured station-local receptor path. This supports circular, linear,
-mixed, single-feed, and over-complete feed inventories without converting the
-archived data to an assumed global basis.
+gain ``G``, optional two-feed gain ratios ``R = G_A / G_B``, and local-feed
+leakage matrices. The one-channel corruption kernel uses a circular-sky Jones
+RIME for source coherency and feed rotation, then applies each leakage matrix
+in its station's declared feed frame before projecting to recorded products.
+This supports circular, linear, and mixed two-feed leakage models without
+converting archived data to an assumed global basis.
 
 .. currentmodule:: ngehtsim.obs.observation_geometry
 

--- a/docs/source/obsgen.rst
+++ b/docs/source/obsgen.rst
@@ -150,10 +150,14 @@ amplitude and unwrapped-phase cadences:
 The base ``station_gain``, ``leakage``, and ``gain_ratio`` models apply to all
 stations. Their corresponding ``*_overrides`` mappings replace a base model
 for selected stations; use an override value of ``None`` to disable a base
-corruption at one station. A default ``GainRatioModel()`` follows each
-two-feed station's local receptor order, while explicit ``feed_a`` and
-``feed_b`` values refer to the local identifiers configured in
-``station_receptors`` rather than assuming a global polarization basis.
+corruption at one station. A default ``GainRatioModel()`` or
+``LeakageModel()`` follows each two-feed station's local receptor order, while
+explicit ``feed_a`` and ``feed_b`` values refer to the local identifiers
+configured in ``station_receptors`` rather than assuming a global
+polarization basis. ``LeakageModel`` represents the ordinary local matrix
+``[[1, D_A], [D_B, 1]]``: use ``D_R,D_L`` at R/L stations and ``D_X,D_Y`` at
+X/Y stations. ``leakage_a_mean`` and ``leakage_b_mean`` can specify fixed
+complex D-terms in addition to stochastic ``component_sigma`` draws.
 ``StationCorruptionModel()`` retains the native default realization: thermal
 noise, opacity calibration, feed rotation, weather/solar flagging, and a
 station-common 0.04-dex amplitude gain with uniform phase.  Leakage and gain

--- a/ngehtsim/obs/instrumental_corruptions.py
+++ b/ngehtsim/obs/instrumental_corruptions.py
@@ -263,11 +263,11 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
     """Apply a one-channel Jones RIME to arbitrary station-feed products.
 
     ``sky_coherency`` is sampled in the common circular sky basis and has one
-    ``2 x 2`` matrix per visibility row.  Every stored product is then formed
-    as ``e_p J_1 B J_2^H e_q^H``, where ``e`` is the configured receptor row
-    and ``J`` contains the simulated station gain, leakage, and feed-rotation
-    terms. This formulation supports circular, linear, mixed, single-feed,
-    and over-complete receptor inventories without relabelling products.
+    ``2 x 2`` matrix per visibility row. Every stored product is then formed
+    from local station-feed Jones rows. Feed rotation remains a circular-sky
+    operation, while leakage is applied in the declared local feed frame.
+    This formulation supports circular, linear, mixed, single-feed, and
+    over-complete receptor inventories without relabelling products.
 
     Parameters
     ----------
@@ -303,7 +303,7 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
     sky_coherency = np.asarray(sky_coherency, dtype=complex)
     if sky_coherency.shape != (dataset.row_count, 2, 2):
         raise ValueError("sky_coherency must have shape (row, 2, 2).")
-    response, sefd_scale, gain_scale = response_rows_for_dataset(
+    _, sefd_scale, gain_scale = response_rows_for_dataset(
         dataset,
         receptor_configuration,
     )
@@ -326,14 +326,16 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
     if np.any(tau1 < 0.0) or np.any(tau2 < 0.0):
         raise ValueError("Station opacity terms must be non-negative.")
 
-    jones1, jones2 = _native_station_jones(terms, count, station_terms, effects)
-    output_coherency = jones1 @ sky_coherency @ np.swapaxes(np.conj(jones2), -1, -2)
-    if not effects.opacity_calibrated:
-        output_coherency *= np.sqrt(np.exp(-tau1 - tau2))[:, np.newaxis, np.newaxis]
     gain_ratio_factors = _gain_ratio_factor_array(
         station_terms,
         count,
         dataset.receptors.count,
+    )
+    left_rows, right_rows = receptor_rows_for_station_terms(
+        dataset,
+        station_terms,
+        receptor_configuration,
+        effects,
     )
 
     visibilities = np.array(dataset.visibilities, copy=True)
@@ -364,17 +366,9 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
                 continue
             receptor1 = products.receptor1_id[product_id]
             receptor2 = products.receptor2_id[product_id]
-            first = (
-                gain_ratio_factors[row, receptor1]
-                * gain_scale[receptor1]
-                * response[receptor1]
-            )
-            second = (
-                gain_ratio_factors[row, receptor2]
-                * gain_scale[receptor2]
-                * response[receptor2]
-            )
-            value = first @ output_coherency[row] @ np.conj(second)
+            value = left_rows[row, slot] @ sky_coherency[row] @ np.conj(right_rows[row, slot])
+            if not effects.opacity_calibrated:
+                value *= np.sqrt(np.exp(-tau1[row] - tau2[row]))
             if uncertainty_mode == "sefd":
                 gain_magnitude = (
                     np.abs(station_terms["common_gain1"][row])
@@ -415,7 +409,11 @@ def apply_receptor_corruptions(dataset, sky_coherency, station_terms, stations,
 
 
 def _native_station_jones(terms, count, station_terms, effects):
-    """Build native common-frame station Jones matrices from generic terms."""
+    """Build common-gain and circular feed-rotation Jones matrices.
+
+    Local leakage is intentionally excluded here. It is applied to the local
+    feed-response rows by :func:`receptor_rows_for_station_terms`.
+    """
 
     identity = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
     jones1 = np.array(identity, copy=True)
@@ -439,15 +437,13 @@ def _native_station_jones(terms, count, station_terms, effects):
         jones1[:, 1, 1] = np.exp(1.0j * rotation1)
         jones2[:, 0, 0] = np.exp(-1.0j * rotation2)
         jones2[:, 1, 1] = np.exp(1.0j * rotation2)
-    jones1 = _matrix_term(station_terms, "leakage_matrix1", count) @ jones1
-    jones2 = _matrix_term(station_terms, "leakage_matrix2", count) @ jones2
     gain1 = _term_array(station_terms, "common_gain1", count)
     gain2 = _term_array(station_terms, "common_gain2", count)
     return gain1[:, np.newaxis, np.newaxis] * jones1, gain2[:, np.newaxis, np.newaxis] * jones2
 
 
 def _matrix_term(station_terms, name, count):
-    """Return one validated row-aligned two-by-two station matrix term."""
+    """Return one validated row-aligned two-by-two local-feed matrix term."""
 
     try:
         values = np.asarray(station_terms[name], dtype=complex)
@@ -473,8 +469,8 @@ def _gain_ratio_factor_array(station_terms, count, receptor_count):
 def receptor_rows_for_station_terms(dataset, station_terms, receptor_configuration, effects):
     """Return effective receptor Jones rows for generic fringe selection.
 
-    The rows include the same simulated station gain, leakage, and feed
-    rotation applied by :func:`apply_receptor_corruptions`.  They permit a
+    The rows include the same simulated station gain, local-feed leakage, and
+    feed rotation applied by :func:`apply_receptor_corruptions`. They permit a
     fringe-evidence estimator to reconstruct Stokes I in a common sky basis
     rather than treating a particular recorded feed basis as special.
 
@@ -509,11 +505,14 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
     )
     terms = {name: _term_array(station_terms, name, count) for name in required}
     jones1, jones2 = _native_station_jones(terms, count, station_terms, effects)
+    leakage1 = _matrix_term(station_terms, "leakage_feed_matrix1", count)
+    leakage2 = _matrix_term(station_terms, "leakage_feed_matrix2", count)
     gain_ratio_factors = _gain_ratio_factor_array(
         station_terms,
         count,
         dataset.receptors.count,
     )
+    station_receptors, local_receptor_index = _station_receptor_indices(dataset)
     left = np.zeros((dataset.row_count, dataset.visibilities.shape[2], 2), dtype=complex)
     right = np.zeros_like(left)
     products = dataset.correlation_products
@@ -523,17 +522,64 @@ def receptor_rows_for_station_terms(dataset, station_terms, receptor_configurati
                 continue
             receptor1 = products.receptor1_id[product_id]
             receptor2 = products.receptor2_id[product_id]
+            response1 = _local_feed_response(
+                response,
+                leakage1[row],
+                receptor1,
+                dataset.antenna1[row],
+                station_receptors,
+                local_receptor_index,
+            )
+            response2 = _local_feed_response(
+                response,
+                leakage2[row],
+                receptor2,
+                dataset.antenna2[row],
+                station_receptors,
+                local_receptor_index,
+            )
             left[row, slot] = (
                 gain_ratio_factors[row, receptor1]
                 * gain_scale[receptor1]
-                * (response[receptor1] @ jones1[row])
+                * (response1 @ jones1[row])
             )
             right[row, slot] = (
                 gain_ratio_factors[row, receptor2]
                 * gain_scale[receptor2]
-                * (response[receptor2] @ jones2[row])
+                * (response2 @ jones2[row])
             )
     return left, right
+
+
+def _station_receptor_indices(dataset):
+    """Return local receptor ordering for every station in ``dataset``."""
+
+    receptor_count = dataset.receptors.count
+    local_index = np.empty(receptor_count, dtype=np.intp)
+    station_receptors = []
+    for station_index in range(len(dataset.stations.names)):
+        indices = np.flatnonzero(dataset.receptors.station_index == station_index)
+        station_receptors.append(indices)
+        local_index[indices] = np.arange(len(indices), dtype=np.intp)
+    return tuple(station_receptors), local_index
+
+
+def _local_feed_response(
+    response,
+    leakage_matrix,
+    receptor_index,
+    station_index,
+    station_receptors,
+    local_receptor_index,
+):
+    """Return one local-feed response row after its local leakage matrix."""
+
+    indices = station_receptors[station_index]
+    if receptor_index not in indices:
+        raise ValueError("Correlation product receptor does not match its baseline station.")
+    if len(indices) != 2:
+        return response[receptor_index]
+    return leakage_matrix[local_receptor_index[receptor_index]] @ response[indices]
 
 
 def _term_array(station_terms, name, count):

--- a/ngehtsim/obs/simulation_result.py
+++ b/ngehtsim/obs/simulation_result.py
@@ -29,6 +29,14 @@ class SimulationResult:
         opacity, SEFD, gains, leakage, and availability information. Arrays
         are copied and made read-only; this mapping is simulation provenance,
         not yet a stable archive schema.
+
+        Native two-feed simulations provide ``common_gain1`` and
+        ``common_gain2`` for the baseline endpoints, per-receptor
+        ``gain_ratio_factors``, and ``leakage_feed_matrix1`` and
+        ``leakage_feed_matrix2``. Leakage matrices use each endpoint
+        station's declared local receptor order; the corresponding station
+        names are in ``t1`` and ``t2`` and the order is defined by
+        ``dataset.receptors``.
     """
 
     dataset: VisibilityDataset

--- a/ngehtsim/obs/station_effects.py
+++ b/ngehtsim/obs/station_effects.py
@@ -267,26 +267,76 @@ class GainRatioModel:
 
 @dataclass(frozen=True)
 class LeakageModel:
-    """Station-frame circular leakage distribution.
+    r"""Stochastic two-feed leakage distribution in the local feed frame.
+
+    For the ordered local feeds A and B, the native RIME applies
+
+    .. math::
+
+       D_{\rm feed} =
+       \begin{pmatrix}1 & D_A \\ D_B & 1\end{pmatrix}.
+
+    ``D_A`` is the leakage from feed B into feed A and ``D_B`` is the reverse
+    coupling.  Consequently, R/L stations use ordinary ``D_R`` and ``D_L``
+    terms, while X/Y stations use ordinary ``D_X`` and ``D_Y`` terms.  The
+    common circular sky basis is used only for source coherency and feed
+    rotation; it does not define the leakage parameters.
 
     Parameters
     ----------
+    feed_a, feed_b : str or None, optional
+        Ordered local feed IDs defining the rows and columns of the leakage
+        matrix. Omit both to use a station's declared two-feed order. Supplying
+        one feed requires supplying the other.
+    leakage_a_mean, leakage_b_mean : complex, optional
+        Deterministic complex means of ``D_A`` and ``D_B``. Together with
+        ``component_sigma=0`` these define an exact local-feed leakage model.
     component_sigma : float, optional
         Standard deviation assigned independently to the real and imaginary
-        parts of each off-diagonal circular-basis leakage term.
+        parts of each off-diagonal local-feed leakage term.
     cadence : RealizationCadence, optional
         Realization grouping for the complete complex leakage matrix. The
         default is one stable D-term realization per track.
     """
 
+    feed_a: str | None = None
+    feed_b: str | None = None
+    leakage_a_mean: complex = 0.0j
+    leakage_b_mean: complex = 0.0j
     component_sigma: float = 0.0
     cadence: RealizationCadence = field(default_factory=RealizationCadence.track)
 
     def __post_init__(self):
+        if (self.feed_a is None) != (self.feed_b is None):
+            raise ValueError("feed_a and feed_b must either both be supplied or both be None.")
+        if self.feed_a is not None:
+            if (
+                not isinstance(self.feed_a, str)
+                or not isinstance(self.feed_b, str)
+                or not self.feed_a
+                or not self.feed_b
+                or self.feed_a == self.feed_b
+            ):
+                raise ValueError("feed_a and feed_b must be distinct non-empty feed IDs.")
+        for name in ("leakage_a_mean", "leakage_b_mean"):
+            try:
+                value = complex(getattr(self, name))
+            except (TypeError, ValueError) as exc:
+                raise TypeError("{0} must be a complex scalar.".format(name)) from exc
+            if not np.isfinite(value.real) or not np.isfinite(value.imag):
+                raise ValueError("{0} must have finite real and imaginary parts.".format(name))
+            object.__setattr__(self, name, value)
         if not np.isfinite(self.component_sigma) or self.component_sigma < 0.0:
             raise ValueError("component_sigma must be finite and non-negative.")
         if not isinstance(self.cadence, RealizationCadence):
             raise TypeError("cadence must be a RealizationCadence instance.")
+
+    def sample(self, rng):
+        """Draw the two local-feed complex leakage terms."""
+
+        draw_a = self.component_sigma * (rng.normal(0.0, 1.0) + 1.0j * rng.normal(0.0, 1.0))
+        draw_b = self.component_sigma * (rng.normal(0.0, 1.0) + 1.0j * rng.normal(0.0, 1.0))
+        return self.leakage_a_mean + draw_a, self.leakage_b_mean + draw_b
 
 
 @dataclass(frozen=True)
@@ -313,8 +363,10 @@ class StationCorruptionModel:
         station-common gain model at named stations. ``None`` disables the
         default common gain at that station.
     leakage : LeakageModel or None, optional
-        Default circular station-frame leakage realization for every station.
-        ``None`` disables leakage by default.
+        Default local-feed leakage realization for every two-feed station.
+        ``None`` disables leakage by default. A default model is skipped for
+        single-feed stations; stations with more than two feeds require a
+        future general leakage parameterization.
     leakage_overrides : mapping, optional
         Mapping ``{station: LeakageModel or None}`` that replaces the default
         leakage model at named stations. ``None`` disables default leakage at
@@ -371,14 +423,16 @@ class StationCorruptionModel:
             object.__setattr__(self, name, MappingProxyType(normalized))
 
     def validate_receptors(self, station_names, receptors):
-        """Validate declared gain ratios against a resolved receptor inventory.
+        """Validate gain-ratio and local-leakage models against receptor inventory.
 
         Gain ratios are valid only for a station containing exactly two feeds.
         A default ratio is skipped for a single-feed station, which uses only
         its station-common gain. A ratio explicitly configured as an override
         for a single-feed station is rejected. Datasets with more than two
         feeds remain usable without a ratio model but reject a requested ratio
-        until a general multi-feed parameterization is introduced.
+        until a general multi-feed parameterization is introduced. Local-feed
+        leakage follows the same two-feed rule; a default leakage model is
+        skipped for a single-feed station.
         """
 
         names = tuple(str(name) for name in station_names)
@@ -420,6 +474,33 @@ class StationCorruptionModel:
                 raise ValueError(
                     "Gain-ratio feeds for {0} must match its two configured feeds.".format(station)
                 )
+        for station in names:
+            model = self.leakage_model(station)
+            if model is None:
+                continue
+            station_index = names.index(station)
+            feed_ids = tuple(
+                receptors.feed_id[index]
+                for index in np.flatnonzero(receptors.station_index == station_index)
+            )
+            if len(feed_ids) == 1:
+                if self.leakage_overrides.get(station) is not None:
+                    raise ValueError(
+                        "Station {0} has one feed and cannot define a two-feed leakage matrix.".format(
+                            station
+                        )
+                    )
+                continue
+            if len(feed_ids) != 2:
+                raise NotImplementedError(
+                    "Local-feed leakage currently supports exactly two feeds per station; "
+                    "{0} has {1}.".format(station, len(feed_ids))
+                )
+            feed_a, feed_b = self.leakage_feed_pair(station, feed_ids)
+            if set(feed_ids) != {feed_a, feed_b}:
+                raise ValueError(
+                    "Leakage feeds for {0} must match its two configured feeds.".format(station)
+                )
 
     def station_gain_model(self, station):
         """Return the effective station-common gain model for ``station``."""
@@ -445,6 +526,16 @@ class StationCorruptionModel:
         """
 
         model = self.gain_ratio_model(station)
+        if model is None:
+            return None
+        if model.feed_a is None:
+            return tuple(feed_ids)
+        return model.feed_a, model.feed_b
+
+    def leakage_feed_pair(self, station, feed_ids):
+        """Return the effective ordered local-feed pair for leakage at ``station``."""
+
+        model = self.leakage_model(station)
         if model is None:
             return None
         if model.feed_a is None:

--- a/ngehtsim/obs/station_observation.py
+++ b/ngehtsim/obs/station_observation.py
@@ -653,10 +653,11 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, effects,
 
     Notes
     -----
-    The terms are evaluated in the common circular sky frame and are projected
-    into configured native receptor paths by the one-channel corruption RIME.
-    They are retained in :class:`SimulationResult` as provenance, not yet as a
-    stable archive interchange format.
+    Sky coherency and feed rotation use the common circular sky frame. Leakage
+    matrices instead use each station's declared local feed frame and are
+    applied after the receptor response by the one-channel corruption RIME.
+    The terms are retained in :class:`SimulationResult` as provenance, not yet
+    as a stable archive interchange format.
     """
 
     if not isinstance(effects, StationCorruptionModel):
@@ -697,7 +698,7 @@ def station_terms_for_dataset(dataset, F0, station_context, rng, effects,
         effects,
         rng,
     )
-    terms["leakage_matrix1"], terms["leakage_matrix2"] = _sample_leakage_matrices(
+    terms["leakage_feed_matrix1"], terms["leakage_feed_matrix2"] = _sample_local_leakage_matrices(
         dataset,
         metadata,
         effects,
@@ -862,7 +863,7 @@ def template_station_terms_for_dataset(dataset, rng, effects, *,
         effects,
         rng,
     )
-    leakage_matrix1, leakage_matrix2 = _sample_leakage_matrices(
+    leakage_feed_matrix1, leakage_feed_matrix2 = _sample_local_leakage_matrices(
         dataset,
         metadata,
         effects,
@@ -892,8 +893,8 @@ def template_station_terms_for_dataset(dataset, rng, effects, *,
         "uptime_mask": np.ones(count, dtype=bool),
         "common_gain1": common_gain1,
         "common_gain2": common_gain2,
-        "leakage_matrix1": leakage_matrix1,
-        "leakage_matrix2": leakage_matrix2,
+        "leakage_feed_matrix1": leakage_feed_matrix1,
+        "leakage_feed_matrix2": leakage_feed_matrix2,
         "gain_ratio_factors": _sample_gain_ratio_factors(dataset, effects, rng),
     }, dataset.stations
 
@@ -1030,32 +1031,44 @@ def _row_group_values(group_ids, sampler, rng):
     return values
 
 
-def _sample_leakage_matrices(dataset, metadata, effects, rng):
-    """Return cadence-aware station-frame leakage matrices with overrides."""
+def _sample_local_leakage_matrices(dataset, metadata, effects, rng):
+    """Return cadence-aware local-feed leakage matrices with overrides.
+
+    Matrix rows and columns follow the declared receptor order at each
+    two-feed endpoint station. The matrices are intentionally local: the
+    receptor RIME applies them after the local feed-response matrix rather
+    than treating them as circular-sky Jones terms.
+    """
 
     count = dataset.row_count
     matrix1 = np.broadcast_to(np.eye(2, dtype=complex), (count, 2, 2)).copy()
     matrix2 = np.array(matrix1, copy=True)
     rows = metadata["_rows"]
     group_cache = {}
+    station_indices = {station: index for index, station in enumerate(dataset.stations.names)}
     for site in metadata["sites_obs"]:
         leakage_model = effects.leakage_model(site)
         if leakage_model is None:
             continue
+        receptor_indices = np.flatnonzero(
+            dataset.receptors.station_index == station_indices[site]
+        )
+        if len(receptor_indices) == 1:
+            continue
+        feed_ids = tuple(dataset.receptors.feed_id[index] for index in receptor_indices)
+        feed_a, feed_b = effects.leakage_feed_pair(site, feed_ids)
+        local_index = {feed_id: index for index, feed_id in enumerate(feed_ids)}
+        index_a = local_index[feed_a]
+        index_b = local_index[feed_b]
         group_ids = _cached_group_ids(dataset, leakage_model.cadence, group_cache)
         first = rows.t1 == site
         second = rows.t2 == site
         for group_id in np.unique(group_ids):
-            d_a = leakage_model.component_sigma * (
-                rng.normal(0.0, 1.0) + 1.0j * rng.normal(0.0, 1.0)
-            )
-            d_b = leakage_model.component_sigma * (
-                rng.normal(0.0, 1.0) + 1.0j * rng.normal(0.0, 1.0)
-            )
+            d_a, d_b = leakage_model.sample(rng)
             first_group = first & (group_ids == group_id)
             second_group = second & (group_ids == group_id)
-            matrix1[first_group, 0, 1] = d_a
-            matrix1[first_group, 1, 0] = d_b
-            matrix2[second_group, 0, 1] = d_a
-            matrix2[second_group, 1, 0] = d_b
+            matrix1[first_group, index_a, index_b] = d_a
+            matrix1[first_group, index_b, index_a] = d_b
+            matrix2[second_group, index_a, index_b] = d_a
+            matrix2[second_group, index_b, index_a] = d_b
     return matrix1, matrix2

--- a/tests/test_instrumental_corruptions.py
+++ b/tests/test_instrumental_corruptions.py
@@ -163,14 +163,14 @@ def test_circular_generator_matches_composed_station_jones_matrices():
 
     jones1 = _station_jones(
         terms["common_gain1"],
-        terms["leakage_matrix1"],
+        terms["leakage_feed_matrix1"],
         (terms["f_par1"] * terms["par1"])
         + (terms["f_el1"] * terms["el1"])
         + ((np.pi / 180.0) * terms["phi_off1"]),
     )
     jones2 = _station_jones(
         terms["common_gain2"],
-        terms["leakage_matrix2"],
+        terms["leakage_feed_matrix2"],
         (terms["f_par2"] * terms["par2"])
         + (terms["f_el2"] * terms["el2"])
         + ((np.pi / 180.0) * terms["phi_off2"]),

--- a/tests/test_mixed_receptor_rime.py
+++ b/tests/test_mixed_receptor_rime.py
@@ -128,8 +128,8 @@ def test_standard_circular_rime_uses_generic_station_terms():
     assert {
         "common_gain1",
         "common_gain2",
-        "leakage_matrix1",
-        "leakage_matrix2",
+        "leakage_feed_matrix1",
+        "leakage_feed_matrix2",
         "gain_ratio_factors",
     } <= set(result.station_terms)
     assert not any(name.startswith(("gainamp", "gainphase", "leak1", "leak2")) for name in result.station_terms)
@@ -147,7 +147,10 @@ def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
             phase_distribution="uniform",
         ),
         feed_rotation=True,
-        leakage=LeakageModel(component_sigma=0.1),
+        leakage_overrides={
+            "ALMA": LeakageModel(component_sigma=0.1),
+            "APEX": LeakageModel(component_sigma=0.1),
+        },
         gain_ratio_overrides={
             "ALMA": GainRatioModel("X", "Y", amplitude_sigma_dex=0.02),
         },
@@ -205,6 +208,86 @@ def test_mixed_receptor_rime_matches_explicit_effective_jones_rows():
     gain_ratios = result.station_terms["gain_ratio_factors"]
     assert not np.allclose(gain_ratios[:, alma_x], 1.0)
     assert np.allclose(gain_ratios[:, alma_x] * gain_ratios[:, alma_y], 1.0)
+
+
+def test_local_feed_leakage_matches_explicit_mixed_basis_jones_matrices():
+    """X/Y and R/L stations must receive independent local-feed D-terms."""
+
+    settings = dict(SETTINGS)
+    settings["sites"] = ["ALMA", "APEX"]
+    receptor_layout = {"ALMA": ("X", "Y"), "APEX": ("R", "L")}
+    d_alma = np.array(((1.0, 0.02 + 0.03j), (-0.04 + 0.01j, 1.0)), dtype=complex)
+    d_apex = np.array(((1.0, -0.05 + 0.02j), (0.06 - 0.01j, 1.0)), dtype=complex)
+    effects = StationCorruptionModel(
+        thermal_noise=False,
+        station_gain=None,
+        feed_rotation=False,
+        leakage_overrides={
+            "ALMA": LeakageModel(
+                "X",
+                "Y",
+                leakage_a_mean=d_alma[0, 1],
+                leakage_b_mean=d_alma[1, 0],
+            ),
+            "APEX": LeakageModel(
+                "R",
+                "L",
+                leakage_a_mean=d_apex[0, 1],
+                leakage_b_mean=d_apex[1, 0],
+            ),
+        },
+        flag_wind=False,
+        flag_daylight=False,
+        flag_sun=False,
+    )
+    generator = og.obs_generator(settings=settings, station_receptors=receptor_layout)
+    result = generator.simulate(_polarized_model(), effects=effects)
+    dataset = result.dataset
+    configuration = resolve_receptor_configuration(dataset.stations.names, receptor_layout)
+    _, _, sky_coherency = source_models.observe_source_dataset(
+        _polarized_model(),
+        dataset,
+        generator.source_context(),
+        return_coherency=True,
+    )
+    response = configuration.response_circular
+    station_receptors = {
+        station: np.flatnonzero(dataset.receptors.station_index == station_index)
+        for station_index, station in enumerate(dataset.stations.names)
+    }
+    local_index = {
+        receptor: index
+        for indices in station_receptors.values()
+        for index, receptor in enumerate(indices)
+    }
+    local_d = {"ALMA": d_alma, "APEX": d_apex}
+    expected = np.zeros_like(dataset.visibilities[:, 0])
+    products = dataset.correlation_products
+    for row, product_ids in enumerate(dataset.row_product_id):
+        first_station = dataset.stations.names[dataset.antenna1[row]]
+        second_station = dataset.stations.names[dataset.antenna2[row]]
+        first_indices = station_receptors[first_station]
+        second_indices = station_receptors[second_station]
+        first_rows = local_d[first_station] @ response[first_indices]
+        second_rows = local_d[second_station] @ response[second_indices]
+        for slot, product_id in enumerate(product_ids):
+            if product_id < 0:
+                continue
+            receptor1 = products.receptor1_id[product_id]
+            receptor2 = products.receptor2_id[product_id]
+            expected[row, slot] = (
+                first_rows[local_index[receptor1]]
+                @ sky_coherency[row]
+                @ np.conj(second_rows[local_index[receptor2]])
+            )
+
+    for endpoint, matrix_name in (("t1", "leakage_feed_matrix1"), ("t2", "leakage_feed_matrix2")):
+        endpoint_stations = np.asarray(result.station_terms[endpoint])
+        for station, leakage_matrix in local_d.items():
+            mask = endpoint_stations == station
+            if np.any(mask):
+                assert np.allclose(result.station_terms[matrix_name][mask], leakage_matrix)
+    assert np.allclose(dataset.visibilities[:, 0], expected, atol=1.0e-12)
 
 
 def test_mixed_receptor_fringegroups_uses_generic_stokes_i_evidence():

--- a/tests/test_observation_template.py
+++ b/tests/test_observation_template.py
@@ -226,9 +226,9 @@ def test_template_station_effect_defaults_and_overrides_follow_two_feed_model():
         result.station_terms["common_gain2"],
         10.0 ** 0.1 * np.exp(0.4j),
     )
-    assert np.any(np.abs(result.station_terms["leakage_matrix1"][:, 0, 1]) > 0.0)
+    assert np.any(np.abs(result.station_terms["leakage_feed_matrix1"][:, 0, 1]) > 0.0)
     assert np.allclose(
-        result.station_terms["leakage_matrix2"],
+        result.station_terms["leakage_feed_matrix2"],
         np.eye(2, dtype=complex),
     )
 
@@ -255,6 +255,41 @@ def test_template_relayout_supports_mixed_feeds_and_fitseht_round_trip(tmp_path)
     assert restored.receptors.polarization_label == output.receptors.polarization_label
     assert np.array_equal(restored.row_product_id, output.row_product_id)
     assert np.allclose(restored.visibilities, output.visibilities)
+
+
+def test_template_relayout_realizes_leakage_in_local_feed_order():
+    """Template source substitution retains local X/Y and R/L D-term truth."""
+
+    template = ObservationTemplate.from_dataset(_template_dataset())
+    d_aa = np.array(((1.0, 0.02 + 0.03j), (-0.04 + 0.01j, 1.0)), dtype=complex)
+    d_bb = np.array(((1.0, -0.05 + 0.02j), (0.06 - 0.01j, 1.0)), dtype=complex)
+    effects = _clean_effects(
+        leakage_overrides={
+            "AA": LeakageModel(
+                "X",
+                "Y",
+                leakage_a_mean=d_aa[0, 1],
+                leakage_b_mean=d_aa[1, 0],
+            ),
+            "BB": LeakageModel(
+                "R",
+                "L",
+                leakage_a_mean=d_bb[0, 1],
+                leakage_b_mean=d_bb[1, 0],
+            ),
+        },
+    )
+    result = template.simulate(
+        _model(),
+        effects=effects,
+        station_receptors={"AA": ("X", "Y")},
+        transform_backend="direct",
+        random_seed=7,
+    )
+
+    assert result.dataset.receptors.polarization_label == ("X", "Y", "R", "L")
+    assert np.allclose(result.station_terms["leakage_feed_matrix1"], d_aa)
+    assert np.allclose(result.station_terms["leakage_feed_matrix2"], d_bb)
 
 
 def test_template_feed_rotation_requires_explicit_mount_metadata():

--- a/tests/test_source_models.py
+++ b/tests/test_source_models.py
@@ -784,8 +784,8 @@ def test_native_simulation_keeps_terms_in_the_result_not_the_generator():
         "SEFD2",
         "common_gain1",
         "common_gain2",
-        "leakage_matrix1",
-        "leakage_matrix2",
+        "leakage_feed_matrix1",
+        "leakage_feed_matrix2",
     ):
         assert name in result.station_terms
         assert result.station_terms[name].shape[0] == result.dataset.row_count

--- a/tests/test_station_effects.py
+++ b/tests/test_station_effects.py
@@ -104,6 +104,23 @@ def test_gain_ratio_defaults_to_track_and_can_use_station_local_feed_order():
     assert named_ratio.feed_b == "Y"
 
 
+def test_leakage_model_draws_local_feed_terms_with_explicit_means():
+    leakage = LeakageModel(
+        "X",
+        "Y",
+        leakage_a_mean=0.02 + 0.03j,
+        leakage_b_mean=-0.04 + 0.01j,
+        component_sigma=0.1,
+    )
+
+    assert leakage.feed_a == "X"
+    assert leakage.feed_b == "Y"
+    assert leakage.cadence == RealizationCadence.track()
+    assert leakage.sample(FixedRng()) == pytest.approx(
+        (0.12 + 0.13j, 0.06 + 0.11j)
+    )
+
+
 def test_realization_cadences_group_rows_without_guessing_scans():
     dataset = _dataset()
 
@@ -154,6 +171,8 @@ def test_station_corruption_model_resolves_immutable_default_and_override_models
     assert effects.gain_ratio_model("APEX") is None
     assert effects.gain_ratio_feed_pair("LMT", ("R", "L")) == ("R", "L")
     assert effects.gain_ratio_feed_pair("ALMA", ("X", "Y")) == ("X", "Y")
+    assert effects.leakage_feed_pair("LMT", ("R", "L")) == ("R", "L")
+    assert effects.leakage_feed_pair("ALMA", ("X", "Y")) == ("X", "Y")
     assert effects.has_gain_corruption
     assert effects.has_leakage_corruption
     with pytest.raises(TypeError):
@@ -171,6 +190,10 @@ def test_station_corruption_model_rejects_invalid_configuration():
         GainModel(phase_distribution="gaussian")
     with pytest.raises(ValueError, match="non-negative"):
         LeakageModel(component_sigma=-0.01)
+    with pytest.raises(ValueError, match="both be supplied"):
+        LeakageModel("X")
+    with pytest.raises(ValueError, match="finite"):
+        LeakageModel(leakage_a_mean=np.inf)
     with pytest.raises(ValueError, match="distinct"):
         GainRatioModel("X", "X")
     with pytest.raises(ValueError, match="both be supplied"):
@@ -220,6 +243,11 @@ def test_station_corruption_model_validates_two_feed_ratio_layouts():
     )
     with pytest.raises(NotImplementedError, match="exactly two feeds"):
         StationCorruptionModel(gain_ratio=GainRatioModel()).validate_receptors(
+            ("ALMA",),
+            three_feed_receptors,
+        )
+    with pytest.raises(NotImplementedError, match="Local-feed leakage"):
+        StationCorruptionModel(leakage=LeakageModel()).validate_receptors(
             ("ALMA",),
             three_feed_receptors,
         )

--- a/tests/test_station_observation.py
+++ b/tests/test_station_observation.py
@@ -426,8 +426,8 @@ def test_native_station_terms_preserve_weather_and_use_generic_corruption_fields
     assert {
         "common_gain1",
         "common_gain2",
-        "leakage_matrix1",
-        "leakage_matrix2",
+        "leakage_feed_matrix1",
+        "leakage_feed_matrix2",
         "gain_ratio_factors",
     } <= set(native)
     assert not any(name.startswith(("gainamp", "gainphase", "leak1", "leak2")) for name in native)


### PR DESCRIPTION
Defines native D-terms in each station's local feed frame, adds deterministic D-term means, preserves local leakage provenance, and validates circular, linear, mixed, and template simulations.